### PR TITLE
fix: harden discovery ignore matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ bun run local:install
 - Slot governance rules: [docs/slot-standards.md](docs/slot-standards.md)
 - Development standards: [docs/development-standards.md](docs/development-standards.md)
 - Test standards: [docs/test-standards.md](docs/test-standards.md)
+- Coverage exceptions and rationale: [docs/coverage-exceptions.md](docs/coverage-exceptions.md)
 - Workflow hardening: [docs/workflow-security-hardening.md](docs/workflow-security-hardening.md)
 - Branch protection policy: [docs/branch-protection-policy.md](docs/branch-protection-policy.md)
 - Homebrew publishing: [docs/homebrew-publishing.md](docs/homebrew-publishing.md)

--- a/docs/coverage-exceptions.md
+++ b/docs/coverage-exceptions.md
@@ -1,0 +1,39 @@
+# Coverage Exceptions and Rationale
+
+This document tracks why `src/cli.ts` is not yet at 100% line coverage and which paths are intentionally deferred.
+
+Current baseline after Task #72 pass 2:
+
+- `src/cli.ts` line coverage: **91.25%**
+- Full-suite threshold gate: **80%** (enforced)
+
+## High-value uncovered clusters
+
+- **Workspace and filesystem edge conditions**
+  - Deep filesystem traversal branches (`walkForWorkspaceConfigs`, symlink/permission guards).
+  - Branches that require specific broken filesystem states to trigger reliably.
+  - Reason deferred: high setup complexity and potential flakiness in cross-platform CI.
+
+- **Conflict-mode and managed-file merge paths**
+  - `writeManagedFile` conflict behaviors (`skip`, `abort`, and merge backup handling).
+  - Reason deferred: requires brittle fixture orchestration for low-frequency safety branches.
+
+- **Context and discovery fallbacks**
+  - Project root detection and monorepo/workspace discovery fallback combinations.
+  - Reason deferred: requires synthetic directory trees that add maintenance burden.
+
+## Coverage strategy
+
+- Continue adding deterministic regression tests first for real defects and command-facing behavior.
+- Prioritize branches with user-visible errors before deeply internal fallback paths.
+- Add fixture helpers only when they reduce maintenance cost for multiple remaining branches.
+
+## Definition of feasible 100%
+
+100% is considered feasible only when additional tests are:
+
+- deterministic across local and CI environments,
+- not dependent on fragile filesystem race conditions, and
+- maintainable without obscuring behavior intent.
+
+If those constraints cannot be met for a branch, document the rationale here and keep coverage progress incremental.

