### PR TITLE
refactor: tighten typing in doctor and tests

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -400,8 +400,8 @@ async function doctorCommand({ cwd, packageRoot, flags }: CommandContext) {
     workspaceOverride: getStringFlag(flags, 'workspace')
   });
 
-  const errors = [];
-  const warnings = [];
+  const errors: string[] = [];
+  const warnings: string[] = [];
   try {
     await assertLocalOverridesValid({ rootDir: context.rootDir, rootConfig, registry });
   } catch (err) {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -33,18 +33,20 @@ async function exists(filePath: string) {
 
 async function captureStdout(fn: () => Promise<void>) {
   const writes: string[] = [];
-  const originalWrite = process.stdout.write.bind(process.stdout);
-  (process.stdout as any).write = (chunk: string | Uint8Array, encoding?: BufferEncoding, callback?: (err?: Error) => void) => {
+  const mutableStdout = process.stdout as unknown as { write: typeof process.stdout.write };
+  const originalWrite = mutableStdout.write.bind(process.stdout);
+  mutableStdout.write = ((chunk, encoding, callback) => {
     writes.push(typeof chunk === 'string' ? chunk : chunk.toString());
-    if (typeof callback === 'function') callback();
+    const done = typeof encoding === 'function' ? encoding : callback;
+    if (typeof done === 'function') done();
     return true;
-  };
+  }) as typeof process.stdout.write;
 
   try {
     await fn();
     return writes.join('');
   } finally {
-    (process.stdout as any).write = originalWrite;
+    mutableStdout.write = originalWrite;
   }
 }
 


### PR DESCRIPTION
## Summary
- Tighten types in `doctor` diagnostics to avoid implicit mutable-any patterns.
- Replace `as any` test stdout interception with typed write handling.
- Preserve existing behavior and verify with full quality gates.

## Test plan
- [x] Run `bun test test/cli.test.ts`
- [x] Run `bun run check`

Refs #70

Made with [Cursor](https://cursor.com)