### PR TITLE
refactor: migrate registry sync tool to ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "scripts": {
     "lint": "bun tools/check-standards.ts",
     "tools:build": "bunx tsc -p tsconfig.tools.json",
-    "registry:build": "bun tools/sync-registry.mjs",
-    "registry:check": "bun tools/sync-registry.mjs --check",
+    "registry:build": "bun tools/sync-registry.ts",
+    "registry:check": "bun tools/sync-registry.ts --check",
     "catalog:build": "bun tools/generate-module-catalog.mjs",
     "catalog:check": "bun tools/generate-module-catalog.mjs --check",
     "coverage-audit:build": "bun tools/generate-coverage-audit.mjs",

--- a/test/registry-governance.test.ts
+++ b/test/registry-governance.test.ts
@@ -231,6 +231,6 @@ test('split registry and generated catalog are in sync', () => {
     { stdio: 'pipe', encoding: 'utf8' }
   );
 
-  run('tools/sync-registry.mjs', '--check');
+  run('tools/sync-registry.ts', '--check');
   run('tools/generate-module-catalog.mjs', '--check');
 });

--- a/tools/sync-registry.ts
+++ b/tools/sync-registry.ts
@@ -10,11 +10,11 @@ const outputPath = path.join(packageRoot, 'registry.json');
 
 const checkOnly = process.argv.includes('--check');
 
-async function readJson(filePath) {
+async function readJson(filePath: string): Promise<any> {
   return JSON.parse(await fs.readFile(filePath, 'utf8'));
 }
 
-async function listLanguageFiles() {
+async function listLanguageFiles(): Promise<string[]> {
   const entries = await fs.readdir(languageDir, { withFileTypes: true });
   return entries
     .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
@@ -22,13 +22,13 @@ async function listLanguageFiles() {
     .sort();
 }
 
-async function buildRegistry() {
+async function buildRegistry(): Promise<any> {
   const core = await readJson(corePath);
   if ('languages' in core) {
     throw new Error('registry/core.json must not contain a top-level `languages` key');
   }
 
-  const languages = {};
+  const languages: Record<string, any> = {};
   for (const file of await listLanguageFiles()) {
     const languageId = file.replace(/\.json$/u, '');
     languages[languageId] = await readJson(path.join(languageDir, file));
@@ -37,18 +37,18 @@ async function buildRegistry() {
   return { ...core, languages };
 }
 
-function toJsonText(value) {
+function toJsonText(value: any): string {
   return `${JSON.stringify(value, null, 2)}\n`;
 }
 
-async function run() {
+async function run(): Promise<void> {
   const built = await buildRegistry();
   const nextText = toJsonText(built);
 
   if (checkOnly) {
     const currentText = await fs.readFile(outputPath, 'utf8');
     if (currentText !== nextText) {
-      process.stderr.write('registry.json is out of sync. Run: bun tools/sync-registry.mjs\n');
+      process.stderr.write('registry.json is out of sync. Run: bun tools/sync-registry.ts\n');
       process.exitCode = 1;
       return;
     }
@@ -60,7 +60,8 @@ async function run() {
   process.stdout.write('registry.json updated from split sources\n');
 }
 
-run().catch((error) => {
-  process.stderr.write(`${error.message}\n`);
+run().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${message}\n`);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- Migrate `tools/sync-registry.mjs` to `tools/sync-registry.ts`.
- Update `registry:build` and `registry:check` scripts to use the TypeScript tool.
- Update governance sync test to call the new TypeScript script path.

## Test plan
- [x] Run `bun run registry:check`
- [x] Run `bun run tools:build`
- [x] Run `bun run typecheck`
- [x] Run `bun test test/registry-governance.test.ts`

Closes #51

Made with [Cursor](https://cursor.com)