### PR TITLE
docs: expand local override workflow guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Branch protection and required check policy: [docs/branch-protection-policy.md](
 Guide for adding new targets: [docs/targets-guide.md](docs/targets-guide.md).
 Guide for adding modules and slots: [docs/modules-slots-guide.md](docs/modules-slots-guide.md).
 End-to-end CLI usage guide: [docs/cli-usage-guide.md](docs/cli-usage-guide.md).
+Local override workflow and guarantees: [docs/local-override-model.md](docs/local-override-model.md).
 
 ### Local install from repository
 
@@ -56,6 +57,7 @@ bun run local:install
 - Workflow hardening: [docs/workflow-security-hardening.md](docs/workflow-security-hardening.md)
 - Branch protection policy: [docs/branch-protection-policy.md](docs/branch-protection-policy.md)
 - Homebrew publishing: [docs/homebrew-publishing.md](docs/homebrew-publishing.md)
+- Local override workflow and guarantees: [docs/local-override-model.md](docs/local-override-model.md)
 - Module catalog: [docs/module-catalog.md](docs/module-catalog.md)
 - Module/slot coverage audit: [docs/module-coverage-audit.md](docs/module-coverage-audit.md)
 - Follow-up roadmap: [docs/follow-up-plan.md](docs/follow-up-plan.md)

--- a/docs/cli-usage-guide.md
+++ b/docs/cli-usage-guide.md
@@ -120,6 +120,39 @@ Explain one module:
 ailib modules explain prisma --language=typescript
 ```
 
+## Local override workflow
+
+Use `ailib.local.json` to customize local targets/modules/slots without changing managed `ailib.config.json`.
+
+1) Define overrides at root:
+
+```bash
+touch ailib.local.json
+```
+
+2) Apply updates:
+
+```bash
+ailib update
+```
+
+3) Verify local override integrity:
+
+```bash
+ailib doctor
+```
+
+Behavior:
+
+- Invalid overrides fail `ailib update` immediately.
+- `ailib doctor` reports override validation problems with actionable messages.
+- Valid overrides survive regeneration and future `ailib update` runs.
+
+Reference model and schema:
+
+- [docs/local-override-model.md](docs/local-override-model.md)
+- [schema/override.schema.json](../schema/override.schema.json)
+
 ## Troubleshooting
 
 - `Unknown command`:
@@ -139,6 +172,10 @@ ailib modules explain prisma --language=typescript
 
 - `doctor` reports missing pointer or frontmatter mismatch:
   - re-run `ailib update`, then re-check with `ailib doctor`.
+
+- `Invalid ailib.local.json`:
+  - fix invalid keys or unknown references reported by error output
+  - re-run `ailib update`, then `ailib doctor`.
 
 ## Recommended validation loop
 

--- a/docs/local-override-model.md
+++ b/docs/local-override-model.md
@@ -72,6 +72,58 @@ Within each scope:
 - New `ailib` versions must preserve valid local override files.
 - Future model changes must increment `version` and define migration behavior.
 
+## Authoring workflow
+
+1. Create `ailib.local.json` at repository root.
+2. Start with `version`, then add `default_override` and/or `workspace_overrides`.
+3. Run `ailib update` to apply overrides to generated outputs.
+4. Run `ailib doctor` to verify override + generated state consistency.
+
+Recommended loop:
+
+```bash
+ailib update
+ailib doctor
+```
+
+## Validation and failure behavior
+
+- `ailib update` fails fast when `ailib.local.json` is invalid.
+- `ailib doctor` surfaces override validation errors before pointer-file checks.
+- Validation covers:
+  - JSON structure and allowed keys
+  - known workspace keys
+  - known targets/modules/slots
+  - slot-to-module compatibility (`slots.<slot>.set` must match slot ownership)
+
+Example failure patterns:
+
+- `Invalid ailib.local.json: missing required string 'version'`
+- `Invalid ailib.local.json: unknown workspace override key 'apps/missing'`
+- `Invalid ailib.local.json: default_override.targets.add contains unknown target 'foo'`
+
+## Upgrade guarantees
+
+- `ailib update` never rewrites `ailib.local.json`.
+- Valid overrides continue to apply after registry or CLI upgrades.
+- Incompatibilities are explicit and blocking (fail-fast), never silent partial apply.
+- Future breaking model changes require a `version` bump and migration guidance.
+
+## Troubleshooting and recovery
+
+- `Invalid ailib.local.json` during `update`:
+  - run `ailib doctor` for full diagnostics
+  - fix reported key/reference mismatch
+  - rerun `ailib update`
+
+- Override references module not available in workspace language:
+  - switch module to one supported by the workspace language
+  - or remove that override and rely on base config
+
+- Workspace-specific override not taking effect:
+  - confirm key matches workspace relative path exactly (`.` for root)
+  - rerun `ailib doctor --workspace=<path>` to validate scope
+
 ## Example
 
 ```json


### PR DESCRIPTION
## Summary
- Expand local override documentation with workflow, guarantees, and troubleshooting guidance.
- Add CLI usage guidance for `ailib.local.json` authoring, update, and doctor validation loops.
- Link local override docs from README for discoverability.

## Test plan
- [x] Run `bun run check`

Refs #46

Made with [Cursor](https://cursor.com)