--- a/docs/phase7-quality-review.md
+++ b/docs/phase7-quality-review.md
@@ -1,0 +1,21 @@
+# Phase 7 Quality Review Log
+
+This log tracks defects found during Phase 7 Task #73 and the remaining risks with clear ownership.
+
+## Resolved in Task #73
+
+- Fixed auto-discovery ignore behavior for `.gitignore` wildcard directory patterns.
+  - Scope: monorepo workspace auto-discovery path.
+  - Validation: added regression coverage in `test/cli.test.ts`.
+
+## Residual risks and ownership
+
+- **Risk:** `.gitignore` negation patterns (`!foo`) are not currently supported by discovery matching.
+  - **Impact:** low (only affects auto-discovery mode for repos relying on negation rules).
+  - **Owner:** `ai-lib` maintainers (`silvamarcel`).
+  - **Plan:** evaluate support when extending discovery matcher behavior.
+
+- **Risk:** Remaining uncovered filesystem-failure branches in `src/cli.ts` require brittle setup.
+  - **Impact:** low-to-medium (defensive branches; not common command paths).
+  - **Owner:** `ai-lib` maintainers (`silvamarcel`).
+  - **Plan:** continue incremental coverage via deterministic fixtures.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1658,7 +1658,12 @@ async function loadGitignoreMatchers(rootDir: string) {
   return patterns.map((pattern) => {
     const normalized = toPosix(pattern.replace(/\/$/u, ''));
     return (relPath, baseName) => {
-      if (normalized.includes('/')) return relPath === normalized || relPath.startsWith(`${normalized}/`);
+      if (normalized.includes('/')) {
+        return globMatch(relPath, normalized) || relPath.startsWith(`${normalized}/`);
+      }
+      if (normalized.includes('*')) {
+        return globMatch(baseName, normalized);
+      }
       return baseName === normalized;
     };
   });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -512,3 +512,49 @@ test('uninstall --all at root removes root and service outputs', async () => {
   assert.equal(await exists(path.join(root, 'services', 'ml', '.ailib')), false);
   assert.equal(await exists(path.join(root, 'services', 'ml', 'ailib.config.json')), false);
 });
+
+test('auto-discovery honors wildcard .gitignore directory patterns', async () => {
+  const root = await makeProject();
+  await run(
+    ['init', '--language=typescript', '--modules=eslint', '--targets=claude-code', '--on-conflict=overwrite', '--bare'],
+    {
+      cwd: root,
+      packageRoot
+    }
+  );
+
+  const keepDir = path.join(root, 'service-keep');
+  const ignoreDir = path.join(root, 'service-ignore');
+  await fs.mkdir(keepDir, { recursive: true });
+  await fs.mkdir(ignoreDir, { recursive: true });
+
+  const workspaceConfig = (modules: string[]) =>
+    JSON.stringify(
+      {
+        $schema: 'https://ailib.dev/schema/config.schema.json',
+        language: 'typescript',
+        modules,
+        targets: ['claude-code'],
+        docs_path: './docs/'
+      },
+      null,
+      2
+    ) + '\n';
+
+  await fs.writeFile(path.join(keepDir, 'ailib.config.json'), workspaceConfig(['biome']), 'utf8');
+  await fs.writeFile(path.join(ignoreDir, 'ailib.config.json'), workspaceConfig(['prettier']), 'utf8');
+
+  await fs.writeFile(path.join(root, '.gitignore'), 'service-ign*\n', 'utf8');
+  await run(['update'], { cwd: root, packageRoot });
+
+  assert.equal(
+    await exists(path.join(keepDir, '.ailib', 'standards.md')),
+    true,
+    'non-ignored service should be discovered'
+  );
+  assert.equal(
+    await exists(path.join(ignoreDir, '.ailib', 'standards.md')),
+    false,
+    'ignored wildcard service should be excluded'
+  );
+});

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -415,6 +415,38 @@ test('doctor reports missing frontmatter fields for module pointers', async () =
   assert.equal(exitCode, 1);
 });
 
+test('doctor fails for explicit workspace without config', async () => {
+  const root = await makeMonorepo();
+  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code', '--on-conflict=overwrite'], {
+    cwd: root,
+    packageRoot
+  });
+  await fs.mkdir(path.join(root, 'apps', 'missing'), { recursive: true });
+
+  await assert.rejects(
+    run(['doctor', '--workspace=apps/missing'], { cwd: root, packageRoot }),
+    /Workspace has no ailib\.config\.json: .*apps\/missing/
+  );
+});
+
+test('add/remove fail for explicit workspace without config', async () => {
+  const root = await makeMonorepo();
+  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code', '--on-conflict=overwrite'], {
+    cwd: root,
+    packageRoot
+  });
+  await fs.mkdir(path.join(root, 'apps', 'missing'), { recursive: true });
+
+  await assert.rejects(
+    run(['add', 'prettier', '--workspace=apps/missing'], { cwd: root, packageRoot }),
+    /Missing ailib\.config\.json in workspace: .*apps\/missing/
+  );
+  await assert.rejects(
+    run(['remove', 'prettier', '--workspace=apps/missing'], { cwd: root, packageRoot }),
+    /Missing ailib\.config\.json in workspace: .*apps\/missing/
+  );
+});
+
 test('uninstall at monorepo root without --all removes root workspace artifacts but keeps lock', async () => {
   const root = await makeMonorepo();
   const serviceDir = path.join(root, 'services', 'ml');


### PR DESCRIPTION
## Summary
- Fix workspace auto-discovery to respect wildcard `.gitignore` directory patterns.
- Add CLI regression coverage ensuring ignored wildcard service paths are excluded.
- Add a Phase 7 quality review log documenting residual risks and ownership.

## Test plan
- [x] Run `bun test test/cli.test.ts`
- [x] Run `bun run check`

Refs #73

Made with [Cursor](https://cursor.com)