### PR TITLE
feat: add test standards for consumers

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,7 @@
 ## Standards Check
 
 - [ ] I followed the development standards in `docs/development-standards.md`
+- [ ] I followed the test standards in `docs/test-standards.md`
 - [ ] I used a TDD flow (red/green/refactor) for behavior changes
 - [ ] I kept the PR scope to one logical concern
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ brew install ailib
 Homebrew publishing and release steps: [docs/homebrew-publishing.md](docs/homebrew-publishing.md).
 Slot governance and naming rules: [docs/slot-standards.md](docs/slot-standards.md).
 Development standards for contributions: [docs/development-standards.md](docs/development-standards.md).
+Test standards and coverage thresholds: [docs/test-standards.md](docs/test-standards.md).
 Generated module catalog: [docs/module-catalog.md](docs/module-catalog.md).
 Follow-up implementation roadmap: [docs/follow-up-plan.md](docs/follow-up-plan.md).
 

--- a/core/test-standards.md
+++ b/core/test-standards.md
@@ -1,0 +1,36 @@
+---
+id: test-standards
+display: ailib Test Standards
+version: 1.0.0
+updated: 2026-04-21
+core: true
+---
+
+# Test Standards
+
+These standards apply to generated consumer workspaces and `ailib` contributions.
+
+## 1) Required Test Types
+
+- Unit tests for focused logic.
+- Integration tests for command workflows and file outputs.
+- Regression tests for each bug fix.
+- Smoke checks for end-to-end core paths.
+
+## 2) Coverage Targets
+
+- `src/` and `core/` changes: 85% line coverage minimum.
+- `tools/` changes: 80% line coverage minimum.
+- Critical command flows (`init/update/doctor/uninstall`): strong integration coverage.
+
+## 3) Quality Gates
+
+- `bun run typecheck` passes.
+- `bun run check` passes.
+- Behavior changes include tests.
+
+## 4) Definition of Done
+
+- Required test types are addressed.
+- Coverage targets are respected for changed areas.
+- Checks pass before merge.

