### PR TITLE
refactor: migrate coverage checker to ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "coverage-audit:build": "bun tools/generate-coverage-audit.mjs",
     "coverage-audit:check": "bun tools/generate-coverage-audit.mjs --check",
     "coverage:build": "bun test --coverage --coverage-reporter=text --coverage-reporter=lcov",
-    "coverage:check": "bun run coverage:build && bun tools/check-coverage-threshold.mjs --file coverage/lcov.info --min-lines=80",
+    "coverage:check": "bun run coverage:build && bun tools/check-coverage-threshold.ts --file coverage/lcov.info --min-lines=80",
     "standards:check": "bun tools/check-standards.ts",
     "typecheck": "bunx tsc --noEmit",
     "test": "bun test",

--- a/tools/check-coverage-threshold.ts
+++ b/tools/check-coverage-threshold.ts
@@ -4,7 +4,7 @@ import process from 'node:process';
 
 const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
 
-function readArg(name, fallback) {
+function readArg(name: string, fallback: string): string {
   const prefix = `--${name}=`;
   const direct = process.argv.find((arg) => arg.startsWith(prefix));
   if (direct) return direct.slice(prefix.length);
@@ -15,7 +15,7 @@ function readArg(name, fallback) {
   return fallback;
 }
 
-async function run() {
+async function run(): Promise<void> {
   const minLinesRaw = readArg('min-lines', '80');
   const lcovFile = readArg('file', path.join('coverage', 'lcov.info'));
 
@@ -59,7 +59,7 @@ async function run() {
   );
 }
 
-run().catch((error) => {
+run().catch((error: unknown) => {
   console.error(error instanceof Error ? error.message : String(error));
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- Migrate `tools/check-coverage-threshold.mjs` to `tools/check-coverage-threshold.ts`.
- Update `coverage:check` script to run the TypeScript implementation.
- Preserve existing LCOV parsing and threshold enforcement behavior.

## Test plan
- [x] Run `bun run coverage:check`
- [x] Run `bun run tools:build`
- [x] Run `bun run typecheck`
- [x] Run `bun run test`

Closes #51

Made with [Cursor](https://cursor.com)