### PR TITLE
refactor: migrate standards tool to ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ bun run coverage:check
 bun run lint
 bun run typecheck
 bun run test
+bun run tools:build
 bun run standards:check
 bun run check
 ```

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "registry.json"
   ],
   "scripts": {
-    "lint": "bun tools/check-standards.mjs",
+    "lint": "bun tools/check-standards.ts",
+    "tools:build": "bunx tsc -p tsconfig.tools.json",
     "registry:build": "bun tools/sync-registry.mjs",
     "registry:check": "bun tools/sync-registry.mjs --check",
     "catalog:build": "bun tools/generate-module-catalog.mjs",
@@ -27,7 +28,7 @@
     "coverage-audit:check": "bun tools/generate-coverage-audit.mjs --check",
     "coverage:build": "bun test --coverage --coverage-reporter=text --coverage-reporter=lcov",
     "coverage:check": "bun run coverage:build && bun tools/check-coverage-threshold.mjs --file coverage/lcov.info --min-lines=80",
-    "standards:check": "bun tools/check-standards.mjs",
+    "standards:check": "bun tools/check-standards.ts",
     "typecheck": "bunx tsc --noEmit",
     "test": "bun test",
     "check": "bun run lint && bun run test && bun run typecheck && bun run coverage-audit:check && bun run registry:check && bun run catalog:check && bun run coverage:check"

--- a/tools/check-standards.ts
+++ b/tools/check-standards.ts
@@ -25,7 +25,7 @@ const requiredReadmeLinks = [
   '[docs/test-standards.md](docs/test-standards.md)'
 ];
 
-async function ensureFileExists(relPath) {
+async function ensureFileExists(relPath: string): Promise<void> {
   const fullPath = path.join(root, relPath);
   try {
     await fs.access(fullPath);
@@ -34,7 +34,7 @@ async function ensureFileExists(relPath) {
   }
 }
 
-async function assertContains(relPath, snippets) {
+async function assertContains(relPath: string, snippets: string[]): Promise<void> {
   const fullPath = path.join(root, relPath);
   const content = await fs.readFile(fullPath, 'utf8');
   for (const snippet of snippets) {
@@ -44,7 +44,7 @@ async function assertContains(relPath, snippets) {
   }
 }
 
-async function main() {
+async function main(): Promise<void> {
   for (const relPath of requiredFiles) {
     await ensureFileExists(relPath);
   }
@@ -55,7 +55,8 @@ async function main() {
   process.stdout.write('standards checks passed\n');
 }
 
-main().catch((err) => {
-  process.stderr.write(`${err.message}\n`);
+main().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`${message}\n`);
   process.exit(1);
 });

--- a/tsconfig.tools.json
+++ b/tsconfig.tools.json
@@ -3,12 +3,14 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "allowImportingTsExtensions": true,
+    "outDir": "dist/tools",
+    "rootDir": "tools",
     "types": ["node"],
     "strict": false,
-    "noEmit": true,
     "allowJs": false,
+    "declaration": false,
+    "sourceMap": false,
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts", "tools/**/*.ts", "test/**/*.ts"]
+  "include": ["tools/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- Migrate `tools/check-standards.mjs` to `tools/check-standards.ts` with equivalent behavior.
- Add `tsconfig.tools.json` and `tools:build` script as the initial tooling compilation foundation.
- Update scripts and docs to run standards checks from TypeScript tooling.

## Test plan
- [x] Run `bun run lint`
- [x] Run `bun run tools:build`
- [x] Run `bun run typecheck`
- [x] Run `bun run test`

Closes #51

Made with [Cursor](https://cursor.com)