### PR TITLE
feat: add module coverage audit report

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Slot governance and naming rules: [docs/slot-standards.md](docs/slot-standards.m
 Development standards for contributions: [docs/development-standards.md](docs/development-standards.md).
 Test standards and coverage thresholds: [docs/test-standards.md](docs/test-standards.md).
 Generated module catalog: [docs/module-catalog.md](docs/module-catalog.md).
+Module/slot coverage audit report: [docs/module-coverage-audit.md](docs/module-coverage-audit.md).
 Follow-up implementation roadmap: [docs/follow-up-plan.md](docs/follow-up-plan.md).
 
 ## Quick start
@@ -93,6 +94,8 @@ bun run registry:build
 bun run registry:check
 bun run catalog:build
 bun run catalog:check
+bun run coverage-audit:build
+bun run coverage-audit:check
 bun run standards:check
 bun run check
 ```

--- a/docs/module-coverage-audit.md
+++ b/docs/module-coverage-audit.md
@@ -1,0 +1,126 @@
+# Module/Slot Coverage Audit
+
+This report is generated from `registry.json` and `languages/*/modules/*.md`.
+Run `bun tools/generate-coverage-audit.mjs` after registry/module documentation changes.
+
+## Summary
+
+- Registry modules: **37**
+- Module docs: **37**
+- Canonical slots: **28**
+
+## Coverage by Language
+
+### Go (`go`)
+
+- Registry modules: 0
+- Module docs: 0
+- Missing docs: 0
+- Orphan docs: 0
+- Frontmatter issues: 0
+- No gaps detected.
+
+### Java (`java`)
+
+- Registry modules: 0
+- Module docs: 0
+- Missing docs: 0
+- Orphan docs: 0
+- Frontmatter issues: 0
+- No gaps detected.
+
+### JavaScript (`javascript`)
+
+- Registry modules: 0
+- Module docs: 0
+- Missing docs: 0
+- Orphan docs: 0
+- Frontmatter issues: 0
+- No gaps detected.
+
+### Python (`python`)
+
+- Registry modules: 6
+- Module docs: 6
+- Missing docs: 0
+- Orphan docs: 0
+- Frontmatter issues: 0
+- No gaps detected.
+
+### Rust (`rust`)
+
+- Registry modules: 0
+- Module docs: 0
+- Missing docs: 0
+- Orphan docs: 0
+- Frontmatter issues: 0
+- No gaps detected.
+
+### TypeScript (`typescript`)
+
+- Registry modules: 31
+- Module docs: 31
+- Missing docs: 0
+- Orphan docs: 0
+- Frontmatter issues: 0
+- No gaps detected.
+
+## Slot Usage
+
+- `linter`: 3 module(s)
+  - `python:ruff`, `typescript:eslint`, `typescript:biome`
+- `formatter`: 2 module(s)
+  - `python:black`, `typescript:prettier`
+- `package_manager`: 4 module(s)
+  - `python:poetry`, `python:uv`, `typescript:bun`, `typescript:pnpm`
+- `test_runner`: 2 module(s)
+  - `python:pytest`, `typescript:vitest`
+- `styling_system`: 1 module(s)
+  - `typescript:tailwind`
+- `frontend_framework`: 1 module(s)
+  - `typescript:nextjs`
+- `backend_framework`: 2 module(s)
+  - `python:fastapi`, `typescript:nestjs`
+- `ui_library`: 1 module(s)
+  - `typescript:react`
+- `http_adapter`: 1 module(s)
+  - `typescript:fastify`
+- `api_protocol`: 1 module(s)
+  - `typescript:graphql`
+- `graphql_server`: 1 module(s)
+  - `typescript:apollo-server`
+- `orm`: 2 module(s)
+  - `typescript:prisma`, `typescript:typeorm`
+- `event_bus`: 1 module(s)
+  - `typescript:kafkajs`
+- `logger`: 1 module(s)
+  - `typescript:nestjs-pino`
+- `observability`: 1 module(s)
+  - `typescript:nestjs-otel`
+- `runtime_platform`: 1 module(s)
+  - `typescript:aws-lambda`
+- `infra_framework`: 1 module(s)
+  - `typescript:serverless-framework`
+- `bundler`: 1 module(s)
+  - `typescript:esbuild`
+- `schema_validation`: 1 module(s)
+  - `typescript:zod`
+- `dto_validation`: 1 module(s)
+  - `typescript:class-validator`
+- `config_validation`: 1 module(s)
+  - `typescript:joi`
+- `api_docs`: 1 module(s)
+  - `typescript:nestjs-swagger`
+- `cloud_platform`: 1 module(s)
+  - `typescript:aws-amplify`
+- `payments_provider`: 1 module(s)
+  - `typescript:stripe`
+- `database_engine`: 1 module(s)
+  - `typescript:dynamodb`
+- `auth_provider`: 1 module(s)
+  - `typescript:cognito`
+- `email_provider`: 1 module(s)
+  - `typescript:ses`
+- `object_storage_provider`: 1 module(s)
+  - `typescript:s3`
+

--- a/package.json
+++ b/package.json
@@ -22,10 +22,12 @@
     "registry:check": "bun tools/sync-registry.mjs --check",
     "catalog:build": "bun tools/generate-module-catalog.mjs",
     "catalog:check": "bun tools/generate-module-catalog.mjs --check",
+    "coverage-audit:build": "bun tools/generate-coverage-audit.mjs",
+    "coverage-audit:check": "bun tools/generate-coverage-audit.mjs --check",
     "standards:check": "bun tools/check-standards.mjs",
     "typecheck": "bunx tsc --noEmit",
     "test": "bun test",
-    "check": "bun test && bunx tsc --noEmit && bun tools/sync-registry.mjs --check && bun tools/generate-module-catalog.mjs --check && bun tools/check-standards.mjs"
+    "check": "bun test && bunx tsc --noEmit && bun tools/sync-registry.mjs --check && bun tools/generate-module-catalog.mjs --check && bun tools/generate-coverage-audit.mjs --check && bun tools/check-standards.mjs"
   },
   "keywords": [
     "ai",

--- a/tools/generate-coverage-audit.mjs
+++ b/tools/generate-coverage-audit.mjs
@@ -1,0 +1,185 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const registryPath = path.join(packageRoot, 'registry.json');
+const outputPath = path.join(packageRoot, 'docs', 'module-coverage-audit.md');
+const checkOnly = process.argv.includes('--check');
+
+async function readJson(filePath) {
+  return JSON.parse(await fs.readFile(filePath, 'utf8'));
+}
+
+function parseFrontmatter(markdown) {
+  const match = markdown.match(/^---\n([\s\S]*?)\n---\n/u);
+  if (!match) return null;
+  const fields = {};
+  for (const line of match[1].split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const idx = line.indexOf(':');
+    if (idx < 0) continue;
+    const key = line.slice(0, idx).trim();
+    fields[key] = line.slice(idx + 1).trim();
+  }
+  return fields;
+}
+
+async function collectDocModuleInfo(languageId) {
+  const dir = path.join(packageRoot, 'languages', languageId, 'modules');
+  let entries = [];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const modules = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+    const moduleId = entry.name.replace(/\.md$/u, '');
+    const filePath = path.join(dir, entry.name);
+    const markdown = await fs.readFile(filePath, 'utf8');
+    const frontmatter = parseFrontmatter(markdown) || {};
+    modules.push({ moduleId, filePath, frontmatter });
+  }
+  return modules;
+}
+
+async function buildAudit(registry) {
+  const report = {
+    byLanguage: [],
+    global: {
+      registryModules: 0,
+      docModules: 0
+    },
+    slotUsage: new Map()
+  };
+
+  for (const slot of registry.slots || []) report.slotUsage.set(slot, []);
+
+  for (const [languageId, languageDef] of Object.entries(registry.languages || {})) {
+    const registryModules = Object.entries(languageDef.modules || {}).map(([moduleId, moduleDef]) => ({
+      moduleId,
+      slot: moduleDef.slot
+    }));
+    const docModules = await collectDocModuleInfo(languageId);
+
+    const registryIds = new Set(registryModules.map((m) => m.moduleId));
+    const docIds = new Set(docModules.map((m) => m.moduleId));
+
+    const missingDocs = registryModules.filter((m) => !docIds.has(m.moduleId)).map((m) => m.moduleId);
+    const orphanDocs = docModules.filter((m) => !registryIds.has(m.moduleId)).map((m) => m.moduleId);
+
+    const frontmatterIssues = [];
+    for (const doc of docModules) {
+      const expectedSlot = languageDef.modules?.[doc.moduleId]?.slot;
+      if (expectedSlot) {
+        const issues = [];
+        if (doc.frontmatter.id !== doc.moduleId) issues.push(`id=${doc.frontmatter.id || '(missing)'}`);
+        if (doc.frontmatter.language !== languageId) issues.push(`language=${doc.frontmatter.language || '(missing)'}`);
+        if (doc.frontmatter.slot !== expectedSlot) issues.push(`slot=${doc.frontmatter.slot || '(missing)'}`);
+        if (issues.length) {
+          frontmatterIssues.push(`- \`${doc.moduleId}\`: ${issues.join(', ')}`);
+        }
+      }
+    }
+
+    for (const mod of registryModules) {
+      const slot = mod.slot;
+      if (!report.slotUsage.has(slot)) report.slotUsage.set(slot, []);
+      report.slotUsage.get(slot).push(`${languageId}:${mod.moduleId}`);
+    }
+
+    report.global.registryModules += registryModules.length;
+    report.global.docModules += docModules.length;
+    report.byLanguage.push({
+      languageId,
+      display: languageDef.display,
+      registryCount: registryModules.length,
+      docCount: docModules.length,
+      missingDocs,
+      orphanDocs,
+      frontmatterIssues
+    });
+  }
+
+  return report;
+}
+
+function renderReport(registry, report) {
+  const lines = [];
+  lines.push('# Module/Slot Coverage Audit');
+  lines.push('');
+  lines.push('This report is generated from `registry.json` and `languages/*/modules/*.md`.');
+  lines.push('Run `bun tools/generate-coverage-audit.mjs` after registry/module documentation changes.');
+  lines.push('');
+  lines.push('## Summary');
+  lines.push('');
+  lines.push(`- Registry modules: **${report.global.registryModules}**`);
+  lines.push(`- Module docs: **${report.global.docModules}**`);
+  lines.push(`- Canonical slots: **${(registry.slots || []).length}**`);
+  lines.push('');
+  lines.push('## Coverage by Language');
+  lines.push('');
+
+  for (const language of report.byLanguage.sort((a, b) => a.languageId.localeCompare(b.languageId))) {
+    lines.push(`### ${language.display} (\`${language.languageId}\`)`);
+    lines.push('');
+    lines.push(`- Registry modules: ${language.registryCount}`);
+    lines.push(`- Module docs: ${language.docCount}`);
+    lines.push(`- Missing docs: ${language.missingDocs.length}`);
+    lines.push(`- Orphan docs: ${language.orphanDocs.length}`);
+    lines.push(`- Frontmatter issues: ${language.frontmatterIssues.length}`);
+    if (language.missingDocs.length) lines.push(`- Missing doc module IDs: ${language.missingDocs.map((m) => `\`${m}\``).join(', ')}`);
+    if (language.orphanDocs.length) lines.push(`- Orphan doc module IDs: ${language.orphanDocs.map((m) => `\`${m}\``).join(', ')}`);
+    if (language.frontmatterIssues.length) {
+      lines.push('- Frontmatter mismatches:');
+      lines.push(...language.frontmatterIssues);
+    }
+    if (!language.missingDocs.length && !language.orphanDocs.length && !language.frontmatterIssues.length) {
+      lines.push('- No gaps detected.');
+    }
+    lines.push('');
+  }
+
+  lines.push('## Slot Usage');
+  lines.push('');
+  for (const slot of registry.slots || []) {
+    const usedBy = report.slotUsage.get(slot) || [];
+    lines.push(`- \`${slot}\`: ${usedBy.length} module(s)`);
+    if (usedBy.length) {
+      lines.push(`  - ${usedBy.map((entry) => `\`${entry}\``).join(', ')}`);
+    } else {
+      lines.push('  - (no modules mapped)');
+    }
+  }
+  lines.push('');
+
+  return `${lines.join('\n')}\n`;
+}
+
+async function run() {
+  const registry = await readJson(registryPath);
+  const report = await buildAudit(registry);
+  const nextText = renderReport(registry, report);
+
+  if (checkOnly) {
+    const currentText = await fs.readFile(outputPath, 'utf8');
+    if (currentText !== nextText) {
+      process.stderr.write('docs/module-coverage-audit.md is out of sync. Run: bun tools/generate-coverage-audit.mjs\n');
+      process.exitCode = 1;
+      return;
+    }
+    process.stdout.write('docs/module-coverage-audit.md is up to date\n');
+    return;
+  }
+
+  await fs.writeFile(outputPath, nextText, 'utf8');
+  process.stdout.write('docs/module-coverage-audit.md updated\n');
+}
+
+run().catch((error) => {
+  process.stderr.write(`${error.message}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add `tools/generate-coverage-audit.mjs` to generate a module/slot coverage audit report from `registry.json` and module docs.
- Add build/check scripts and enforce audit synchronization in `bun run check`.
- Add `docs/module-coverage-audit.md` and link it from README.

## Test plan
- [x] Run `bun run coverage-audit:build`
- [x] Run `bun run check`

Closes #33

Made with [Cursor](https://cursor.com)