### PR TITLE
style: enforce prettier checks repo-wide

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+coverage
+dist
+node_modules
+.cursor
+registry.json
+docs/module-catalog.md
+docs/module-coverage-audit.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "trailingComma": "none",
+  "printWidth": 120,
+  "proseWrap": "preserve"
+}

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ ailib uninstall
 ```
 
 For complete CLI and maintenance command coverage, see:
+
 - [docs/cli-usage-guide.md](docs/cli-usage-guide.md)
 
 ## Supported languages

--- a/ailib.config.json
+++ b/ailib.config.json
@@ -2,16 +2,7 @@
   "$schema": "https://ailib.dev/schema/config.schema.json",
   "registry_ref": "v1.0.0",
   "language": "typescript",
-  "modules": [
-    "eslint",
-    "prettier",
-    "vitest",
-    "serverless-framework",
-    "aws-lambda",
-    "esbuild",
-    "zod",
-    "pnpm"
-  ],
+  "modules": ["eslint", "prettier", "vitest", "serverless-framework", "aws-lambda", "esbuild", "zod", "pnpm"],
   "targets": ["claude-code", "cursor", "windsurf", "copilot", "openai", "gemini"],
   "docs_path": "docs/",
   "on_conflict": "merge"

--- a/bun.lock
+++ b/bun.lock
@@ -5,12 +5,15 @@
       "name": "@ailib/cli",
       "devDependencies": {
         "@types/node": "^25.6.0",
+        "prettier": "^3.8.3",
         "typescript": "^6.0.3",
       },
     },
   },
   "packages": {
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 

--- a/docs/cli-usage-guide.md
+++ b/docs/cli-usage-guide.md
@@ -124,19 +124,19 @@ ailib modules explain prisma --language=typescript
 
 Use `ailib.local.json` to customize local targets/modules/slots without changing managed `ailib.config.json`.
 
-1) Define overrides at root:
+1. Define overrides at root:
 
 ```bash
 touch ailib.local.json
 ```
 
-2) Apply updates:
+2. Apply updates:
 
 ```bash
 ailib update
 ```
 
-3) Verify local override integrity:
+3. Verify local override integrity:
 
 ```bash
 ailib doctor

--- a/docs/development-standards.md
+++ b/docs/development-standards.md
@@ -10,6 +10,7 @@ This guide defines the minimum implementation standards for `ailib` changes.
 - Keep tests deterministic and local to the changed behavior.
 
 Expected loop:
+
 1. Red: write/adjust tests and confirm failure.
 2. Green: implement minimal code to pass.
 3. Refactor: improve readability/structure without changing behavior.
@@ -40,6 +41,7 @@ Expected loop:
 
 ## 5) Quality Gates for PRs
 
+- `bun run lint` (includes standards + Prettier checks) must pass.
 - `bun run typecheck` must pass.
 - `bun run check` must pass.
 - New behavior should include/adjust tests.
@@ -48,6 +50,7 @@ Expected loop:
 ## 6) Definition of Done
 
 A change is done when:
+
 - implementation follows this guide,
 - relevant tests are in place and passing,
 - required docs are updated,

--- a/docs/test-standards.md
+++ b/docs/test-standards.md
@@ -18,6 +18,7 @@ Coverage targets are minimums for changed code paths:
 - **Critical command flows (`init/update/doctor/uninstall`):** 90% path coverage via integration tests
 
 Notes:
+
 - Thresholds are quality gates, not a substitute for meaningful assertions.
 - Do not inflate coverage with low-value tests.
 
@@ -43,6 +44,7 @@ Notes:
 ## 6) Definition of Done
 
 A test-related change is done when:
+
 - required test types are addressed,
 - coverage targets are respected for changed areas,
 - and checks pass in CI/local validation flow.

--- a/languages/typescript/modules/aws-lambda.md
+++ b/languages/typescript/modules/aws-lambda.md
@@ -21,7 +21,7 @@ All runtime code for Lambda follows these rules, regardless of deployment tool.
 Handlers are default exports named `handler`:
 
 ```ts
-import type { APIGatewayProxyHandlerV2 } from "aws-lambda";
+import type { APIGatewayProxyHandlerV2 } from 'aws-lambda';
 
 export const handler: APIGatewayProxyHandlerV2 = async (event) => {
   // …

--- a/languages/typescript/modules/zod.md
+++ b/languages/typescript/modules/zod.md
@@ -33,9 +33,9 @@ const RequestSchema = z.object({
 });
 
 export const handler: APIGatewayProxyHandlerV2 = async (event) => {
-  const parsed = RequestSchema.safeParse(JSON.parse(event.body ?? "{}"));
+  const parsed = RequestSchema.safeParse(JSON.parse(event.body ?? '{}'));
   if (!parsed.success) {
-    return badRequest("INVALID_INPUT", parsed.error.flatten());
+    return badRequest('INVALID_INPUT', parsed.error.flatten());
   }
   // …domain call…
   return ok(ResponseSchema.parse(result));
@@ -57,7 +57,7 @@ A shared helper converts `ZodError` to the standard error envelope:
 function badRequest(code: string, details: unknown) {
   return {
     statusCode: 400,
-    body: JSON.stringify({ error: { code, message: "Invalid input", details } })
+    body: JSON.stringify({ error: { code, message: 'Invalid input', details } })
   };
 }
 ```

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "release:build": "bash scripts/build-release-artifacts.sh",
     "local:install": "bash scripts/install-local.sh",
     "security:audit": "bun audit --audit-level=high",
-    "lint": "bun tools/check-standards.ts",
+    "format:check": "prettier --check \"**/*.{ts,js,json,md,yml,yaml}\" --ignore-unknown",
+    "format:write": "prettier --write \"**/*.{ts,js,json,md,yml,yaml}\" --ignore-unknown",
+    "lint": "bun tools/check-standards.ts && bun run format:check",
     "tools:build": "bunx tsc -p tsconfig.tools.json",
     "registry:build": "bun tools/sync-registry.ts",
     "registry:check": "bun tools/sync-registry.ts --check",
@@ -50,6 +52,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.0",
+    "prettier": "^3.8.3",
     "typescript": "^6.0.3"
   }
 }

--- a/registry/languages/typescript.json
+++ b/registry/languages/typescript.json
@@ -9,7 +9,10 @@
     "pnpm": { "slot": "package_manager", "conflicts_with": ["npm", "yarn", "bun"] },
     "vitest": { "slot": "test_runner", "conflicts_with": ["jest"] },
     "tailwind": { "slot": "styling_system" },
-    "nestjs": { "slot": "backend_framework", "conflicts_with": ["express-framework", "koa-framework", "hapi-framework"] },
+    "nestjs": {
+      "slot": "backend_framework",
+      "conflicts_with": ["express-framework", "koa-framework", "hapi-framework"]
+    },
     "fastify": { "slot": "http_adapter", "conflicts_with": ["express", "koa", "hapi"] },
     "graphql": { "slot": "api_protocol", "conflicts_with": [] },
     "apollo-server": { "slot": "graphql_server", "requires": ["graphql"], "conflicts_with": ["mercurius"] },
