### PR TITLE
test: enforce no explicit any typing

### DIFF
--- a/docs/development-standards.md
+++ b/docs/development-standards.md
@@ -21,6 +21,7 @@ Expected loop:
 - Keep side effects isolated and visible at call sites.
 - Remove dead code during the same change where it becomes obsolete.
 - Avoid broad "catch-all" utilities when a narrow helper is clearer.
+- Avoid explicit `any` typing in `src/`, `tools/`, and `test/`; use explicit interfaces/type aliases instead.
 
 ## 3) SOLID Expectations (Practical)
 

--- a/test/standards-compliance.test.ts
+++ b/test/standards-compliance.test.ts
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const scanRoots = ['src', 'tools', 'test'];
+const explicitAnyPattern = /(?:\bas\s+any\b|:\s*any\b|<\s*any\s*>|Record<[^>\n]*,\s*any\s*>)/u;
+
+async function collectTypeScriptFiles(rootDir: string): Promise<string[]> {
+  const entries = await fs.readdir(rootDir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === 'coverage') continue;
+    const fullPath = path.join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await collectTypeScriptFiles(fullPath));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith('.ts')) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function findExplicitAnyLines(source: string): Array<{ line: number; text: string }> {
+  const lines = source.split('\n');
+  const matches: Array<{ line: number; text: string }> = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    if (explicitAnyPattern.test(lines[index])) {
+      matches.push({ line: index + 1, text: lines[index].trim() });
+    }
+  }
+  return matches;
+}
+
+test('no explicit any typing in src/tools/test TypeScript files', async () => {
+  const violations: string[] = [];
+  for (const relRoot of scanRoots) {
+    const absRoot = path.join(packageRoot, relRoot);
+    const files = await collectTypeScriptFiles(absRoot);
+    for (const filePath of files) {
+      const source = await fs.readFile(filePath, 'utf8');
+      const fileMatches = findExplicitAnyLines(source);
+      for (const match of fileMatches) {
+        const relPath = path.relative(packageRoot, filePath);
+        violations.push(`${relPath}:${match.line} ${match.text}`);
+      }
+    }
+  }
+
+  assert.deepEqual(
+    violations,
+    [],
+    `Explicit 'any' typing is not allowed:\n- ${violations.join('\n- ')}`
+  );
+});


### PR DESCRIPTION
## Summary
- Add a standards-compliance test that blocks explicit `any` typing in `src/`, `tools/`, and `test/` TypeScript files.
- Update development standards to explicitly require avoiding `any` in these maintained paths.
- Preserve existing behavior while adding a regression guardrail for standards drift.

## Test plan
- [x] Run `bun test test/standards-compliance.test.ts`
- [x] Run `bun run check`

Refs #70

Made with [Cursor](https://cursor.com)