### PR TITLE
refactor: reduce any usage in tests and tools

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1052,7 +1052,7 @@ function validateListOverrideScope({
   return errors;
 }
 
-function isRecord(value: unknown): value is Record<string, any> {
+function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 

--- a/test/registry-governance.test.ts
+++ b/test/registry-governance.test.ts
@@ -8,21 +8,53 @@ const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname)
 const registryPath = path.join(packageRoot, 'registry.json');
 const slotNamePattern = /^[a-z]+(?:_[a-z]+)*$/u;
 
-async function loadRegistry(): Promise<any> {
+type FrontmatterValue = string | string[];
+type Frontmatter = Record<string, FrontmatterValue>;
+
+interface ModuleDef {
+  slot: string;
+  requires?: string[];
+  conflicts_with?: string[];
+}
+
+interface LanguageDef {
+  modules?: Record<string, ModuleDef>;
+}
+
+interface SlotDef {
+  kind: 'exclusive' | 'composable';
+  description: string;
+}
+
+interface AliasMeta {
+  replacement: string;
+  deprecated_since: string;
+  remove_in: string;
+}
+
+interface Registry {
+  slots?: string[];
+  slot_defs?: Record<string, SlotDef>;
+  slot_aliases?: Record<string, string>;
+  slot_alias_meta?: Record<string, AliasMeta>;
+  languages?: Record<string, LanguageDef>;
+}
+
+async function loadRegistry(): Promise<Registry> {
   return JSON.parse(await fs.readFile(registryPath, 'utf8'));
 }
 
-function parseFrontmatter(markdown: string): any {
+function parseFrontmatter(markdown: string): Frontmatter | null {
   const match = markdown.match(/^---\n([\s\S]*?)\n---\n/u);
   if (!match) return null;
-  const fields = {};
+  const fields: Frontmatter = {};
   for (const line of match[1].split('\n')) {
     const trimmed = line.trim();
     if (!trimmed || trimmed.startsWith('#')) continue;
     const idx = line.indexOf(':');
     if (idx < 0) continue;
     const key = line.slice(0, idx).trim();
-    let value: any = line.slice(idx + 1).trim();
+    let value: FrontmatterValue = line.slice(idx + 1).trim();
     if (value.startsWith('[') && value.endsWith(']')) {
       value = value
         .slice(1, -1)
@@ -56,7 +88,7 @@ test('registry slots follow naming and coverage rules', async () => {
     'slot_defs keys must match slots exactly'
   );
 
-  for (const [slot, def] of Object.entries(slotDefs as Record<string, any>)) {
+  for (const [slot, def] of Object.entries(slotDefs)) {
     assert.equal(typeof def.description, 'string', `slot_defs.${slot}.description must be string`);
     assert.ok(def.description.trim().length > 0, `slot_defs.${slot}.description must not be empty`);
     assert.ok(
@@ -76,7 +108,7 @@ test('registry slots follow naming and coverage rules', async () => {
     'slot_alias_meta keys must match slot_aliases keys'
   );
 
-  for (const [alias, meta] of Object.entries(aliasMeta as Record<string, any>)) {
+  for (const [alias, meta] of Object.entries(aliasMeta)) {
     assert.equal(
       meta.replacement,
       slotAliases[alias],
@@ -98,7 +130,7 @@ test('registry modules use canonical slots and docs match', async () => {
   const aliases = registry.slot_aliases || {};
   const usedSlots = new Set<string>();
 
-  for (const [languageId, languageDef] of Object.entries(registry.languages || {}) as Array<[string, any]>) {
+  for (const [languageId, languageDef] of Object.entries(registry.languages || {})) {
     const moduleDir = path.join(packageRoot, 'languages', languageId, 'modules');
     const docModuleIds = await fs.readdir(moduleDir, { withFileTypes: true })
       .then((entries) => entries
@@ -115,7 +147,7 @@ test('registry modules use canonical slots and docs match', async () => {
       `Registry/docs module mismatch for language '${languageId}'`
     );
 
-    for (const [moduleId, moduleDef] of Object.entries(languageDef.modules || {}) as Array<[string, any]>) {
+    for (const [moduleId, moduleDef] of Object.entries(languageDef.modules || {})) {
       const rawSlot = moduleDef.slot;
       assert.ok(rawSlot, `Missing slot for module '${languageId}:${moduleId}'`);
       const canonical = aliases[rawSlot] || rawSlot;
@@ -168,10 +200,10 @@ test('registry modules use canonical slots and docs match', async () => {
 test('registry module relationships and frontmatter metadata are valid', async () => {
   const registry = await loadRegistry();
 
-  for (const [languageId, languageDef] of Object.entries(registry.languages || {}) as Array<[string, any]>) {
+  for (const [languageId, languageDef] of Object.entries(registry.languages || {})) {
     const moduleIds = new Set(Object.keys(languageDef.modules || {}));
 
-    for (const [moduleId, moduleDef] of Object.entries(languageDef.modules || {}) as Array<[string, any]>) {
+    for (const [moduleId, moduleDef] of Object.entries(languageDef.modules || {})) {
       const requires = moduleDef.requires || [];
       const conflicts = moduleDef.conflicts_with || [];
       const requiresSet = new Set(requires);
@@ -225,7 +257,7 @@ test('registry module relationships and frontmatter metadata are valid', async (
 });
 
 test('split registry and generated catalog are in sync', () => {
-  const run = (script, ...args) => execFileSync(
+  const run = (script: string, ...args: string[]) => execFileSync(
     process.execPath,
     [path.join(packageRoot, script), ...args],
     { stdio: 'pipe', encoding: 'utf8' }

--- a/tools/generate-coverage-audit.ts
+++ b/tools/generate-coverage-audit.ts
@@ -37,8 +37,22 @@ type CoverageReport = {
   slotUsage: Map<string, string[]>;
 };
 
-async function readJson(filePath: string): Promise<any> {
-  return JSON.parse(await fs.readFile(filePath, 'utf8'));
+interface ModuleDef {
+  slot: string;
+}
+
+interface LanguageDef {
+  display: string;
+  modules?: Record<string, ModuleDef>;
+}
+
+interface Registry {
+  slots?: string[];
+  languages?: Record<string, LanguageDef>;
+}
+
+async function readJson<T>(filePath: string): Promise<T> {
+  return JSON.parse(await fs.readFile(filePath, 'utf8')) as T;
 }
 
 function parseFrontmatter(markdown: string): Record<string, string> | null {
@@ -76,7 +90,7 @@ async function collectDocModuleInfo(languageId: string): Promise<DocModuleInfo[]
   return modules;
 }
 
-async function buildAudit(registry: any): Promise<CoverageReport> {
+async function buildAudit(registry: Registry): Promise<CoverageReport> {
   const report: CoverageReport = {
     byLanguage: [],
     global: {
@@ -88,9 +102,9 @@ async function buildAudit(registry: any): Promise<CoverageReport> {
 
   for (const slot of registry.slots || []) report.slotUsage.set(slot, []);
 
-  for (const [languageId, languageDef] of Object.entries(registry.languages || {}) as Array<[string, any]>) {
+  for (const [languageId, languageDef] of Object.entries(registry.languages || {})) {
     const registryModules: RegistryModuleInfo[] = Object.entries(languageDef.modules || {}).map(
-      ([moduleId, moduleDef]: [string, any]) => ({
+      ([moduleId, moduleDef]) => ({
         moduleId,
         slot: moduleDef.slot
       })
@@ -139,7 +153,7 @@ async function buildAudit(registry: any): Promise<CoverageReport> {
   return report;
 }
 
-function renderReport(registry: any, report: CoverageReport): string {
+function renderReport(registry: Registry, report: CoverageReport): string {
   const lines: string[] = [];
   lines.push('# Module/Slot Coverage Audit');
   lines.push('');
@@ -192,7 +206,7 @@ function renderReport(registry: any, report: CoverageReport): string {
 }
 
 async function run(): Promise<void> {
-  const registry = await readJson(registryPath);
+  const registry = await readJson<Registry>(registryPath);
   const report = await buildAudit(registry);
   const nextText = renderReport(registry, report);
 

--- a/tools/generate-module-catalog.ts
+++ b/tools/generate-module-catalog.ts
@@ -7,11 +7,34 @@ const registryPath = path.join(packageRoot, 'registry.json');
 const outputPath = path.join(packageRoot, 'docs', 'module-catalog.md');
 const checkOnly = process.argv.includes('--check');
 
-async function readJson(filePath: string): Promise<any> {
-  return JSON.parse(await fs.readFile(filePath, 'utf8'));
+interface SlotDef {
+  kind?: 'exclusive' | 'composable' | string;
+  description?: string;
 }
 
-function renderCatalog(registry: any): string {
+interface ModuleDef {
+  slot: string;
+  requires?: string[];
+  conflicts_with?: string[];
+}
+
+interface LanguageDef {
+  display: string;
+  path: string;
+  modules?: Record<string, ModuleDef>;
+}
+
+interface Registry {
+  slots?: string[];
+  slot_defs?: Record<string, SlotDef>;
+  languages?: Record<string, LanguageDef>;
+}
+
+async function readJson<T>(filePath: string): Promise<T> {
+  return JSON.parse(await fs.readFile(filePath, 'utf8')) as T;
+}
+
+function renderCatalog(registry: Registry): string {
   const lines: string[] = [];
   lines.push('# Module Catalog');
   lines.push('');
@@ -32,15 +55,15 @@ function renderCatalog(registry: any): string {
   lines.push('## Language Modules');
   lines.push('');
 
-  for (const [languageId, languageDef] of Object.entries(registry.languages || {}) as Array<[string, any]>) {
+  for (const [languageId, languageDef] of Object.entries(registry.languages || {})) {
     lines.push(`### ${languageDef.display} (\`${languageId}\`)`);
     lines.push('');
     lines.push(`Core: \`${languageDef.path}\``);
     lines.push('');
 
-    const modulesBySlot = new Map<string, Array<[string, any]>>();
+    const modulesBySlot = new Map<string, Array<[string, ModuleDef]>>();
     for (const slot of registry.slots || []) modulesBySlot.set(slot, []);
-    for (const [moduleId, moduleDef] of Object.entries(languageDef.modules || {}) as Array<[string, any]>) {
+    for (const [moduleId, moduleDef] of Object.entries(languageDef.modules || {})) {
       const slot = moduleDef.slot;
       if (!modulesBySlot.has(slot)) modulesBySlot.set(slot, []);
       modulesBySlot.get(slot)?.push([moduleId, moduleDef]);
@@ -70,7 +93,7 @@ function renderCatalog(registry: any): string {
 }
 
 async function run(): Promise<void> {
-  const registry = await readJson(registryPath);
+  const registry = await readJson<Registry>(registryPath);
   const nextText = renderCatalog(registry);
 
   if (checkOnly) {

--- a/tools/sync-registry.ts
+++ b/tools/sync-registry.ts
@@ -10,8 +10,10 @@ const outputPath = path.join(packageRoot, 'registry.json');
 
 const checkOnly = process.argv.includes('--check');
 
-async function readJson(filePath: string): Promise<any> {
-  return JSON.parse(await fs.readFile(filePath, 'utf8'));
+type JsonObject = Record<string, unknown>;
+
+async function readJson<T>(filePath: string): Promise<T> {
+  return JSON.parse(await fs.readFile(filePath, 'utf8')) as T;
 }
 
 async function listLanguageFiles(): Promise<string[]> {
@@ -22,22 +24,22 @@ async function listLanguageFiles(): Promise<string[]> {
     .sort();
 }
 
-async function buildRegistry(): Promise<any> {
-  const core = await readJson(corePath);
+async function buildRegistry(): Promise<JsonObject & { languages: Record<string, JsonObject> }> {
+  const core = await readJson<JsonObject>(corePath);
   if ('languages' in core) {
     throw new Error('registry/core.json must not contain a top-level `languages` key');
   }
 
-  const languages: Record<string, any> = {};
+  const languages: Record<string, JsonObject> = {};
   for (const file of await listLanguageFiles()) {
     const languageId = file.replace(/\.json$/u, '');
-    languages[languageId] = await readJson(path.join(languageDir, file));
+    languages[languageId] = await readJson<JsonObject>(path.join(languageDir, file));
   }
 
   return { ...core, languages };
 }
 
-function toJsonText(value: any): string {
+function toJsonText(value: unknown): string {
   return `${JSON.stringify(value, null, 2)}\n`;
 }
 


### PR DESCRIPTION
## Summary
- Reduce `any` usage across governance tests and tooling scripts with explicit interfaces.
- Tighten JSON/frontmatter typing in registry-related validation and catalog/audit generators.
- Preserve behavior while improving maintainability and standards compliance.

## Test plan
- [x] Run `bun test test/registry-governance.test.ts`
- [x] Run `bun run typecheck`
- [x] Run `bun run check`

Refs #70

Made with [Cursor](https://cursor.com)