### PR TITLE
infra: harden external pr workflow defaults

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: quality-gates-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -15,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -32,6 +38,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -49,6 +57,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -66,6 +76,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -86,6 +98,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -104,6 +118,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -8,15 +8,22 @@ on:
   schedule:
     - cron: '0 6 * * 1'
 
+concurrency:
+  group: security-scans-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   dependency-audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -30,7 +37,9 @@ jobs:
         run: bun audit --audit-level=high
 
   secret-scan:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
@@ -38,6 +47,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run gitleaks scan
         uses: gitleaks/gitleaks-action@v2
@@ -46,7 +56,9 @@ jobs:
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
 
   codeql-analysis:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       actions: read
       contents: read
@@ -54,6 +66,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ brew install ailib
 ```
 
 Homebrew publishing and release steps: [docs/homebrew-publishing.md](docs/homebrew-publishing.md).
+Workflow hardening patterns for external PRs: [docs/workflow-security-hardening.md](docs/workflow-security-hardening.md).
 
 ### Local install from repository
 

--- a/docs/workflow-security-hardening.md
+++ b/docs/workflow-security-hardening.md
@@ -1,0 +1,24 @@
+# Workflow Security Hardening
+
+This document defines hardened defaults for GitHub Actions workflows in `ai-lib`.
+
+## Default rules
+
+- Use `pull_request` instead of `pull_request_target` for untrusted contributions.
+- Keep top-level permissions minimal (`contents: read` by default).
+- Set job-level elevated permissions only when required.
+- Use `actions/checkout` with `persist-credentials: false`.
+- Add `concurrency` groups to avoid stale runs.
+- Add `timeout-minutes` to prevent unbounded execution.
+
+## External PR handling
+
+- External/fork PRs must run with least privilege.
+- Jobs requiring repository secrets must be guarded to avoid running on forked PRs.
+- Trusted-only jobs should use explicit `if` conditions to limit execution context.
+
+## Current implementation in this repository
+
+- `quality-gates.yml` uses minimal permissions and non-persistent checkout credentials.
+- `security-scans.yml` runs dependency audit for all contexts, but restricts secret-dependent scans for fork PRs.
+- Secret scan and CodeQL jobs are gated to trusted contexts while preserving coverage on push/main and schedule.


### PR DESCRIPTION
## Summary
- Harden `quality-gates` and `security-scans` workflows for external PR contexts.
- Add least-privilege checkout defaults (`persist-credentials: false`), concurrency guards, and job timeouts.
- Gate secret-dependent scans for forked PRs and document hardened workflow patterns.

## Test plan
- [x] Run `bun run security:audit`
- [x] Run `bun run check`

Closes #39

Made with [Cursor](https://cursor.com)