### PR TITLE
infra: add quality workflow gates

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  validate:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -24,5 +24,94 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Run quality checks
+      - name: Run lint checks
+        run: bun run lint
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run typecheck
+        run: bun run typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run tests
+        run: bun run test
+
+  registry-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Validate registry and generated docs sync
+        run: |
+          bun run registry:check
+          bun run catalog:check
+          bun run coverage-audit:check
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run coverage threshold checks
+        run: bun run coverage:check
+
+  check:
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck, test, registry-validation, coverage]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run full check command
         run: bun run check

--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ bun run catalog:build
 bun run catalog:check
 bun run coverage-audit:build
 bun run coverage-audit:check
+bun run coverage:build
+bun run coverage:check
+bun run lint
+bun run typecheck
+bun run test
 bun run standards:check
 bun run check
 ```

--- a/package.json
+++ b/package.json
@@ -18,16 +18,19 @@
     "registry.json"
   ],
   "scripts": {
+    "lint": "bun tools/check-standards.mjs",
     "registry:build": "bun tools/sync-registry.mjs",
     "registry:check": "bun tools/sync-registry.mjs --check",
     "catalog:build": "bun tools/generate-module-catalog.mjs",
     "catalog:check": "bun tools/generate-module-catalog.mjs --check",
     "coverage-audit:build": "bun tools/generate-coverage-audit.mjs",
     "coverage-audit:check": "bun tools/generate-coverage-audit.mjs --check",
+    "coverage:build": "bun test --coverage --coverage-reporter=text --coverage-reporter=lcov",
+    "coverage:check": "bun run coverage:build && bun tools/check-coverage-threshold.mjs --file coverage/lcov.info --min-lines=80",
     "standards:check": "bun tools/check-standards.mjs",
     "typecheck": "bunx tsc --noEmit",
     "test": "bun test",
-    "check": "bun test && bunx tsc --noEmit && bun tools/sync-registry.mjs --check && bun tools/generate-module-catalog.mjs --check && bun tools/generate-coverage-audit.mjs --check && bun tools/check-standards.mjs"
+    "check": "bun run lint && bun run test && bun run typecheck && bun run coverage-audit:check && bun run registry:check && bun run catalog:check && bun run coverage:check"
   },
   "keywords": [
     "ai",

--- a/tools/check-coverage-threshold.mjs
+++ b/tools/check-coverage-threshold.mjs
@@ -1,0 +1,65 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+
+function readArg(name, fallback) {
+  const prefix = `--${name}=`;
+  const direct = process.argv.find((arg) => arg.startsWith(prefix));
+  if (direct) return direct.slice(prefix.length);
+
+  const idx = process.argv.findIndex((arg) => arg === `--${name}`);
+  if (idx >= 0 && process.argv[idx + 1]) return process.argv[idx + 1];
+
+  return fallback;
+}
+
+async function run() {
+  const minLinesRaw = readArg('min-lines', '80');
+  const lcovFile = readArg('file', path.join('coverage', 'lcov.info'));
+
+  const minLines = Number(minLinesRaw);
+  if (!Number.isFinite(minLines) || minLines < 0 || minLines > 100) {
+    throw new Error(`Invalid --min-lines value '${minLinesRaw}'. Expected number between 0 and 100.`);
+  }
+
+  const filePath = path.isAbsolute(lcovFile) ? lcovFile : path.join(packageRoot, lcovFile);
+  const content = await fs.readFile(filePath, 'utf8');
+  const lines = content.split(/\r?\n/u);
+
+  let totalLines = 0;
+  let coveredLines = 0;
+
+  for (const line of lines) {
+    if (!line.startsWith('DA:')) continue;
+    const payload = line.slice(3).split(',');
+    if (payload.length !== 2) continue;
+    const hits = Number(payload[1]);
+    if (!Number.isFinite(hits)) continue;
+    totalLines += 1;
+    if (hits > 0) coveredLines += 1;
+  }
+
+  if (totalLines === 0) {
+    throw new Error(`No line coverage entries found in '${lcovFile}'.`);
+  }
+
+  const lineCoverage = (coveredLines / totalLines) * 100;
+  const rounded = Math.round(lineCoverage * 100) / 100;
+
+  if (lineCoverage < minLines) {
+    throw new Error(
+      `Line coverage ${rounded}% is below threshold ${minLines}% (${coveredLines}/${totalLines}).`
+    );
+  }
+
+  console.log(
+    `Coverage threshold check passed: ${rounded}% >= ${minLines}% (${coveredLines}/${totalLines})`
+  );
+}
+
+run().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Split CI quality-gates into explicit jobs for lint, typecheck, tests, registry sync, and coverage checks.
- Add `tools/check-coverage-threshold.mjs` and wire `coverage:check` to enforce a minimum line coverage threshold.
- Update `check` and maintenance scripts so local checks match CI gates.

## Test plan
- [x] Run `bun run lint`
- [x] Run `bun run typecheck`
- [x] Run `bun run test`
- [x] Run `bun run coverage:check`
- [x] Run `bun run registry:check`
- [x] Run `bun run catalog:check`
- [x] Run `bun run coverage-audit:check`

Closes #35

Made with [Cursor](https://cursor.com)