### PR TITLE
feat: add development standards for consumers

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+- Describe the core change in 1-3 bullets.
+
+## Standards Check
+
+- [ ] I followed the development standards in `docs/development-standards.md`
+- [ ] I used a TDD flow (red/green/refactor) for behavior changes
+- [ ] I kept the PR scope to one logical concern
+
+## Test Plan
+
+- [ ] `bun run typecheck`
+- [ ] `bun run check`
+- [ ] Additional verification performed (if needed)
+
+## Issue Link
+
+Refs #

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ brew install ailib
 
 Homebrew publishing and release steps: [docs/homebrew-publishing.md](docs/homebrew-publishing.md).
 Slot governance and naming rules: [docs/slot-standards.md](docs/slot-standards.md).
+Development standards for contributions: [docs/development-standards.md](docs/development-standards.md).
 Generated module catalog: [docs/module-catalog.md](docs/module-catalog.md).
 Follow-up implementation roadmap: [docs/follow-up-plan.md](docs/follow-up-plan.md).
 

--- a/core/development-standards.md
+++ b/core/development-standards.md
@@ -8,8 +8,41 @@ core: true
 
 # Development Standards
 
-- Use TDD where behavior changes: red -> green -> refactor.
-- Keep PR scope to one logical concern.
-- Favor explicit naming, small focused functions, and clear side effects.
-- Apply SOLID pragmatically in shared CLI and generation flows.
-- Require passing `bun run typecheck` and `bun run check` before merge.
+These standards apply to generated consumer workspaces and to `ailib` contribution work.
+
+## 1) TDD Workflow
+
+- Start with a failing test for the target behavior.
+- Implement the smallest change needed to make the test pass.
+- Refactor after tests pass while preserving behavior.
+
+## 2) Clean Code Baselines
+
+- Keep functions focused on one responsibility.
+- Prefer explicit naming over ambiguous shortcuts.
+- Keep side effects visible at call sites.
+- Remove dead code during related changes.
+
+## 3) SOLID Expectations (Practical)
+
+- Use Single Responsibility for config parsing, validation, and generation concerns.
+- Extend behavior through explicit module/target definitions rather than unrelated flow edits.
+- Keep contracts focused and substitutable.
+
+## 4) Change Scope Rules
+
+- Keep one logical concern per PR.
+- Prefer small PRs.
+- Separate behavior-preserving refactors from feature additions when possible.
+
+## 5) Quality Gates
+
+- `bun run typecheck` must pass.
+- `bun run check` must pass.
+- Behavior changes must include/adjust tests.
+
+## 6) Definition of Done
+
+- Standards followed.
+- Tests and checks pass.
+- Relevant docs/PR checklist updated.

--- a/core/development-standards.md
+++ b/core/development-standards.md
@@ -1,0 +1,15 @@
+---
+id: development-standards
+display: ailib Development Standards
+version: 1.0.0
+updated: 2026-04-21
+core: true
+---
+
+# Development Standards
+
+- Use TDD where behavior changes: red -> green -> refactor.
+- Keep PR scope to one logical concern.
+- Favor explicit naming, small focused functions, and clear side effects.
+- Apply SOLID pragmatically in shared CLI and generation flows.
+- Require passing `bun run typecheck` and `bun run check` before merge.

