### PR TITLE
infra: enforce standards in CI workflow

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -1,0 +1,28 @@
+name: quality-gates
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run quality checks
+        run: bun run check

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ bun run registry:build
 bun run registry:check
 bun run catalog:build
 bun run catalog:check
+bun run standards:check
 bun run check
 ```
 

--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
     "registry:check": "bun tools/sync-registry.mjs --check",
     "catalog:build": "bun tools/generate-module-catalog.mjs",
     "catalog:check": "bun tools/generate-module-catalog.mjs --check",
+    "standards:check": "bun tools/check-standards.mjs",
     "typecheck": "bunx tsc --noEmit",
     "test": "bun test",
-    "check": "bun test && bunx tsc --noEmit && bun tools/sync-registry.mjs --check && bun tools/generate-module-catalog.mjs --check"
+    "check": "bun test && bunx tsc --noEmit && bun tools/sync-registry.mjs --check && bun tools/generate-module-catalog.mjs --check && bun tools/check-standards.mjs"
   },
   "keywords": [
     "ai",

--- a/tools/check-standards.mjs
+++ b/tools/check-standards.mjs
@@ -1,0 +1,61 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+
+const requiredFiles = [
+  'docs/development-standards.md',
+  'docs/test-standards.md',
+  'core/development-standards.md',
+  'core/test-standards.md',
+  '.github/pull_request_template.md',
+  'README.md'
+];
+
+const requiredTemplateSnippets = [
+  '`docs/development-standards.md`',
+  '`docs/test-standards.md`',
+  '`bun run typecheck`',
+  '`bun run check`',
+  'Refs #'
+];
+
+const requiredReadmeLinks = [
+  '[docs/development-standards.md](docs/development-standards.md)',
+  '[docs/test-standards.md](docs/test-standards.md)'
+];
+
+async function ensureFileExists(relPath) {
+  const fullPath = path.join(root, relPath);
+  try {
+    await fs.access(fullPath);
+  } catch {
+    throw new Error(`Missing required standards file: ${relPath}`);
+  }
+}
+
+async function assertContains(relPath, snippets) {
+  const fullPath = path.join(root, relPath);
+  const content = await fs.readFile(fullPath, 'utf8');
+  for (const snippet of snippets) {
+    if (!content.includes(snippet)) {
+      throw new Error(`Missing required snippet in ${relPath}: ${snippet}`);
+    }
+  }
+}
+
+async function main() {
+  for (const relPath of requiredFiles) {
+    await ensureFileExists(relPath);
+  }
+
+  await assertContains('.github/pull_request_template.md', requiredTemplateSnippets);
+  await assertContains('README.md', requiredReadmeLinks);
+
+  process.stdout.write('standards checks passed\n');
+}
+
+main().catch((err) => {
+  process.stderr.write(`${err.message}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add a `quality-gates` GitHub Actions workflow to run `bun run check` on pull requests and pushes to `main`.
- Add `tools/check-standards.mjs` to validate standards docs/template/README references.
- Include standards validation in `bun run check` and document `bun run standards:check` in README.

## Test plan
- [x] Run `bun run standards:check`
- [x] Run `bun run check`

Closes #25

Made with [Cursor](https://cursor.com)