### PR TITLE
test: extend coverage with exception rationale

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ bun run local:install
 - Slot governance rules: [docs/slot-standards.md](docs/slot-standards.md)
 - Development standards: [docs/development-standards.md](docs/development-standards.md)
 - Test standards: [docs/test-standards.md](docs/test-standards.md)
+- Coverage exceptions and rationale: [docs/coverage-exceptions.md](docs/coverage-exceptions.md)
 - Workflow hardening: [docs/workflow-security-hardening.md](docs/workflow-security-hardening.md)
 - Branch protection policy: [docs/branch-protection-policy.md](docs/branch-protection-policy.md)
 - Homebrew publishing: [docs/homebrew-publishing.md](docs/homebrew-publishing.md)

--- a/docs/coverage-exceptions.md
+++ b/docs/coverage-exceptions.md
@@ -1,0 +1,39 @@
+# Coverage Exceptions and Rationale
+
+This document tracks why `src/cli.ts` is not yet at 100% line coverage and which paths are intentionally deferred.
+
+Current baseline after Task #72 pass 2:
+
+- `src/cli.ts` line coverage: **91.25%**
+- Full-suite threshold gate: **80%** (enforced)
+
+## High-value uncovered clusters
+
+- **Workspace and filesystem edge conditions**
+  - Deep filesystem traversal branches (`walkForWorkspaceConfigs`, symlink/permission guards).
+  - Branches that require specific broken filesystem states to trigger reliably.
+  - Reason deferred: high setup complexity and potential flakiness in cross-platform CI.
+
+- **Conflict-mode and managed-file merge paths**
+  - `writeManagedFile` conflict behaviors (`skip`, `abort`, and merge backup handling).
+  - Reason deferred: requires brittle fixture orchestration for low-frequency safety branches.
+
+- **Context and discovery fallbacks**
+  - Project root detection and monorepo/workspace discovery fallback combinations.
+  - Reason deferred: requires synthetic directory trees that add maintenance burden.
+
+## Coverage strategy
+
+- Continue adding deterministic regression tests first for real defects and command-facing behavior.
+- Prioritize branches with user-visible errors before deeply internal fallback paths.
+- Add fixture helpers only when they reduce maintenance cost for multiple remaining branches.
+
+## Definition of feasible 100%
+
+100% is considered feasible only when additional tests are:
+
+- deterministic across local and CI environments,
+- not dependent on fragile filesystem race conditions, and
+- maintainable without obscuring behavior intent.
+
+If those constraints cannot be met for a branch, document the rationale here and keep coverage progress incremental.

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -415,6 +415,38 @@ test('doctor reports missing frontmatter fields for module pointers', async () =
   assert.equal(exitCode, 1);
 });
 
+test('doctor fails for explicit workspace without config', async () => {
+  const root = await makeMonorepo();
+  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code', '--on-conflict=overwrite'], {
+    cwd: root,
+    packageRoot
+  });
+  await fs.mkdir(path.join(root, 'apps', 'missing'), { recursive: true });
+
+  await assert.rejects(
+    run(['doctor', '--workspace=apps/missing'], { cwd: root, packageRoot }),
+    /Workspace has no ailib\.config\.json: .*apps\/missing/
+  );
+});
+
+test('add/remove fail for explicit workspace without config', async () => {
+  const root = await makeMonorepo();
+  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code', '--on-conflict=overwrite'], {
+    cwd: root,
+    packageRoot
+  });
+  await fs.mkdir(path.join(root, 'apps', 'missing'), { recursive: true });
+
+  await assert.rejects(
+    run(['add', 'prettier', '--workspace=apps/missing'], { cwd: root, packageRoot }),
+    /Missing ailib\.config\.json in workspace: .*apps\/missing/
+  );
+  await assert.rejects(
+    run(['remove', 'prettier', '--workspace=apps/missing'], { cwd: root, packageRoot }),
+    /Missing ailib\.config\.json in workspace: .*apps\/missing/
+  );
+});
+
 test('uninstall at monorepo root without --all removes root workspace artifacts but keeps lock', async () => {
   const root = await makeMonorepo();
   const serviceDir = path.join(root, 'services', 'ml');


### PR DESCRIPTION
## Summary
- Add CLI tests for explicit workspace error paths in `doctor`, `add`, and `remove` commands.
- Document non-100% coverage rationale and feasibility criteria in `docs/coverage-exceptions.md`.
- Link coverage exceptions documentation from the README index.

## Test plan
- [x] Run `bun test test/cli.test.ts`
- [x] Run `bun run coverage:build`
- [x] Run `bun run check`

Refs #72

Made with [Cursor](https://cursor.com)