@@ -22,8 +25,16 @@
     "joi": { "slot": "config_validation", "conflicts_with": [] },
     "nestjs-swagger": { "slot": "api_docs", "requires": ["nestjs"], "conflicts_with": [] },
     "react": { "slot": "ui_library", "conflicts_with": ["preact", "solid", "vue"] },
-    "nextjs": { "slot": "frontend_framework", "requires": ["react"], "conflicts_with": ["remix", "astro", "sveltekit", "nuxt"] },
-    "serverless-framework": { "slot": "infra_framework", "requires": ["aws-lambda"], "conflicts_with": ["sst", "cdk", "sam"] },
+    "nextjs": {
+      "slot": "frontend_framework",
+      "requires": ["react"],
+      "conflicts_with": ["remix", "astro", "sveltekit", "nuxt"]
+    },
+    "serverless-framework": {
+      "slot": "infra_framework",
+      "requires": ["aws-lambda"],
+      "conflicts_with": ["sst", "cdk", "sam"]
+    },
     "aws-lambda": { "slot": "runtime_platform", "conflicts_with": ["cloudflare-workers", "vercel-functions"] },
     "aws-amplify": { "slot": "cloud_platform", "conflicts_with": ["firebase", "supabase"] },
     "stripe": { "slot": "payments_provider" },

--- a/schema/module.schema.json
+++ b/schema/module.schema.json
@@ -16,8 +16,5 @@
     "tested_with": { "type": "array", "items": { "type": "string" } },
     "deprecated": { "type": ["boolean", "string"] }
   },
-  "anyOf": [
-    { "required": ["language"] },
-    { "required": ["core"] }
-  ]
+  "anyOf": [{ "required": ["language"] }, { "required": ["core"] }]
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -167,15 +167,15 @@ export async function run(argv: string[], options: RunOptions = {}) {
 function printHelp() {
   process.stdout.write(
     'ailib commands:\n' +
-    '  ailib init [--language=<lang>] [--targets=a,b] [--modules=m1,m2] [--workspaces=a/*,b/*] [--bare] [--no-inherit] [--on-conflict=overwrite|merge|skip|abort]\n' +
-    '  ailib update [--workspace=<path>]\n' +
-    '  ailib add <module> [--workspace=<path>]\n' +
-    '  ailib remove <module> [--workspace=<path>]\n' +
-    '  ailib doctor [--workspace=<path>]\n' +
-    '  ailib uninstall [--all]\n' +
-    '  ailib slots list\n' +
-    '  ailib modules list [--language=<lang>]\n' +
-    '  ailib modules explain <module> [--language=<lang>]\n'
+      '  ailib init [--language=<lang>] [--targets=a,b] [--modules=m1,m2] [--workspaces=a/*,b/*] [--bare] [--no-inherit] [--on-conflict=overwrite|merge|skip|abort]\n' +
+      '  ailib update [--workspace=<path>]\n' +
+      '  ailib add <module> [--workspace=<path>]\n' +
+      '  ailib remove <module> [--workspace=<path>]\n' +
+      '  ailib doctor [--workspace=<path>]\n' +
+      '  ailib uninstall [--all]\n' +
+      '  ailib slots list\n' +
+      '  ailib modules list [--language=<lang>]\n' +
+      '  ailib modules explain <module> [--language=<lang>]\n'
   );
 }
 
@@ -302,7 +302,12 @@ async function initCommand({ cwd, packageRoot, flags }: CommandContext) {
     if (targets.length) config.targets = targets;
 
     await fs.writeFile(path.join(projectRoot, CONFIG_FILE), `${JSON.stringify(config, null, 2)}\n`, 'utf8');
-    await applyWorkspaceUpdate({ packageRoot, rootDir: nearestRoot, workspaceOverride: projectRoot, forceOnConflict: onConflict });
+    await applyWorkspaceUpdate({
+      packageRoot,
+      rootDir: nearestRoot,
+      workspaceOverride: projectRoot,
+      forceOnConflict: onConflict
+    });
     process.stdout.write('ailib initialized\n');
     return;
   }
@@ -332,7 +337,12 @@ async function updateCommand({ cwd, packageRoot, flags }: CommandContext) {
   const context = await resolveContext(cwd);
   const workspaceFlag = getStringFlag(flags, 'workspace');
   const workspaceOverride = workspaceFlag ? resolveWorkspacePath(context.rootDir, workspaceFlag) : undefined;
-  await applyWorkspaceUpdate({ packageRoot, rootDir: context.rootDir, workspaceOverride, forceOnConflict: 'overwrite' });
+  await applyWorkspaceUpdate({
+    packageRoot,
+    rootDir: context.rootDir,
+    workspaceOverride,
+    forceOnConflict: 'overwrite'
+  });
   process.stdout.write('ailib updated\n');
 }
 
@@ -352,7 +362,11 @@ async function addCommand({ cwd, packageRoot, flags, moduleId }: CommandContext 
     rootConfig: await readJson<WorkspaceConfig>(path.join(context.rootDir, CONFIG_FILE)),
     registry
   });
-  validateModuleSelection({ registry, language: effective.language, modules: uniqueList([...(config.modules || []), moduleId]) });
+  validateModuleSelection({
+    registry,
+    language: effective.language,
+    modules: uniqueList([...(config.modules || []), moduleId])
+  });
 
   config.modules = uniqueList([...(config.modules || []), moduleId]);
   await fs.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
@@ -414,7 +428,12 @@ async function doctorCommand({ cwd, packageRoot, flags }: CommandContext) {
     return;
   }
 
