### PR TITLE
feat: define local override config model

### DIFF
--- a/docs/follow-up-plan.md
+++ b/docs/follow-up-plan.md
@@ -57,3 +57,5 @@ This roadmap tracks post-foundation work for `ailib`.
   - validation + doctor checks for invalid overrides
 - Guarantee:
   - upstream `ailib` upgrades do not wipe consumer-local customizations.
+
+Model draft and schema reference: [docs/local-override-model.md](local-override-model.md), [schema/override.schema.json](../schema/override.schema.json).

--- a/docs/local-override-model.md
+++ b/docs/local-override-model.md
@@ -1,0 +1,100 @@
+# Local Override Config Model
+
+This document defines the proposed model for consumer-local customization in `ailib`.
+
+## Goal
+
+Allow teams to customize targets/modules/slots locally without forking generated files or losing custom behavior on `ailib` upgrades.
+
+## File and versioning
+
+- File name: `ailib.local.json`
+- Scope: repository-local (recommended in `.gitignore` unless intentionally shared)
+- Schema: `schema/override.schema.json`
+- Version field: required (`version`)
+
+Example root:
+
+```json
+{
+  "version": "1.0.0",
+  "default_override": {},
+  "workspace_overrides": {}
+}
+```
+
+## Override scopes
+
+Each override block supports three scopes:
+
+- `targets`
+- `modules`
+- `slots`
+
+`targets` and `modules` support:
+
+- `add: []`
+- `remove: []`
+- `set: []` (full replacement)
+
+`slots` supports per-slot rules:
+
+- `<slot>.set: "<moduleId>"` (force module for slot)
+- `<slot>.remove: true` (unset local slot override)
+
+## Workspace resolution
+
+- `default_override`: fallback for all workspaces
+- `workspace_overrides`: keyed by workspace path
+  - use `"."` for root workspace
+  - use relative workspace path (for example `apps/api`) for service-specific rules
+
+## Precedence rules
+
+Highest precedence first:
+
+1. `workspace_overrides[<workspace>]`
+2. `default_override`
+3. managed config from `ailib.config.json` / inherited config
+4. registry defaults
+
+Within each scope:
+
+1. apply `set` if present
+2. apply `add`
+3. apply `remove`
+4. apply slot-level rules (`slots`)
+
+## Compatibility guarantees
+
+- Unknown keys must be rejected by schema validation.
+- Unknown module/target/slot references must be reported by validation/doctor checks.
+- New `ailib` versions must preserve valid local override files.
+- Future model changes must increment `version` and define migration behavior.
+
+## Example
+
+```json
+{
+  "version": "1.0.0",
+  "default_override": {
+    "targets": {
+      "add": ["openai"]
+    }
+  },
+  "workspace_overrides": {
+    ".": {
+      "modules": {
+        "add": ["prettier"]
+      }
+    },
+    "apps/api": {
+      "slots": {
+        "logger": {
+          "set": "nestjs-pino"
+        }
+      }
+    }
+  }
+}
+```

--- a/schema/override.schema.json
+++ b/schema/override.schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ailib.dev/schema/override.schema.json",
+  "type": "object",
+  "required": ["version"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Schema/model version for local override compatibility."
+    },
+    "workspace_overrides": {
+      "type": "object",
+      "description": "Workspace-specific override rules keyed by workspace path ('.' for root).",
+      "additionalProperties": {
+        "$ref": "#/$defs/workspaceOverride"
+      }
+    },
+    "default_override": {
+      "description": "Fallback override applied when workspace-specific override is not defined.",
+      "$ref": "#/$defs/workspaceOverride"
+    }
+  },
+  "$defs": {
+    "workspaceOverride": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "targets": {
+          "$ref": "#/$defs/targetScope"
+        },
+        "modules": {
+          "$ref": "#/$defs/moduleScope"
+        },
+        "slots": {
+          "$ref": "#/$defs/slotScope"
+        }
+      }
+    },
+    "targetScope": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "add": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "remove": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "set": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "moduleScope": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "add": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "remove": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "set": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "slotScope": {
+      "type": "object",
+      "description": "Override selected module per slot key.",
+      "additionalProperties": {
+        "$ref": "#/$defs/slotRule"
+      }
+    },
+    "slotRule": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "set": {
+          "type": "string"
+        },
+        "remove": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `schema/override.schema.json` as the versioned local override model for `ailib.local.json`.
- Add `docs/local-override-model.md` defining scopes (`targets`, `modules`, `slots`) and precedence rules.
- Link model references from `docs/follow-up-plan.md` for Phase 6 implementation.

## Test plan
- [x] Run `bun run check`

Refs #43

Made with [Cursor](https://cursor.com)