--- a/docs/test-standards.md
+++ b/docs/test-standards.md
@@ -1,0 +1,48 @@
+# Test Standards
+
+This guide defines minimum testing expectations for `ailib` changes.
+
+## 1) Required Test Types
+
+- **Unit:** Validate single-function behavior (parsing, validation, formatting, merge helpers).
+- **Integration:** Validate command workflows (`init`, `update`, `doctor`, `uninstall`) with filesystem effects.
+- **Regression:** Add a test whenever fixing a bug to prevent recurrence.
+- **Smoke:** Confirm end-to-end command flow and generated output sanity for core paths.
+
+## 2) Coverage Thresholds
+
+Coverage targets are minimums for changed code paths:
+
+- **CLI/core logic (`src/`, `core/`):** 85% line coverage
+- **Tooling scripts (`tools/`):** 80% line coverage
+- **Critical command flows (`init/update/doctor/uninstall`):** 90% path coverage via integration tests
+
+Notes:
+- Thresholds are quality gates, not a substitute for meaningful assertions.
+- Do not inflate coverage with low-value tests.
+
+## 3) Naming and Organization
+
+- Keep tests near existing suites under `test/` with descriptive names.
+- Name test cases by behavior, not implementation details.
+- Group related assertions by command or workflow context.
+- Prefer deterministic fixtures and isolated temp directories.
+
+## 4) Regression Rule
+
+- Every bug fix must include a failing test first (or test update) proving the defect.
+- The same test must pass with the fix.
+
+## 5) PR Quality Gates
+
+- `bun run typecheck` passes.
+- `bun run check` passes.
+- New/changed behavior includes tests.
+- If coverage changes, explain rationale in PR summary.
+
+## 6) Definition of Done
+
+A test-related change is done when:
+- required test types are addressed,
+- coverage targets are respected for changed areas,
+- and checks pass in CI/local validation flow.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -548,6 +548,12 @@ async function ensureWorkspaceAssets({ workspaceDir, packageRoot, state, rootDir
 
   await copySourceFile({
     packageRoot,
+    sourceRel: 'core/test-standards.md',
+    target: path.join(outRoot, 'test-standards.md')
+  });
+
+  await copySourceFile({
+    packageRoot,
     sourceRel: `languages/${state.effective.language}/core.md`,
     target: path.join(outRoot, 'standards.md')
   });
@@ -654,7 +660,7 @@ function renderRouterDoc({ label, workspaceDir, rootDir, state }: { label: strin
     : `# PROJECT-SPECIFIC CONTEXT\nPrioritize service-local business logic in @./docs/.\nFor cross-service context, consult @${toPosix(path.join(relToRoot, 'docs/'))}.\nIf guidance conflicts, service-local docs win for service-scoped work.\n`;
 
   const modulesText = moduleLines.length ? moduleLines.join('\n') : '- (none)';
-  return `# ailib Router (${label})\n\n# AILIB SYSTEM PROMPT\nAct as the AI Agent defined in ${behaviorRef}.\nAdhere to the coding standards in @.ailib/standards.md.\nApply development workflow rules in @.ailib/development-standards.md.\n\n# MODULES & EXTENSIONS\n${modulesText}\n\n${docsBlock}`;
+  return `# ailib Router (${label})\n\n# AILIB SYSTEM PROMPT\nAct as the AI Agent defined in ${behaviorRef}.\nAdhere to the coding standards in @.ailib/standards.md.\nApply development workflow rules in @.ailib/development-standards.md.\nApply test and coverage rules in @.ailib/test-standards.md.\n\n# MODULES & EXTENSIONS\n${modulesText}\n\n${docsBlock}`;
 }
 
 async function buildWorkspaceState({ workspaceDir, rootDir, rootConfig, registry }: { workspaceDir: string; rootDir: string; rootConfig: WorkspaceConfig; registry: Registry }): Promise<WorkspaceState> {
@@ -663,6 +669,7 @@ async function buildWorkspaceState({ workspaceDir, rootDir, rootConfig, registry
 
   const requiredFiles = [
     '.ailib/development-standards.md',
+    '.ailib/test-standards.md',
     '.ailib/standards.md',
     ...effective.localModules.map((m) => `.ailib/modules/${m}.md`)
   ];
@@ -940,6 +947,12 @@ async function writeRootLock({ rootDir, packageRoot, packageVersion, registryRef
       const rel = '.ailib/development-standards.md';
       const text = await fs.readFile(path.join(workspaceDir, rel), 'utf8');
       files[rel] = { source: 'core/development-standards.md', sha256: sha256(text) };
+    }
+
+    {
+      const rel = '.ailib/test-standards.md';
+      const text = await fs.readFile(path.join(workspaceDir, rel), 'utf8');
+      files[rel] = { source: 'core/test-standards.md', sha256: sha256(text) };
     }
 
     {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -113,6 +113,7 @@ test('init creates root config, root lock, and routers with new layout', async (
   assert.equal(await exists(path.join(cwd, 'ailib.lock')), true);
   assert.equal(await exists(path.join(cwd, '.ailib/behavior.md')), true);
   assert.equal(await exists(path.join(cwd, '.ailib/development-standards.md')), true);
+  assert.equal(await exists(path.join(cwd, '.ailib/test-standards.md')), true);
   assert.equal(await exists(path.join(cwd, '.ailib/standards.md')), true);
   assert.equal(await exists(path.join(cwd, '.ailib/modules/eslint.md')), true);
   assert.equal(await exists(path.join(cwd, 'CLAUDE.md')), true);
@@ -142,6 +143,7 @@ test('monorepo update inherits root and supports service override modules', asyn
 
   assert.equal(await exists(path.join(root, '.ailib/behavior.md')), true);
   assert.equal(await exists(path.join(root, '.ailib/development-standards.md')), true);
+  assert.equal(await exists(path.join(root, '.ailib/test-standards.md')), true);
   assert.equal(await exists(path.join(root, 'apps', 'web', '.ailib/modules/biome.md')), true);
   assert.equal(await exists(path.join(root, 'apps', 'web', '.ailib/modules/eslint.md')), false);
   assert.equal(await exists(path.join(root, 'services', 'ml', '.ailib/standards.md')), true);


### PR DESCRIPTION
## Summary
- Add a test standards guide with required test types, coverage targets, naming rules, and quality gates.
- Add consumer-facing `core/test-standards.md` and generate `.ailib/test-standards.md` during init/update.
- Enforce test standards pointer in router guidance, doctor required files, lockfile tracking, and PR checklist.

## Test plan
- [x] Run `bun run check`

Closes #24

Made with [Cursor](https://cursor.com)