-  const rootEffective = await getEffectiveWorkspaceConfig({ workspaceDir: context.rootDir, rootDir: context.rootDir, rootConfig, registry });
+  const rootEffective = await getEffectiveWorkspaceConfig({
+    workspaceDir: context.rootDir,
+    rootDir: context.rootDir,
+    rootConfig,
+    registry
+  });
   for (const workspaceDir of workspaceDirs) {
     const workspaceLabel = workspaceLabelFor(context.rootDir, workspaceDir);
     const configPath = path.join(workspaceDir, CONFIG_FILE);
@@ -526,7 +545,8 @@ async function uninstallWorkspace(workspaceDir: string, config: WorkspaceConfig 
       const targetDef = registry.targets[target];
       if (!targetDef) continue;
       await rmIfExists(path.join(workspaceDir, targetDef.output));
-      if (targetDef.root_output && isRootWorkspaceConfig(config)) await rmIfExists(path.join(workspaceDir, targetDef.root_output));
+      if (targetDef.root_output && isRootWorkspaceConfig(config))
+        await rmIfExists(path.join(workspaceDir, targetDef.root_output));
       if (target === 'copilot' && isRootWorkspaceConfig(config)) {
         await rmIfExists(path.join(workspaceDir, '.github/instructions'));
       }
@@ -534,10 +554,17 @@ async function uninstallWorkspace(workspaceDir: string, config: WorkspaceConfig 
   }
 }
 
-async function applyWorkspaceUpdate(
-  { packageRoot, rootDir, workspaceOverride, forceOnConflict }:
-  { packageRoot: string; rootDir: string; workspaceOverride?: string; forceOnConflict?: string }
-) {
+async function applyWorkspaceUpdate({
+  packageRoot,
+  rootDir,
+  workspaceOverride,
+  forceOnConflict
+}: {
+  packageRoot: string;
+  rootDir: string;
+  workspaceOverride?: string;
+  forceOnConflict?: string;
+}) {
   const rootConfigPath = path.join(rootDir, CONFIG_FILE);
   ensure(await exists(rootConfigPath), `Missing ${CONFIG_FILE} at root: ${rootDir}`);
 
@@ -565,10 +592,26 @@ async function applyWorkspaceUpdate(
     await generateWorkspaceRouters({ workspaceDir, rootDir, state, onConflict, allStates: stateMap, registry });
   }
 
-  await writeRootLock({ rootDir, packageRoot, packageVersion: packageJson.version, registryRef: rootConfig.registry_ref || registry.version, allStates: stateMap });
+  await writeRootLock({
+    rootDir,
+    packageRoot,
+    packageVersion: packageJson.version,
+    registryRef: rootConfig.registry_ref || registry.version,
+    allStates: stateMap
+  });
 }
 
-async function ensureWorkspaceAssets({ workspaceDir, packageRoot, state, rootDir }: { workspaceDir: string; packageRoot: string; state: WorkspaceState; rootDir: string }) {
+async function ensureWorkspaceAssets({
+  workspaceDir,
+  packageRoot,
+  state,
+  rootDir
+}: {
+  workspaceDir: string;
+  packageRoot: string;
+  state: WorkspaceState;
+  rootDir: string;
+}) {
   const outRoot = path.join(workspaceDir, '.ailib');
   await fs.mkdir(path.join(outRoot, 'modules'), { recursive: true });
 
@@ -643,7 +686,9 @@ async function generateWorkspaceRouters({
 
     const label = targetDef.display || targetId;
     const frontmatter = targetDef.frontmatter
-      ? (atRoot ? targetDef.frontmatter.root : targetDef.frontmatter.workspace)
+      ? atRoot
+        ? targetDef.frontmatter.root
+        : targetDef.frontmatter.workspace
       : '';
     const rendered = `${frontmatter || ''}${renderRouterDoc({ label, workspaceDir, rootDir, state })}`;
     await writeManagedFile({ outPath: path.join(workspaceDir, targetDef.output), rendered, onConflict });
@@ -673,16 +718,31 @@ async function generateWorkspaceRouters({
       const applyTo = rel === '.' ? '**' : `${toPosix(rel)}/**`;
       const fileName = rel === '.' ? 'root.instructions.md' : `${sanitizeForFilename(rel)}.instructions.md`;
       const content = `---\napplyTo: "${applyTo}"\n---\n\n${renderRouterDoc({ label: registry.targets.copilot?.display || 'GitHub Copilot', workspaceDir: dir, rootDir, state: s })}`;
-      await writeManagedFile({ outPath: path.join(rootDir, '.github/instructions', fileName), rendered: content, onConflict });
+      await writeManagedFile({
+        outPath: path.join(rootDir, '.github/instructions', fileName),
+        rendered: content,
+        onConflict
+      });
     }
   }
 }
 
-function renderRouterDoc({ label, workspaceDir, rootDir, state }: { label: string; workspaceDir: string; rootDir: string; state: WorkspaceState }) {
+function renderRouterDoc({
+  label,
+  workspaceDir,
+  rootDir,
+  state
+}: {
+  label: string;
+  workspaceDir: string;
+  rootDir: string;
+  state: WorkspaceState;
+}) {
   const relToRoot = relativePathForPointers(workspaceDir, rootDir);
-  const behaviorRef = path.resolve(workspaceDir) === path.resolve(rootDir)
-    ? '@.ailib/behavior.md'
-    : `@${toPosix(path.join(relToRoot, '.ailib/behavior.md'))}`;
+  const behaviorRef =
+    path.resolve(workspaceDir) === path.resolve(rootDir)
+      ? '@.ailib/behavior.md'
+      : `@${toPosix(path.join(relToRoot, '.ailib/behavior.md'))}`;
 
   const inheritedModuleLines = state.inheritedModules.map((mod) => {
     const modPath = `@${toPosix(path.join(relToRoot, '.ailib/modules', `${mod}.md`))}`;
@@ -691,15 +751,26 @@ function renderRouterDoc({ label, workspaceDir, rootDir, state }: { label: strin
 
   const localModuleLines = state.localModules.map((mod) => `- @.ailib/modules/${mod}.md`);
   const moduleLines = [...inheritedModuleLines, ...localModuleLines];
-  const docsBlock = path.resolve(workspaceDir) === path.resolve(rootDir)
-    ? '# PROJECT-SPECIFIC CONTEXT\nPrioritize project context in @./docs/.\n'
-    : `# PROJECT-SPECIFIC CONTEXT\nPrioritize service-local business logic in @./docs/.\nFor cross-service context, consult @${toPosix(path.join(relToRoot, 'docs/'))}.\nIf guidance conflicts, service-local docs win for service-scoped work.\n`;
+  const docsBlock =
+    path.resolve(workspaceDir) === path.resolve(rootDir)
+      ? '# PROJECT-SPECIFIC CONTEXT\nPrioritize project context in @./docs/.\n'
+      : `# PROJECT-SPECIFIC CONTEXT\nPrioritize service-local business logic in @./docs/.\nFor cross-service context, consult @${toPosix(path.join(relToRoot, 'docs/'))}.\nIf guidance conflicts, service-local docs win for service-scoped work.\n`;
 
   const modulesText = moduleLines.length ? moduleLines.join('\n') : '- (none)';
   return `# ailib Router (${label})\n\n# AILIB SYSTEM PROMPT\nAct as the AI Agent defined in ${behaviorRef}.\nAdhere to the coding standards in @.ailib/standards.md.\nApply development workflow rules in @.ailib/development-standards.md.\nApply test and coverage rules in @.ailib/test-standards.md.\n\n# MODULES & EXTENSIONS\n${modulesText}\n\n${docsBlock}`;
 }
 
-async function buildWorkspaceState({ workspaceDir, rootDir, rootConfig, registry }: { workspaceDir: string; rootDir: string; rootConfig: WorkspaceConfig; registry: Registry }): Promise<WorkspaceState> {
+async function buildWorkspaceState({
+  workspaceDir,
+  rootDir,
+  rootConfig,
+  registry
+}: {
+  workspaceDir: string;
+  rootDir: string;
+  rootConfig: WorkspaceConfig;
+  registry: Registry;
+}): Promise<WorkspaceState> {
   const effective = await getEffectiveWorkspaceConfig({ workspaceDir, rootDir, rootConfig, registry });
   validateModuleSelection({ registry, language: effective.language, modules: effective.modules });
 
@@ -742,8 +813,8 @@ async function getEffectiveWorkspaceConfig({
   const mergedModules = mergeModules({
     registry,
     language,
-    parentModules: isRootWorkspace ? [] : (base.modules || []),
-    localModules: workspaceRaw.modules || (isRootWorkspace ? (base.modules || []) : [])
+    parentModules: isRootWorkspace ? [] : base.modules || [],
+    localModules: workspaceRaw.modules || (isRootWorkspace ? base.modules || [] : [])
   });
 
   const targets = mergeTargets({
@@ -802,13 +873,9 @@ async function applyLocalOverrides({
     return { modules, targets, warnings };
   }
 
-  const workspaceKey = path.resolve(workspaceDir) === path.resolve(rootDir)
-    ? '.'
-    : toPosix(path.relative(rootDir, workspaceDir));
-  const override = mergeWorkspaceOverrides(
-    config.default_override,
-    (config.workspace_overrides || {})[workspaceKey]
-  );
+  const workspaceKey =
+    path.resolve(workspaceDir) === path.resolve(rootDir) ? '.' : toPosix(path.relative(rootDir, workspaceDir));
+  const override = mergeWorkspaceOverrides(config.default_override, (config.workspace_overrides || {})[workspaceKey]);
 
   const validTargets = new Set(Object.keys(registry.targets || {}));
   const validModules = new Set(Object.keys(registry.languages[language]?.modules || {}));
@@ -901,16 +968,21 @@ async function validateLocalOverrideConfig({
   }
 
   const workspaceDirs = await listWorkspaceDirs({ rootDir, rootConfig });
-  const workspaceKeys = new Set(['.', ...workspaceDirs
-    .filter((workspaceDir) => path.resolve(workspaceDir) !== path.resolve(rootDir))
-    .map((workspaceDir) => toPosix(path.relative(rootDir, workspaceDir)))]);
+  const workspaceKeys = new Set([
+    '.',
+    ...workspaceDirs
+      .filter((workspaceDir) => path.resolve(workspaceDir) !== path.resolve(rootDir))
+      .map((workspaceDir) => toPosix(path.relative(rootDir, workspaceDir)))
+  ]);
 
   if (config.default_override !== undefined) {
-    errors.push(...validateWorkspaceOverride({
-      override: config.default_override,
-      label: 'default_override',
-      registry
-    }));
+    errors.push(
+      ...validateWorkspaceOverride({
+        override: config.default_override,
+        label: 'default_override',
+        registry
+      })
+    );
   }
 
   if (config.workspace_overrides !== undefined) {
@@ -925,11 +997,13 @@ async function validateLocalOverrideConfig({
         if (!workspaceKeys.has(workspaceKey)) {
           errors.push(`unknown workspace override key '${workspaceKey}'`);
         }
-        errors.push(...validateWorkspaceOverride({
-          override,
-          label: `workspace_overrides.${workspaceKey}`,
-          registry
-        }));
+        errors.push(
+          ...validateWorkspaceOverride({
+            override,
+            label: `workspace_overrides.${workspaceKey}`,
+            registry
+          })
+        );
       }
     }
   }
@@ -959,20 +1033,24 @@ function validateWorkspaceOverride({
   }
 
   if (override.targets !== undefined) {
-    errors.push(...validateListOverrideScope({
-      scope: override.targets,
-      label: `${label}.targets`,
-      validSet: new Set(Object.keys(registry.targets || {})),
-      valueLabel: 'target'
-    }));
+    errors.push(
+      ...validateListOverrideScope({
+        scope: override.targets,
+        label: `${label}.targets`,
+        validSet: new Set(Object.keys(registry.targets || {})),
+        valueLabel: 'target'
+      })
+    );
   }
 
   if (override.modules !== undefined) {
-    errors.push(...validateListOverrideScope({
-      scope: override.modules,
-      label: `${label}.modules`,
-      valueLabel: 'module'
-    }));
+    errors.push(
+      ...validateListOverrideScope({
+        scope: override.modules,
+        label: `${label}.modules`,
+        valueLabel: 'module'
+      })
+    );
   }
 
   if (override.slots !== undefined) {
@@ -1068,15 +1146,7 @@ async function assertLocalOverridesValid({
   await loadLocalOverrideConfig({ rootDir, rootConfig, registry });
 }
 
-function ensureValidItems({
-  list,
-  validSet,
-  label
-}: {
-  list: string[];
-  validSet: Set<string>;
-  label: string;
-}) {
+function ensureValidItems({ list, validSet, label }: { list: string[]; validSet: Set<string>; label: string }) {
   const invalid = list.filter((value) => !validSet.has(value));
   if (invalid.length) {
     throw new Error(`Invalid ${LOCAL_OVERRIDE_FILE}: ${label} contains unknown value(s): ${invalid.join(', ')}`);
@@ -1226,7 +1296,11 @@ async function resolveExtendsBase({
   return normalizeRootConfig(rootConfig, registry);
 }
 
-async function resolveConfigByExtends(workspaceDir: string, extendsValue: string, seen: Set<string>): Promise<WorkspaceConfig> {
+async function resolveConfigByExtends(
+  workspaceDir: string,
+  extendsValue: string,
+  seen: Set<string>
+): Promise<WorkspaceConfig> {
   const targetPath = extendsValue.endsWith('.json')
     ? path.resolve(workspaceDir, extendsValue)
     : path.join(path.resolve(workspaceDir, extendsValue), CONFIG_FILE);
@@ -1328,7 +1402,15 @@ function mergeModules({
   };
 }
 
-function mergeTargets({ parentTargets, localTargets, targetsRemoved }: { parentTargets: string[]; localTargets: string[]; targetsRemoved: string[] }) {
+function mergeTargets({
+  parentTargets,
+  localTargets,
+  targetsRemoved
+}: {
+  parentTargets: string[];
+  localTargets: string[];
+  targetsRemoved: string[];
+}) {
   const parent = uniqueList(parentTargets || []);
   const removed = new Set(targetsRemoved || []);
   const local = uniqueList(localTargets || []);
@@ -1365,7 +1447,15 @@ function diffSlots(rootModules: string[], workspaceModules: string[], registry: 
   return diffs;
 }
 
-function validateModuleSelection({ registry, language, modules }: { registry: Registry; language: string; modules: string[] }) {
+function validateModuleSelection({
+  registry,
+  language,
+  modules
+}: {
+  registry: Registry;
+  language: string;
+  modules: string[];
+}) {
   const lang = registry.languages[language];
   ensure(lang, `Unsupported language: ${language}`);
 
@@ -1394,7 +1484,19 @@ function validateModuleSelection({ registry, language, modules }: { registry: Re
   }
 }
 
-async function writeRootLock({ rootDir, packageRoot, packageVersion, registryRef, allStates }: { rootDir: string; packageRoot: string; packageVersion: string; registryRef: string; allStates: Map<string, WorkspaceState> }) {
+async function writeRootLock({
+  rootDir,
+  packageRoot,
+  packageVersion,
+  registryRef,
+  allStates
+}: {
+  rootDir: string;
+  packageRoot: string;
+  packageVersion: string;
+  registryRef: string;
+  allStates: Map<string, WorkspaceState>;
+}) {
   const registryText = await fs.readFile(path.join(packageRoot, 'registry.json'), 'utf8');
   const lock = {
     lockfile_version: 1,
@@ -1447,7 +1549,15 @@ async function writeRootLock({ rootDir, packageRoot, packageVersion, registryRef
   await fs.writeFile(path.join(rootDir, LOCK_FILE), `${JSON.stringify(lock, null, 2)}\n`, 'utf8');
 }
 
-async function listWorkspaceDirs({ rootDir, rootConfig, workspaceOverride }: { rootDir: string; rootConfig: WorkspaceConfig; workspaceOverride?: string }) {
+async function listWorkspaceDirs({
+  rootDir,
+  rootConfig,
+  workspaceOverride
+}: {
+  rootDir: string;
+  rootConfig: WorkspaceConfig;
+  workspaceOverride?: string;
+}) {
   if (workspaceOverride) {
     const abs = resolveWorkspacePath(rootDir, workspaceOverride);
     ensure(await exists(path.join(abs, CONFIG_FILE)), `Workspace has no ${CONFIG_FILE}: ${workspaceOverride}`);
@@ -1488,7 +1598,15 @@ async function discoverServiceWorkspaces({ rootDir, rootConfig }: { rootDir: str
   return out;
 }
 
-async function walkForWorkspaceConfigs({ rootDir, maxDepth, applyGitignore }: { rootDir: string; maxDepth: number; applyGitignore: boolean }) {
+async function walkForWorkspaceConfigs({
+  rootDir,
+  maxDepth,
+  applyGitignore
+}: {
+  rootDir: string;
+  maxDepth: number;
+  applyGitignore: boolean;
+}) {
   const matches = [];
   const ignoreMatchers = applyGitignore ? await loadGitignoreMatchers(rootDir) : [];
 
@@ -1509,17 +1627,19 @@ async function walkForWorkspaceConfigs({ rootDir, maxDepth, applyGitignore }: { 
       return;
     }
 
-    await Promise.all(entries.map(async (entry) => {
-      if (!entry.isDirectory()) return;
-      const child = path.join(currentDir, entry.name);
-      try {
-        const stat = await fs.lstat(child);
-        if (stat.isSymbolicLink()) return;
-      } catch {
-        return;
-      }
-      await walk(child, depth + 1);
-    }));
+    await Promise.all(
+      entries.map(async (entry) => {
+        if (!entry.isDirectory()) return;
+        const child = path.join(currentDir, entry.name);
+        try {
+          const stat = await fs.lstat(child);
+          if (stat.isSymbolicLink()) return;
+        } catch {
+          return;
+        }
+        await walk(child, depth + 1);
+      })
+    );
   }
 
   await walk(path.resolve(rootDir), 0);
@@ -1607,7 +1727,10 @@ async function findNearestMonorepoRoot(startDir: string): Promise<string | null>
   return found;
 }
 
-function resolveDefaultWorkspaceForMutation(context: { rootDir: string; workspaceDir: string }, workspaceFlag?: string) {
+function resolveDefaultWorkspaceForMutation(
+  context: { rootDir: string; workspaceDir: string },
+  workspaceFlag?: string
+) {
   if (workspaceFlag) return resolveWorkspacePath(context.rootDir, workspaceFlag);
   if (path.resolve(context.workspaceDir) !== path.resolve(context.rootDir)) return context.workspaceDir;
   return context.rootDir;
@@ -1632,7 +1755,15 @@ function relativePathForPointers(fromDir: string, toDir: string) {
   return rel || '.';
 }
 
-async function writeManagedFile({ outPath, rendered, onConflict }: { outPath: string; rendered: string; onConflict: string }) {
+async function writeManagedFile({
+  outPath,
+  rendered,
+  onConflict
+}: {
+  outPath: string;
+  rendered: string;
+  onConflict: string;
+}) {
   await fs.mkdir(path.dirname(outPath), { recursive: true });
 
   if (await exists(outPath)) {
@@ -1656,7 +1787,15 @@ async function writeManagedFile({ outPath, rendered, onConflict }: { outPath: st
   await fs.writeFile(outPath, `${rendered.trim()}\n`, 'utf8');
 }
 
-async function copySourceFile({ packageRoot, sourceRel, target }: { packageRoot: string; sourceRel: string; target: string }) {
+async function copySourceFile({
+  packageRoot,
+  sourceRel,
+  target
+}: {
+  packageRoot: string;
+  sourceRel: string;
+  target: string;
+}) {
   const source = path.join(packageRoot, sourceRel);
   ensure(await exists(source), `Missing module source: ${sourceRel}`);
   await fs.mkdir(path.dirname(target), { recursive: true });
@@ -1674,7 +1813,11 @@ function parseFrontmatter(markdown: string): Record<string, string | string[]> |
     const key = line.slice(0, idx).trim();
     let value: string | string[] = line.slice(idx + 1).trim();
     if (value.startsWith('[') && value.endsWith(']')) {
-      value = value.slice(1, -1).split(',').map((x) => x.trim()).filter(Boolean);
+      value = value
+        .slice(1, -1)
+        .split(',')
+        .map((x) => x.trim())
+        .filter(Boolean);
     }
     fields[key] = value;
   }
@@ -1685,9 +1828,9 @@ async function detectProjectRoot(startDir: string): Promise<string> {
   let current = path.resolve(startDir);
   while (true) {
     if (
-      await exists(path.join(current, '.git')) ||
-      await exists(path.join(current, 'package.json')) ||
-      await exists(path.join(current, 'pyproject.toml'))
+      (await exists(path.join(current, '.git'))) ||
+      (await exists(path.join(current, 'package.json'))) ||
+      (await exists(path.join(current, 'pyproject.toml')))
     ) {
       return current;
     }
@@ -1736,7 +1879,10 @@ function splitCsv(value: string | boolean | string[] | undefined) {
   if (!value) return [];
   if (Array.isArray(value)) return value;
   if (typeof value !== 'string') return [];
-  return value.split(',').map((v) => v.trim()).filter(Boolean);
+  return value
+    .split(',')
+    .map((v) => v.trim())
+    .filter(Boolean);
 }
 
 function uniqueList(items: string[]) {
@@ -1750,9 +1896,7 @@ function canonicalSlot(registry: Registry, slot: string | undefined) {
   if (resolved !== slot && !WARNED_SLOT_ALIASES.has(slot)) {
     const aliasMeta = registry.slot_alias_meta?.[slot];
     const removeIn = aliasMeta?.remove_in ? ` and is planned for removal in ${aliasMeta.remove_in}` : '';
-    process.stderr.write(
-      `warning: slot alias '${slot}' is deprecated; use '${resolved}'${removeIn}\n`
-    );
+    process.stderr.write(`warning: slot alias '${slot}' is deprecated; use '${resolved}'${removeIn}\n`);
     WARNED_SLOT_ALIASES.add(slot);
   }
   return resolved;

--- a/test/bun-packaging.test.ts
+++ b/test/bun-packaging.test.ts
@@ -54,11 +54,7 @@ test('package files list points to existing release paths', async () => {
   assert.ok(fileEntries.length > 0, 'package.json files array should not be empty');
 
   for (const entry of fileEntries) {
-    assert.equal(
-      await exists(path.join(packageRoot, entry)),
-      true,
-      `missing packaged path: ${entry}`
-    );
+    assert.equal(await exists(path.join(packageRoot, entry)), true, `missing packaged path: ${entry}`);
   }
 });
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -73,10 +73,7 @@ test('run prints help for empty argv and --help', async () => {
 });
 
 test('run throws for unknown command', async () => {
-  await assert.rejects(
-    run(['unknown-command'], { packageRoot }),
-    /Unknown command: unknown-command/
-  );
+  await assert.rejects(run(['unknown-command'], { packageRoot }), /Unknown command: unknown-command/);
 });
 
 test('slots list prints canonical slots with metadata', async () => {
@@ -109,7 +106,17 @@ test('modules explain prints module details', async () => {
 
 test('init creates root config, root lock, and routers with new layout', async () => {
   const cwd = await makeProject();
-  await run(['init', '--language=typescript', '--modules=eslint,vitest', '--targets=claude-code,copilot', '--on-conflict=overwrite', '--bare'], { cwd, packageRoot });
+  await run(
+    [
+      'init',
+      '--language=typescript',
+      '--modules=eslint,vitest',
+      '--targets=claude-code,copilot',
+      '--on-conflict=overwrite',
+      '--bare'
+    ],
+    { cwd, packageRoot }
+  );
 
   assert.equal(await exists(path.join(cwd, 'ailib.config.json')), true);
   assert.equal(await exists(path.join(cwd, 'ailib.lock')), true);
@@ -124,7 +131,17 @@ test('init creates root config, root lock, and routers with new layout', async (
 
 test('init supports generic target outputs including openai and gemini', async () => {
   const cwd = await makeProject();
-  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code,cursor,windsurf,openai,gemini', '--on-conflict=overwrite', '--bare'], { cwd, packageRoot });
+  await run(
+    [
+      'init',
+      '--language=typescript',
+      '--modules=eslint',
+      '--targets=claude-code,cursor,windsurf,openai,gemini',
+      '--on-conflict=overwrite',
+      '--bare'
+    ],
+    { cwd, packageRoot }
+  );
 
   assert.equal(await exists(path.join(cwd, 'CLAUDE.md')), true);
   assert.equal(await exists(path.join(cwd, '.cursor/rules/ailib.mdc')), true);
@@ -136,10 +153,25 @@ test('init supports generic target outputs including openai and gemini', async (
 
 test('monorepo update inherits root and supports service override modules', async () => {
   const root = await makeMonorepo();
-  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code,cursor,copilot', '--on-conflict=overwrite'], { cwd: root, packageRoot });
+  await run(
+    [
+      'init',
+      '--language=typescript',
+      '--modules=eslint',
+      '--targets=claude-code,cursor,copilot',
+      '--on-conflict=overwrite'
+    ],
+    { cwd: root, packageRoot }
+  );
 
-  await run(['init', '--language=typescript', '--modules=biome', '--targets=claude-code,cursor,copilot'], { cwd: path.join(root, 'apps', 'web'), packageRoot });
-  await run(['init', '--language=python', '--modules=ruff,pytest,fastapi', '--targets=claude-code,copilot'], { cwd: path.join(root, 'services', 'ml'), packageRoot });
+  await run(['init', '--language=typescript', '--modules=biome', '--targets=claude-code,cursor,copilot'], {
+    cwd: path.join(root, 'apps', 'web'),
+    packageRoot
+  });
+  await run(['init', '--language=python', '--modules=ruff,pytest,fastapi', '--targets=claude-code,copilot'], {
+    cwd: path.join(root, 'services', 'ml'),
+    packageRoot
+  });
 
   await run(['update'], { cwd: root, packageRoot });
 
@@ -159,8 +191,14 @@ test('monorepo update inherits root and supports service override modules', asyn
 
 test('local overrides are merged into effective workspace config', async () => {
   const root = await makeMonorepo();
-  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code,copilot', '--on-conflict=overwrite'], { cwd: root, packageRoot });
-  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code,copilot'], { cwd: path.join(root, 'apps', 'web'), packageRoot });
+  await run(
+    ['init', '--language=typescript', '--modules=eslint', '--targets=claude-code,copilot', '--on-conflict=overwrite'],
+    { cwd: root, packageRoot }
+  );
+  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code,copilot'], {
+    cwd: path.join(root, 'apps', 'web'),
+    packageRoot
+  });
 
   const localOverride = {
     version: '1.0.0',
@@ -186,8 +224,14 @@ test('local overrides are merged into effective workspace config', async () => {
 
 test('add/remove can target workspace in monorepo', async () => {
   const root = await makeMonorepo();
-  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code', '--on-conflict=overwrite'], { cwd: root, packageRoot });
-  await run(['init', '--language=python', '--modules=ruff', '--targets=claude-code'], { cwd: path.join(root, 'services', 'ml'), packageRoot });
+  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code', '--on-conflict=overwrite'], {
+    cwd: root,
+    packageRoot
+  });
+  await run(['init', '--language=python', '--modules=ruff', '--targets=claude-code'], {
+    cwd: path.join(root, 'services', 'ml'),
+    packageRoot
+  });
 
   await run(['add', 'pytest', '--workspace=services/ml'], { cwd: root, packageRoot });
   assert.equal(await exists(path.join(root, 'services', 'ml', '.ailib/modules/pytest.md')), true);
@@ -198,8 +242,14 @@ test('add/remove can target workspace in monorepo', async () => {
 
 test('doctor validates all workspaces and keeps healthy status', async () => {
   const root = await makeMonorepo();
-  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code', '--on-conflict=overwrite'], { cwd: root, packageRoot });
-  await run(['init', '--language=typescript', '--modules=biome', '--targets=claude-code'], { cwd: path.join(root, 'apps', 'web'), packageRoot });
+  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code', '--on-conflict=overwrite'], {
+    cwd: root,
+    packageRoot
+  });
+  await run(['init', '--language=typescript', '--modules=biome', '--targets=claude-code'], {
+    cwd: path.join(root, 'apps', 'web'),
+    packageRoot
+  });
 
   process.exitCode = 0;
   await run(['doctor'], { cwd: root, packageRoot });
@@ -208,8 +258,14 @@ test('doctor validates all workspaces and keeps healthy status', async () => {
 
 test('doctor fails when required pointer files are missing', async () => {
   const root = await makeMonorepo();
-  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code', '--on-conflict=overwrite'], { cwd: root, packageRoot });
-  await run(['init', '--language=typescript', '--modules=biome', '--targets=claude-code'], { cwd: path.join(root, 'apps', 'web'), packageRoot });
+  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code', '--on-conflict=overwrite'], {
+    cwd: root,
+    packageRoot
+  });
+  await run(['init', '--language=typescript', '--modules=biome', '--targets=claude-code'], {
+    cwd: path.join(root, 'apps', 'web'),
+    packageRoot
+  });
 
   await fs.rm(path.join(root, 'apps', 'web', '.ailib', 'standards.md'));
 
@@ -222,7 +278,10 @@ test('doctor fails when required pointer files are missing', async () => {
 
 test('update fails fast for invalid local override references', async () => {
   const root = await makeMonorepo();
-  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code', '--on-conflict=overwrite'], { cwd: root, packageRoot });
+  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code', '--on-conflict=overwrite'], {
+    cwd: root,
+    packageRoot
+  });
 
   const localOverride = {
     version: '1.0.0',
@@ -234,15 +293,15 @@ test('update fails fast for invalid local override references', async () => {
   };
   await fs.writeFile(path.join(root, 'ailib.local.json'), `${JSON.stringify(localOverride, null, 2)}\n`, 'utf8');
 
-  await assert.rejects(
-    run(['update'], { cwd: root, packageRoot }),
-    /Invalid ailib\.local\.json/
-  );
+  await assert.rejects(run(['update'], { cwd: root, packageRoot }), /Invalid ailib\.local\.json/);
 });
 
 test('doctor reports invalid local override configuration', async () => {
   const root = await makeMonorepo();
-  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code', '--on-conflict=overwrite'], { cwd: root, packageRoot });
+  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code', '--on-conflict=overwrite'], {
+    cwd: root,
+    packageRoot
+  });
 
   const localOverride = {
     version: '1.0.0',
@@ -265,8 +324,14 @@ test('doctor reports invalid local override configuration', async () => {
 
 test('doctor reports missing frontmatter fields for module pointers', async () => {
   const root = await makeMonorepo();
-  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code', '--on-conflict=overwrite'], { cwd: root, packageRoot });
-  await run(['init', '--language=typescript', '--modules=biome', '--targets=claude-code'], { cwd: path.join(root, 'apps', 'web'), packageRoot });
+  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code', '--on-conflict=overwrite'], {
+    cwd: root,
+    packageRoot
+  });
+  await run(['init', '--language=typescript', '--modules=biome', '--targets=claude-code'], {
+    cwd: path.join(root, 'apps', 'web'),
+    packageRoot
+  });
 
   const modulePath = path.join(root, 'apps', 'web', '.ailib', 'modules', 'biome.md');
   const original = await fs.readFile(modulePath, 'utf8');
@@ -286,8 +351,14 @@ test('uninstall at monorepo root without --all removes root workspace artifacts 
   const root = await makeMonorepo();
   const serviceDir = path.join(root, 'services', 'ml');
 
-  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code,copilot', '--on-conflict=overwrite'], { cwd: root, packageRoot });
-  await run(['init', '--language=python', '--modules=ruff', '--targets=claude-code,copilot'], { cwd: serviceDir, packageRoot });
+  await run(
+    ['init', '--language=typescript', '--modules=eslint', '--targets=claude-code,copilot', '--on-conflict=overwrite'],
+    { cwd: root, packageRoot }
+  );
+  await run(['init', '--language=python', '--modules=ruff', '--targets=claude-code,copilot'], {
+    cwd: serviceDir,
+    packageRoot
+  });
 
   await run(['uninstall'], { cwd: root, packageRoot });
 
@@ -304,8 +375,14 @@ test('uninstall at monorepo root without --all removes root workspace artifacts 
 test('uninstall in service workspace removes service and keeps root managed', async () => {
   const root = await makeMonorepo();
   const serviceDir = path.join(root, 'services', 'ml');
-  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code,copilot', '--on-conflict=overwrite'], { cwd: root, packageRoot });
-  await run(['init', '--language=python', '--modules=ruff', '--targets=claude-code,copilot'], { cwd: serviceDir, packageRoot });
+  await run(
+    ['init', '--language=typescript', '--modules=eslint', '--targets=claude-code,copilot', '--on-conflict=overwrite'],
+    { cwd: root, packageRoot }
+  );
+  await run(['init', '--language=python', '--modules=ruff', '--targets=claude-code,copilot'], {
+    cwd: serviceDir,
+    packageRoot
+  });
 
   await run(['uninstall'], { cwd: serviceDir, packageRoot });
 
@@ -318,8 +395,14 @@ test('uninstall in service workspace removes service and keeps root managed', as
 
 test('uninstall --all at root removes root and service outputs', async () => {
   const root = await makeMonorepo();
-  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code,copilot', '--on-conflict=overwrite'], { cwd: root, packageRoot });
-  await run(['init', '--language=python', '--modules=ruff', '--targets=claude-code,copilot'], { cwd: path.join(root, 'services', 'ml'), packageRoot });
+  await run(
+    ['init', '--language=typescript', '--modules=eslint', '--targets=claude-code,copilot', '--on-conflict=overwrite'],
+    { cwd: root, packageRoot }
+  );
+  await run(['init', '--language=python', '--modules=ruff', '--targets=claude-code,copilot'], {
+    cwd: path.join(root, 'services', 'ml'),
+    packageRoot
+  });
 
   await run(['uninstall', '--all'], { cwd: root, packageRoot });
 

--- a/test/registry-governance.test.ts
+++ b/test/registry-governance.test.ts
@@ -82,11 +82,7 @@ test('registry slots follow naming and coverage rules', async () => {
 
   const slotSet = new Set(slots);
   const slotDefSet = new Set(Object.keys(slotDefs));
-  assert.deepEqual(
-    [...slotDefSet].sort(),
-    [...slotSet].sort(),
-    'slot_defs keys must match slots exactly'
-  );
+  assert.deepEqual([...slotDefSet].sort(), [...slotSet].sort(), 'slot_defs keys must match slots exactly');
 
   for (const [slot, def] of Object.entries(slotDefs)) {
     assert.equal(typeof def.description, 'string', `slot_defs.${slot}.description must be string`);
@@ -115,11 +111,7 @@ test('registry slots follow naming and coverage rules', async () => {
       `slot_alias_meta.${alias}.replacement must match slot_aliases target`
     );
     for (const key of ['deprecated_since', 'remove_in']) {
-      assert.match(
-        meta[key],
-        /^\d+\.\d+\.\d+$/u,
-        `slot_alias_meta.${alias}.${key} must be semver-like`
-      );
+      assert.match(meta[key], /^\d+\.\d+\.\d+$/u, `slot_alias_meta.${alias}.${key} must be semver-like`);
     }
   }
 });
@@ -132,61 +124,38 @@ test('registry modules use canonical slots and docs match', async () => {
 
   for (const [languageId, languageDef] of Object.entries(registry.languages || {})) {
     const moduleDir = path.join(packageRoot, 'languages', languageId, 'modules');
-    const docModuleIds = await fs.readdir(moduleDir, { withFileTypes: true })
-      .then((entries) => entries
-        .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
-        .map((entry) => entry.name.replace(/\.md$/u, ''))
-        .sort()
+    const docModuleIds = await fs
+      .readdir(moduleDir, { withFileTypes: true })
+      .then((entries) =>
+        entries
+          .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+          .map((entry) => entry.name.replace(/\.md$/u, ''))
+          .sort()
       )
       .catch(() => []);
     const registryModuleIds = Object.keys(languageDef.modules || {}).sort();
 
-    assert.deepEqual(
-      docModuleIds,
-      registryModuleIds,
-      `Registry/docs module mismatch for language '${languageId}'`
-    );
+    assert.deepEqual(docModuleIds, registryModuleIds, `Registry/docs module mismatch for language '${languageId}'`);
 
     for (const [moduleId, moduleDef] of Object.entries(languageDef.modules || {})) {
       const rawSlot = moduleDef.slot;
       assert.ok(rawSlot, `Missing slot for module '${languageId}:${moduleId}'`);
       const canonical = aliases[rawSlot] || rawSlot;
       usedSlots.add(canonical);
-      assert.ok(
-        slots.has(canonical),
-        `Unknown canonical slot '${canonical}' for module '${languageId}:${moduleId}'`
-      );
+      assert.ok(slots.has(canonical), `Unknown canonical slot '${canonical}' for module '${languageId}:${moduleId}'`);
       assert.equal(
         rawSlot,
         canonical,
         `Module '${languageId}:${moduleId}' uses alias slot '${rawSlot}', use canonical '${canonical}'`
       );
 
-      const modulePath = path.join(
-        packageRoot,
-        'languages',
-        languageId,
-        'modules',
-        `${moduleId}.md`
-      );
+      const modulePath = path.join(packageRoot, 'languages', languageId, 'modules', `${moduleId}.md`);
       const markdown = await fs.readFile(modulePath, 'utf8');
       const frontmatter = parseFrontmatter(markdown);
       assert.ok(frontmatter, `Missing frontmatter in '${modulePath}'`);
-      assert.equal(
-        frontmatter.slot,
-        canonical,
-        `Frontmatter slot mismatch for '${languageId}:${moduleId}'`
-      );
-      assert.equal(
-        frontmatter.id,
-        moduleId,
-        `Frontmatter id mismatch for '${languageId}:${moduleId}'`
-      );
-      assert.equal(
-        frontmatter.language,
-        languageId,
-        `Frontmatter language mismatch for '${languageId}:${moduleId}'`
-      );
+      assert.equal(frontmatter.slot, canonical, `Frontmatter slot mismatch for '${languageId}:${moduleId}'`);
+      assert.equal(frontmatter.id, moduleId, `Frontmatter id mismatch for '${languageId}:${moduleId}'`);
+      assert.equal(frontmatter.language, languageId, `Frontmatter language mismatch for '${languageId}:${moduleId}'`);
     }
   }
 
@@ -209,24 +178,10 @@ test('registry module relationships and frontmatter metadata are valid', async (
       const requiresSet = new Set(requires);
       const conflictsSet = new Set(conflicts);
 
-      assert.equal(
-        requires.length,
-        requiresSet.size,
-        `Duplicate requires entries in '${languageId}:${moduleId}'`
-      );
-      assert.equal(
-        conflicts.length,
-        conflictsSet.size,
-        `Duplicate conflicts entries in '${languageId}:${moduleId}'`
-      );
-      assert.ok(
-        !requiresSet.has(moduleId),
-        `Module '${languageId}:${moduleId}' cannot require itself`
-      );
-      assert.ok(
-        !conflictsSet.has(moduleId),
-        `Module '${languageId}:${moduleId}' cannot conflict with itself`
-      );
+      assert.equal(requires.length, requiresSet.size, `Duplicate requires entries in '${languageId}:${moduleId}'`);
+      assert.equal(conflicts.length, conflictsSet.size, `Duplicate conflicts entries in '${languageId}:${moduleId}'`);
+      assert.ok(!requiresSet.has(moduleId), `Module '${languageId}:${moduleId}' cannot require itself`);
+      assert.ok(!conflictsSet.has(moduleId), `Module '${languageId}:${moduleId}' cannot conflict with itself`);
       for (const dependency of requiresSet) {
         assert.ok(
           !conflictsSet.has(dependency),
@@ -234,13 +189,7 @@ test('registry module relationships and frontmatter metadata are valid', async (
         );
       }
 
-      const modulePath = path.join(
-        packageRoot,
-        'languages',
-        languageId,
-        'modules',
-        `${moduleId}.md`
-      );
+      const modulePath = path.join(packageRoot, 'languages', languageId, 'modules', `${moduleId}.md`);
       const markdown = await fs.readFile(modulePath, 'utf8');
       const frontmatter = parseFrontmatter(markdown);
       assert.ok(frontmatter, `Missing frontmatter in '${modulePath}'`);
@@ -257,11 +206,8 @@ test('registry module relationships and frontmatter metadata are valid', async (
 });
 
 test('split registry and generated catalog are in sync', () => {
-  const run = (script: string, ...args: string[]) => execFileSync(
-    process.execPath,
-    [path.join(packageRoot, script), ...args],
-    { stdio: 'pipe', encoding: 'utf8' }
-  );
+  const run = (script: string, ...args: string[]) =>
+    execFileSync(process.execPath, [path.join(packageRoot, script), ...args], { stdio: 'pipe', encoding: 'utf8' });
 
   run('tools/sync-registry.ts', '--check');
   run('tools/generate-module-catalog.ts', '--check');

--- a/test/standards-compliance.test.ts
+++ b/test/standards-compliance.test.ts
@@ -14,7 +14,7 @@ async function collectTypeScriptFiles(rootDir: string): Promise<string[]> {
     if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === 'coverage') continue;
     const fullPath = path.join(rootDir, entry.name);
     if (entry.isDirectory()) {
-      files.push(...await collectTypeScriptFiles(fullPath));
+      files.push(...(await collectTypeScriptFiles(fullPath)));
       continue;
     }
     if (entry.isFile() && entry.name.endsWith('.ts')) {
@@ -50,9 +50,5 @@ test('no explicit any typing in src/tools/test TypeScript files', async () => {
     }
   }
 
-  assert.deepEqual(
-    violations,
-    [],
-    `Explicit 'any' typing is not allowed:\n- ${violations.join('\n- ')}`
-  );
+  assert.deepEqual(violations, [], `Explicit 'any' typing is not allowed:\n- ${violations.join('\n- ')}`);
 });

--- a/tools/check-coverage-threshold.ts
+++ b/tools/check-coverage-threshold.ts
@@ -49,14 +49,10 @@ async function run(): Promise<void> {
   const rounded = Math.round(lineCoverage * 100) / 100;
 
   if (lineCoverage < minLines) {
-    throw new Error(
-      `Line coverage ${rounded}% is below threshold ${minLines}% (${coveredLines}/${totalLines}).`
-    );
+    throw new Error(`Line coverage ${rounded}% is below threshold ${minLines}% (${coveredLines}/${totalLines}).`);
   }
 
-  console.log(
-    `Coverage threshold check passed: ${rounded}% >= ${minLines}% (${coveredLines}/${totalLines})`
-  );
+  console.log(`Coverage threshold check passed: ${rounded}% >= ${minLines}% (${coveredLines}/${totalLines})`);
 }
 
 run().catch((error: unknown) => {

--- a/tools/generate-coverage-audit.ts
+++ b/tools/generate-coverage-audit.ts
@@ -177,8 +177,10 @@ function renderReport(registry: Registry, report: CoverageReport): string {
     lines.push(`- Missing docs: ${language.missingDocs.length}`);
     lines.push(`- Orphan docs: ${language.orphanDocs.length}`);
     lines.push(`- Frontmatter issues: ${language.frontmatterIssues.length}`);
-    if (language.missingDocs.length) lines.push(`- Missing doc module IDs: ${language.missingDocs.map((m) => `\`${m}\``).join(', ')}`);
-    if (language.orphanDocs.length) lines.push(`- Orphan doc module IDs: ${language.orphanDocs.map((m) => `\`${m}\``).join(', ')}`);
+    if (language.missingDocs.length)
+      lines.push(`- Missing doc module IDs: ${language.missingDocs.map((m) => `\`${m}\``).join(', ')}`);
+    if (language.orphanDocs.length)
+      lines.push(`- Orphan doc module IDs: ${language.orphanDocs.map((m) => `\`${m}\``).join(', ')}`);
     if (language.frontmatterIssues.length) {
       lines.push('- Frontmatter mismatches:');
       lines.push(...language.frontmatterIssues);


### PR DESCRIPTION
## Summary
- Add Prettier configuration and ignore rules for maintained repository files.
- Integrate Prettier enforcement into `lint` and existing check workflow.
- Apply repo-wide formatting remediation for files in scope.

## Test plan
- [x] Run `bun run format:check`
- [x] Run `bun run check`

Refs #71

Made with [Cursor](https://cursor.com)