--- a/docs/development-standards.md
+++ b/docs/development-standards.md
@@ -1,0 +1,53 @@
+# Development Standards
+
+This guide defines the minimum implementation standards for `ailib` changes.
+
+## 1) TDD Workflow
+
+- Start with a failing test that captures the behavior you want.
+- Implement the smallest production change required to pass the test.
+- Refactor only after tests pass; keep behavior unchanged.
+- Keep tests deterministic and local to the changed behavior.
+
+Expected loop:
+1. Red: write/adjust tests and confirm failure.
+2. Green: implement minimal code to pass.
+3. Refactor: improve readability/structure without changing behavior.
+
+## 2) Clean Code Baselines
+
+- Functions should have one clear responsibility.
+- Prefer explicit names over comments that restate obvious code.
+- Keep side effects isolated and visible at call sites.
+- Remove dead code during the same change where it becomes obsolete.
+- Avoid broad "catch-all" utilities when a narrow helper is clearer.
+
+## 3) SOLID Expectations (Practical)
+
+- **Single Responsibility:** separate config parsing, validation, and output generation concerns.
+- **Open/Closed:** extend behavior through clear module/target definitions instead of editing unrelated flows.
+- **Liskov Substitution:** keep replacement behaviors compatible with existing command expectations.
+- **Interface Segregation:** keep type contracts focused; avoid oversized interfaces.
+- **Dependency Inversion:** depend on explicit abstractions (typed boundaries) for cross-cutting logic.
+
+## 4) Change Scope Rules
+
+- One logical concern per PR.
+- Prefer small PRs over large multi-goal changes.
+- Keep behavior-preserving refactors separate from feature additions when possible.
+- When touching generated artifacts, include the generation/check command used.
+
+## 5) Quality Gates for PRs
+
+- `bun run typecheck` must pass.
+- `bun run check` must pass.
+- New behavior should include/adjust tests.
+- Docs must be updated when user-facing behavior or contribution flow changes.
+
+## 6) Definition of Done
+
+A change is done when:
+- implementation follows this guide,
+- relevant tests are in place and passing,
+- required docs are updated,
+- and the PR checklist is fully completed.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -542,6 +542,12 @@ async function ensureWorkspaceAssets({ workspaceDir, packageRoot, state, rootDir
 
   await copySourceFile({
     packageRoot,
+    sourceRel: 'core/development-standards.md',
+    target: path.join(outRoot, 'development-standards.md')
+  });
+
+  await copySourceFile({
+    packageRoot,
     sourceRel: `languages/${state.effective.language}/core.md`,
     target: path.join(outRoot, 'standards.md')
   });
@@ -648,7 +654,7 @@ function renderRouterDoc({ label, workspaceDir, rootDir, state }: { label: strin
     : `# PROJECT-SPECIFIC CONTEXT\nPrioritize service-local business logic in @./docs/.\nFor cross-service context, consult @${toPosix(path.join(relToRoot, 'docs/'))}.\nIf guidance conflicts, service-local docs win for service-scoped work.\n`;
 
   const modulesText = moduleLines.length ? moduleLines.join('\n') : '- (none)';
-  return `# ailib Router (${label})\n\n# AILIB SYSTEM PROMPT\nAct as the AI Agent defined in ${behaviorRef}.\nAdhere to the coding standards in @.ailib/standards.md.\n\n# MODULES & EXTENSIONS\n${modulesText}\n\n${docsBlock}`;
+  return `# ailib Router (${label})\n\n# AILIB SYSTEM PROMPT\nAct as the AI Agent defined in ${behaviorRef}.\nAdhere to the coding standards in @.ailib/standards.md.\nApply development workflow rules in @.ailib/development-standards.md.\n\n# MODULES & EXTENSIONS\n${modulesText}\n\n${docsBlock}`;
 }
 
 async function buildWorkspaceState({ workspaceDir, rootDir, rootConfig, registry }: { workspaceDir: string; rootDir: string; rootConfig: WorkspaceConfig; registry: Registry }): Promise<WorkspaceState> {
@@ -656,6 +662,7 @@ async function buildWorkspaceState({ workspaceDir, rootDir, rootConfig, registry
   validateModuleSelection({ registry, language: effective.language, modules: effective.modules });
 
   const requiredFiles = [
+    '.ailib/development-standards.md',
     '.ailib/standards.md',
     ...effective.localModules.map((m) => `.ailib/modules/${m}.md`)
   ];
@@ -927,6 +934,12 @@ async function writeRootLock({ rootDir, packageRoot, packageVersion, registryRef
       const rel = '.ailib/behavior.md';
       const text = await fs.readFile(path.join(workspaceDir, rel), 'utf8');
       files[rel] = { source: 'core/behavior.md', sha256: sha256(text) };
+    }
+
+    {
+      const rel = '.ailib/development-standards.md';
+      const text = await fs.readFile(path.join(workspaceDir, rel), 'utf8');
+      files[rel] = { source: 'core/development-standards.md', sha256: sha256(text) };
     }
 
     {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -112,6 +112,7 @@ test('init creates root config, root lock, and routers with new layout', async (
   assert.equal(await exists(path.join(cwd, 'ailib.config.json')), true);
   assert.equal(await exists(path.join(cwd, 'ailib.lock')), true);
   assert.equal(await exists(path.join(cwd, '.ailib/behavior.md')), true);
+  assert.equal(await exists(path.join(cwd, '.ailib/development-standards.md')), true);
   assert.equal(await exists(path.join(cwd, '.ailib/standards.md')), true);
   assert.equal(await exists(path.join(cwd, '.ailib/modules/eslint.md')), true);
   assert.equal(await exists(path.join(cwd, 'CLAUDE.md')), true);
@@ -140,6 +141,7 @@ test('monorepo update inherits root and supports service override modules', asyn
   await run(['update'], { cwd: root, packageRoot });
 
   assert.equal(await exists(path.join(root, '.ailib/behavior.md')), true);
+  assert.equal(await exists(path.join(root, '.ailib/development-standards.md')), true);
   assert.equal(await exists(path.join(root, 'apps', 'web', '.ailib/modules/biome.md')), true);
   assert.equal(await exists(path.join(root, 'apps', 'web', '.ailib/modules/eslint.md')), false);
   assert.equal(await exists(path.join(root, 'services', 'ml', '.ailib/standards.md')), true);


### PR DESCRIPTION
## Summary
- Add a development standards guide covering TDD, Clean Code, SOLID, scope, and quality gates.
- Add PR template checks that require standards compliance and test commands.
- Generate consumer-facing `.ailib/development-standards.md` and enforce it via doctor/lock validation.

## Test plan
- [x] Run `bun run check`

Closes #23

Made with [Cursor](https://cursor.com)