### PR TITLE
docs: add phase 7 quality roadmap

### DIFF
--- a/docs/follow-up-plan.md
+++ b/docs/follow-up-plan.md
@@ -59,3 +59,14 @@ This roadmap tracks post-foundation work for `ailib`.
   - upstream `ailib` upgrades do not wipe consumer-local customizations.
 
 Model draft and schema reference: [docs/local-override-model.md](local-override-model.md), [schema/override.schema.json](../schema/override.schema.json).
+
+## Phase 7: End-to-end standards and quality uplift
+
+- Run a full repository review to enforce development standards end to end.
+- Close remaining standardization gaps in implementation, tests, and docs alignment.
+- Strengthen formatting and static checks with linting and Prettier coverage across maintained files.
+- Push toward maximal practical coverage (target 100% where feasible), including:
+  - explicit uncovered-area audit
+  - prioritized remediation plan for non-trivial paths
+  - documented exceptions when 100% is not realistically achievable
+- Identify and fix missing validations, quality risks, and latent errors found during review.


### PR DESCRIPTION
## Summary
- Add Phase 7 to the follow-up plan for full standards and quality uplift.
- Scope Phase 7 to standards remediation, lint/prettier enforcement, coverage uplift, and error-gap review.
- Document the 100% coverage intent with explicit exception handling.

## Test plan
- [x] Run `bun run check`

Refs #69

Made with [Cursor](https://cursor.com)