### PR TITLE
Add registry slot governance guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ brew install ailib
 ```
 
 Homebrew publishing and release steps: [docs/homebrew-publishing.md](docs/homebrew-publishing.md).
+Slot governance and naming rules: [docs/slot-standards.md](docs/slot-standards.md).
 
 ## Quick start
 

--- a/docs/slot-standards.md
+++ b/docs/slot-standards.md
@@ -1,0 +1,52 @@
+# Slot Standards
+
+This document defines how module slots are modeled in `registry.json`.
+
+## Design goals
+
+- Keep slots predictable and low-maintenance.
+- Model one decision axis per slot.
+- Preserve backwards compatibility through aliases when renaming slots.
+
+## Naming rules
+
+- Slot names use `snake_case`.
+- Slot names are capability-oriented and vendor-neutral.
+- Prefer semantic suffixes when applicable:
+  - `_framework`
+  - `_provider`
+  - `_adapter`
+  - `_runner`
+  - `_engine`
+
+## Slot behavior
+
+Each slot is defined in `slot_defs` with:
+
+- `kind: "exclusive"`: only one module can occupy the slot.
+- `kind: "composable"`: multiple modules can coexist in the slot.
+
+All canonical slots must be listed in both:
+
+- `slots`
+- `slot_defs`
+
+## Aliases and migrations
+
+- Renamed legacy slots are captured in `slot_aliases`.
+- `slot_aliases` map legacy names to canonical slot names.
+- Alias keys must not also appear in `slots`.
+- Alias targets must always exist in `slots`.
+- New module definitions should always use canonical slot names.
+
+## Module constraints
+
+- Each module definition must declare `slot`.
+- Module `slot` values must map to a canonical slot.
+- Module markdown frontmatter `slot` must match the registry module slot.
+
+## Practical guidance
+
+- Add a new slot only when introducing a genuinely new decision axis.
+- Prefer adding a module under an existing slot over creating a new slot.
+- Keep slot descriptions concise and implementation-agnostic.

--- a/test/registry-governance.test.js
+++ b/test/registry-governance.test.js
@@ -1,0 +1,109 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const registryPath = path.join(packageRoot, 'registry.json');
+const slotNamePattern = /^[a-z]+(?:_[a-z]+)*$/u;
+
+async function loadRegistry() {
+  return JSON.parse(await fs.readFile(registryPath, 'utf8'));
+}
+
+function parseFrontmatter(markdown) {
+  const match = markdown.match(/^---\n([\s\S]*?)\n---\n/u);
+  if (!match) return null;
+  const fields = {};
+  for (const line of match[1].split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const idx = line.indexOf(':');
+    if (idx < 0) continue;
+    const key = line.slice(0, idx).trim();
+    let value = line.slice(idx + 1).trim();
+    if (value.startsWith('[') && value.endsWith(']')) {
+      value = value
+        .slice(1, -1)
+        .split(',')
+        .map((x) => x.trim())
+        .filter(Boolean);
+    }
+    fields[key] = value;
+  }
+  return fields;
+}
+
+test('registry slots follow naming and coverage rules', async () => {
+  const registry = await loadRegistry();
+  const slots = registry.slots || [];
+  const slotDefs = registry.slot_defs || {};
+  const slotAliases = registry.slot_aliases || {};
+
+  assert.ok(slots.length > 0, 'registry.slots must not be empty');
+
+  for (const slot of slots) {
+    assert.match(slot, slotNamePattern, `Invalid slot name '${slot}'`);
+  }
+
+  const slotSet = new Set(slots);
+  const slotDefSet = new Set(Object.keys(slotDefs));
+  assert.deepEqual(
+    [...slotDefSet].sort(),
+    [...slotSet].sort(),
+    'slot_defs keys must match slots exactly'
+  );
+
+  for (const [slot, def] of Object.entries(slotDefs)) {
+    assert.equal(typeof def.description, 'string', `slot_defs.${slot}.description must be string`);
+    assert.ok(def.description.trim().length > 0, `slot_defs.${slot}.description must not be empty`);
+    assert.ok(
+      def.kind === 'exclusive' || def.kind === 'composable',
+      `slot_defs.${slot}.kind must be exclusive|composable`
+    );
+  }
+
+  for (const [alias, target] of Object.entries(slotAliases)) {
+    assert.ok(!slotSet.has(alias), `slot_aliases key '${alias}' must not be canonical slot`);
+    assert.ok(slotSet.has(target), `slot_aliases target '${target}' must exist in slots`);
+  }
+});
+
+test('registry modules use canonical slots and docs match', async () => {
+  const registry = await loadRegistry();
+  const slots = new Set(registry.slots || []);
+  const aliases = registry.slot_aliases || {};
+
+  for (const [languageId, languageDef] of Object.entries(registry.languages || {})) {
+    for (const [moduleId, moduleDef] of Object.entries(languageDef.modules || {})) {
+      const rawSlot = moduleDef.slot;
+      assert.ok(rawSlot, `Missing slot for module '${languageId}:${moduleId}'`);
+      const canonical = aliases[rawSlot] || rawSlot;
+      assert.ok(
+        slots.has(canonical),
+        `Unknown canonical slot '${canonical}' for module '${languageId}:${moduleId}'`
+      );
+      assert.equal(
+        rawSlot,
+        canonical,
+        `Module '${languageId}:${moduleId}' uses alias slot '${rawSlot}', use canonical '${canonical}'`
+      );
+
+      const modulePath = path.join(
+        packageRoot,
+        'languages',
+        languageId,
+        'modules',
+        `${moduleId}.md`
+      );
+      const markdown = await fs.readFile(modulePath, 'utf8');
+      const frontmatter = parseFrontmatter(markdown);
+      assert.ok(frontmatter, `Missing frontmatter in '${modulePath}'`);
+      assert.equal(
+        frontmatter.slot,
+        canonical,
+        `Frontmatter slot mismatch for '${languageId}:${moduleId}'`
+      );
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add a dedicated slot governance standard document in `docs/slot-standards.md`
- add `test/registry-governance.test.js` to enforce slot naming, slot coverage parity, alias integrity, and module/frontmatter slot consistency
- link the slot standard from `README.md` so contributors can find the canonical rules quickly

## Test plan
- [x] Run `node --test`
- [ ] Validate contribution flow by adding a sample module that intentionally violates slot rules and confirming test failure (manual follow-up)

Made with [Cursor](https://cursor.com)

Closes #13