### PR TITLE
fix: enable TypeScript typecheck in phase 1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,11 +4,16 @@
     "": {
       "name": "@ailib/cli",
       "devDependencies": {
+        "@types/node": "^25.6.0",
         "typescript": "^6.0.3",
       },
     },
   },
   "packages": {
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "bun": ">=1.3.0"
   },
   "devDependencies": {
+    "@types/node": "^25.6.0",
     "typescript": "^6.0.3"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ const GLOB_DISCOVERY_MAX_DEPTH = 32;
 const SKIP_DIRS = new Set(['.git', 'node_modules', 'dist', 'build', '.venv']);
 const WARNED_SLOT_ALIASES = new Set();
 
-export async function run(argv, options = {}) {
+export async function run(argv: string[], options: { cwd?: string; packageRoot?: string } = {}) {
   const cwd = options.cwd ?? process.cwd();
   const packageRoot = options.packageRoot ?? path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
 
@@ -117,7 +117,7 @@ async function modulesCommand({ packageRoot, flags }) {
     ensure(lang, `Unsupported language: ${language}`);
 
     const lines = [`modules (${language}):`];
-    const modules = Object.entries(lang.modules || {}).sort(([a], [b]) => a.localeCompare(b));
+    const modules = (Object.entries(lang.modules || {}) as Array<[string, any]>).sort(([a], [b]) => a.localeCompare(b));
     for (const [moduleId, moduleDef] of modules) {
       lines.push(`- ${moduleId} (slot: ${moduleDef.slot})`);
     }
@@ -177,7 +177,7 @@ async function initCommand({ cwd, packageRoot, flags }) {
   if (inServiceContext && flags['no-inherit'] !== true) {
     const projectRoot = path.resolve(cwd);
     const rel = toPosix(path.relative(projectRoot, path.join(nearestRoot, CONFIG_FILE)));
-    const config = {
+    const config: any = {
       $schema: 'https://ailib.dev/schema/config.schema.json',
       extends: rel,
       language,
@@ -193,7 +193,7 @@ async function initCommand({ cwd, packageRoot, flags }) {
   }
 
   const projectRoot = await detectProjectRoot(cwd);
-  const config = {
+  const config: any = {
     $schema: 'https://ailib.dev/schema/config.schema.json',
     registry_ref: registry.version,
     language,
@@ -402,7 +402,10 @@ async function uninstallWorkspace(workspaceDir, config, registry) {
   }
 }
 
-async function applyWorkspaceUpdate({ packageRoot, rootDir, workspaceOverride, forceOnConflict }) {
+async function applyWorkspaceUpdate(
+  { packageRoot, rootDir, workspaceOverride, forceOnConflict }:
+  { packageRoot: string; rootDir: string; workspaceOverride?: string; forceOnConflict?: string }
+) {
   const rootConfigPath = path.join(rootDir, CONFIG_FILE);
   ensure(await exists(rootConfigPath), `Missing ${CONFIG_FILE} at root: ${rootDir}`);
 
@@ -472,7 +475,7 @@ async function ensureWorkspaceAssets({ workspaceDir, packageRoot, state, rootDir
 }
 
 async function generateWorkspaceRouters({ workspaceDir, rootDir, state, onConflict, allStates, registry }) {
-  const targetSet = new Set(state.effective.targets || []);
+  const targetSet = new Set<string>(state.effective.targets || []);
   const atRoot = path.resolve(workspaceDir) === path.resolve(rootDir);
 
   for (const targetId of targetSet) {
@@ -634,19 +637,19 @@ function normalizeRootConfig(rootConfig, registry) {
   };
 }
 
-function mergeModules({ registry, language, parentModules, localModules }) {
+function mergeModules({ registry, language, parentModules, localModules }: any) {
   const lang = registry.languages[language];
   const result = [];
   const owners = [];
   const warnings = [];
 
-  for (const mod of uniqueList(parentModules)) {
+  for (const mod of uniqueList(parentModules) as string[]) {
     if (!lang.modules[mod]) continue;
     result.push(mod);
     owners.push('inherited');
   }
 
-  for (const mod of uniqueList(localModules)) {
+  for (const mod of uniqueList(localModules) as string[]) {
     const localDef = lang.modules[mod];
     if (!localDef) {
       result.push(mod);
@@ -801,7 +804,7 @@ async function writeRootLock({ rootDir, packageRoot, packageVersion, registryRef
   await fs.writeFile(path.join(rootDir, LOCK_FILE), `${JSON.stringify(lock, null, 2)}\n`, 'utf8');
 }
 
-async function listWorkspaceDirs({ rootDir, rootConfig, workspaceOverride }) {
+async function listWorkspaceDirs({ rootDir, rootConfig, workspaceOverride }: { rootDir: string; rootConfig: any; workspaceOverride?: string }) {
   if (workspaceOverride) {
     const abs = resolveWorkspacePath(rootDir, workspaceOverride);
     ensure(await exists(path.join(abs, CONFIG_FILE)), `Workspace has no ${CONFIG_FILE}: ${workspaceOverride}`);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -22,7 +22,7 @@ async function makeMonorepo() {
   return root;
 }
 
-async function exists(filePath) {
+async function exists(filePath: string) {
   try {
     await fs.access(filePath, fsConstants.F_OK);
     return true;
@@ -31,10 +31,10 @@ async function exists(filePath) {
   }
 }
 
-async function captureStdout(fn) {
-  const writes = [];
-  const originalWrite = process.stdout.write;
-  process.stdout.write = (chunk, encoding, callback) => {
+async function captureStdout(fn: () => Promise<void>) {
+  const writes: string[] = [];
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  (process.stdout as any).write = (chunk: string | Uint8Array, encoding?: BufferEncoding, callback?: (err?: Error) => void) => {
     writes.push(typeof chunk === 'string' ? chunk : chunk.toString());
     if (typeof callback === 'function') callback();
     return true;
@@ -44,11 +44,11 @@ async function captureStdout(fn) {
     await fn();
     return writes.join('');
   } finally {
-    process.stdout.write = originalWrite;
+    (process.stdout as any).write = originalWrite;
   }
 }
 
-async function runDoctorAndCapture(root) {
+async function runDoctorAndCapture(root: string) {
   process.exitCode = 0;
   const output = await captureStdout(async () => {
     await run(['doctor'], { cwd: root, packageRoot });

--- a/test/registry-governance.test.ts
+++ b/test/registry-governance.test.ts
@@ -8,11 +8,11 @@ const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname)
 const registryPath = path.join(packageRoot, 'registry.json');
 const slotNamePattern = /^[a-z]+(?:_[a-z]+)*$/u;
 
-async function loadRegistry() {
+async function loadRegistry(): Promise<any> {
   return JSON.parse(await fs.readFile(registryPath, 'utf8'));
 }
 
-function parseFrontmatter(markdown) {
+function parseFrontmatter(markdown: string): any {
   const match = markdown.match(/^---\n([\s\S]*?)\n---\n/u);
   if (!match) return null;
   const fields = {};
@@ -22,7 +22,7 @@ function parseFrontmatter(markdown) {
     const idx = line.indexOf(':');
     if (idx < 0) continue;
     const key = line.slice(0, idx).trim();
-    let value = line.slice(idx + 1).trim();
+    let value: any = line.slice(idx + 1).trim();
     if (value.startsWith('[') && value.endsWith(']')) {
       value = value
         .slice(1, -1)
@@ -56,7 +56,7 @@ test('registry slots follow naming and coverage rules', async () => {
     'slot_defs keys must match slots exactly'
   );
 
-  for (const [slot, def] of Object.entries(slotDefs)) {
+  for (const [slot, def] of Object.entries(slotDefs as Record<string, any>)) {
     assert.equal(typeof def.description, 'string', `slot_defs.${slot}.description must be string`);
     assert.ok(def.description.trim().length > 0, `slot_defs.${slot}.description must not be empty`);
     assert.ok(
@@ -76,7 +76,7 @@ test('registry slots follow naming and coverage rules', async () => {
     'slot_alias_meta keys must match slot_aliases keys'
   );
 
-  for (const [alias, meta] of Object.entries(aliasMeta)) {
+  for (const [alias, meta] of Object.entries(aliasMeta as Record<string, any>)) {
     assert.equal(
       meta.replacement,
       slotAliases[alias],
@@ -97,8 +97,8 @@ test('registry modules use canonical slots and docs match', async () => {
   const slots = new Set(registry.slots || []);
   const aliases = registry.slot_aliases || {};
 
-  for (const [languageId, languageDef] of Object.entries(registry.languages || {})) {
-    for (const [moduleId, moduleDef] of Object.entries(languageDef.modules || {})) {
+  for (const [languageId, languageDef] of Object.entries(registry.languages || {}) as Array<[string, any]>) {
+    for (const [moduleId, moduleDef] of Object.entries(languageDef.modules || {}) as Array<[string, any]>) {
       const rawSlot = moduleDef.slot;
       assert.ok(rawSlot, `Missing slot for module '${languageId}:${moduleId}'`);
       const canonical = aliases[rawSlot] || rawSlot;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,9 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "allowImportingTsExtensions": true,
+    "types": ["node"],
     "strict": false,
-    "noCheck": true,
     "noEmit": true,
     "allowJs": false,
     "skipLibCheck": true


### PR DESCRIPTION
## Summary
- Remove `noCheck` so `tsc --noEmit` performs real TypeScript checks.
- Add Node typings and TS config support for `.ts` import paths used by tests.
- Add minimal boundary typing in CLI/tests to pass typecheck without behavior changes.

## Test plan
- [x] Run `bun run typecheck`
- [x] Run `bun run check`

Closes #21

Made with [Cursor](https://cursor.com)