### PR TITLE
infra: add release bootstrap scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ brew install ailib
 ```
 
 Homebrew publishing and release steps: [docs/homebrew-publishing.md](docs/homebrew-publishing.md).
+
+### Local install from repository
+
+```bash
+bun run local:install
+```
 Slot governance and naming rules: [docs/slot-standards.md](docs/slot-standards.md).
 Development standards for contributions: [docs/development-standards.md](docs/development-standards.md).
 Test standards and coverage thresholds: [docs/test-standards.md](docs/test-standards.md).
@@ -98,7 +104,9 @@ bun run coverage-audit:build
 bun run coverage-audit:check
 bun run coverage:build
 bun run coverage:check
+bun run release:build
 bun run lint
+bun run local:install
 bun run typecheck
 bun run test
 bun run tools:build

--- a/docs/homebrew-publishing.md
+++ b/docs/homebrew-publishing.md
@@ -13,6 +13,27 @@ brew install --HEAD --formula https://raw.githubusercontent.com/Alisya-AI/ai-lib
 
 ## Recommended distribution: dedicated tap
 
+## Build artifacts for npm and formula work
+
+Generate release artifacts from the repository:
+
+```bash
+bun run release:build
+```
+
+Outputs are written to `dist/release/`:
+
+- npm package tarball (`*.tgz`)
+- source tarball (`ailib-v<version>-<sha>-source.tar.gz`)
+- checksum manifest (`release-checksums.txt`)
+- formula snippet helper (`homebrew-formula-snippet.txt`)
+
+For a quicker local run that skips full checks:
+
+```bash
+bun run release:build -- --skip-check
+```
+
 Use a tap repo so users can run `brew install ailib` after one-time tap setup.
 
 ### One-time setup

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "registry.json"
   ],
   "scripts": {
+    "release:build": "bash scripts/build-release-artifacts.sh",
+    "local:install": "bash scripts/install-local.sh",
     "lint": "bun tools/check-standards.ts",
     "tools:build": "bunx tsc -p tsconfig.tools.json",
     "registry:build": "bun tools/sync-registry.ts",

--- a/scripts/build-release-artifacts.sh
+++ b/scripts/build-release-artifacts.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIST_DIR="${ROOT_DIR}/dist/release"
+RUN_CHECKS="true"
+
+for arg in "$@"; do
+  case "$arg" in
+    --skip-check)
+      RUN_CHECKS="false"
+      ;;
+    *)
+      echo "Unknown option: $arg"
+      echo "Usage: bash scripts/build-release-artifacts.sh [--skip-check]"
+      exit 1
+      ;;
+  esac
+done
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "bun is required but was not found in PATH."
+  exit 1
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm is required but was not found in PATH."
+  exit 1
+fi
+
+cd "${ROOT_DIR}"
+
+echo "Installing dependencies..."
+bun install --frozen-lockfile
+
+if [[ "${RUN_CHECKS}" == "true" ]]; then
+  echo "Running full checks..."
+  bun run check
+fi
+
+echo "Building TypeScript tooling outputs..."
+bun run tools:build
+
+mkdir -p "${DIST_DIR}"
+rm -f "${DIST_DIR}"/*.tgz "${DIST_DIR}"/release-checksums.txt "${DIST_DIR}"/homebrew-formula-snippet.txt
+
+echo "Packing npm artifact..."
+PACK_JSON="$(npm pack --pack-destination "${DIST_DIR}" --json)"
+NPM_TARBALL="$(printf '%s' "${PACK_JSON}" | node -e "let input='';process.stdin.on('data',d=>input+=d);process.stdin.on('end',()=>{const parsed=JSON.parse(input);console.log(parsed[0].filename);});")"
+NPM_TARBALL_PATH="${DIST_DIR}/${NPM_TARBALL}"
+
+VERSION="$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('package.json','utf8')).version)")"
+GIT_SHA="$(git rev-parse --short HEAD)"
+SOURCE_TARBALL="ailib-v${VERSION}-${GIT_SHA}-source.tar.gz"
+SOURCE_TARBALL_PATH="${DIST_DIR}/${SOURCE_TARBALL}"
+
+echo "Packing source artifact for formula workflows..."
+git archive --format=tar.gz --output="${SOURCE_TARBALL_PATH}" HEAD
+
+NPM_SHA="$(shasum -a 256 "${NPM_TARBALL_PATH}" | awk '{print $1}')"
+SOURCE_SHA="$(shasum -a 256 "${SOURCE_TARBALL_PATH}" | awk '{print $1}')"
+
+{
+  echo "npm_tarball=${NPM_TARBALL}"
+  echo "npm_sha256=${NPM_SHA}"
+  echo "source_tarball=${SOURCE_TARBALL}"
+  echo "source_sha256=${SOURCE_SHA}"
+  echo "version=${VERSION}"
+  echo "git_sha=${GIT_SHA}"
+} > "${DIST_DIR}/release-checksums.txt"
+
+{
+  echo "# Update this once the release tag exists"
+  echo "url \"https://github.com/Alisya-AI/ai-lib/archive/refs/tags/v${VERSION}.tar.gz\""
+  echo "sha256 \"${SOURCE_SHA}\""
+} > "${DIST_DIR}/homebrew-formula-snippet.txt"
+
+echo "Release artifacts generated:"
+echo "- ${NPM_TARBALL_PATH}"
+echo "- ${SOURCE_TARBALL_PATH}"
+echo "- ${DIST_DIR}/release-checksums.txt"
+echo "- ${DIST_DIR}/homebrew-formula-snippet.txt"

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "bun is required but was not found in PATH."
+  exit 1
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm is required but was not found in PATH."
+  exit 1
+fi
+
+cd "${ROOT_DIR}"
+
+echo "Installing dependencies..."
+bun install --frozen-lockfile
+
+echo "Building TypeScript tooling outputs..."
+bun run tools:build
+
+echo "Installing @ailib/cli globally from local repository..."
+npm install -g .
+
+echo "Validating installed CLI..."
+ailib --help >/dev/null
+
+echo "Local install complete."
+echo "Try: ailib --help"


### PR DESCRIPTION
## Summary
- Add `scripts/build-release-artifacts.sh` to generate npm/source release artifacts and formula checksum helpers.
- Add `scripts/install-local.sh` to bootstrap and install `@ailib/cli` from a local clone.
- Wire `release:build` and `local:install` scripts and document both workflows.

## Test plan
- [x] Run `bash -n scripts/build-release-artifacts.sh`
- [x] Run `bash -n scripts/install-local.sh`
- [x] Run `bun run release:build -- --skip-check`
- [x] Run `bun run check`

Closes #51

Made with [Cursor](https://cursor.com)