### PR TITLE
refactor: extract cli helper modules and types

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,15 @@
 - [ ] I used a TDD flow (red/green/refactor) for behavior changes
 - [ ] I kept the PR scope to one logical concern
 
+## TDD Evidence
+
+- [ ] Behavior change: I added/updated a failing test first (Red), then implemented (Green), then refactored.
+- [ ] Refactor/docs/chore only: no behavior change, so Red step is not applicable.
+- Red evidence (test name/command or short note):
+  - <!-- example: `bun test test/cli.test.ts -t "my failing case"` -->
+- Green evidence (what now passes):
+  - <!-- example: `bun run check` -->
+
 ## Test Plan
 
 - [ ] `bun run typecheck`

--- a/docs/development-standards.md
+++ b/docs/development-standards.md
@@ -45,6 +45,7 @@ Expected loop:
 - `bun run typecheck` must pass.
 - `bun run check` must pass.
 - New behavior should include/adjust tests.
+- PR description must include TDD evidence (Red/Green/Refactor) or explicit no-behavior-change rationale.
 - Docs must be updated when user-facing behavior or contribution flow changes.
 
 ## 6) Definition of Done

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,26 @@ import fs from 'node:fs/promises';
 import { constants as fsConstants } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
+import { getStringFlag, parseFlags } from './cli/flags.ts';
+import { printHelp } from './cli/help.ts';
+import type {
+  CliFlags,
+  CommandContext,
+  EffectiveWorkspaceConfig,
+  LanguageDefinition,
+  ListOverrideScope,
+  LocalOverrideConfig,
+  ModuleDefinition,
+  Registry,
+  RunOptions,
+  SlotAliasMeta,
+  SlotDefinition,
+  SlotOverrideRule,
+  TargetDefinition,
+  WorkspaceConfig,
+  WorkspaceOverrideConfig,
+  WorkspaceState
+} from './cli/types.ts';
 
 const AILIB_BLOCK_START = '<!-- ailib:start -->';
 const AILIB_BLOCK_END = '<!-- ailib:end -->';
@@ -13,115 +33,6 @@ const AUTO_DISCOVERY_MAX_DEPTH = 4;
 const GLOB_DISCOVERY_MAX_DEPTH = 32;
 const SKIP_DIRS = new Set(['.git', 'node_modules', 'dist', 'build', '.venv']);
 const WARNED_SLOT_ALIASES = new Set();
-
-type CliFlags = { _: string[] } & Record<string, string | boolean | string[] | undefined>;
-
-interface RunOptions {
-  cwd?: string;
-  packageRoot?: string;
-}
-
-interface ModuleDefinition {
-  slot: string;
-  requires?: string[];
-  conflicts_with?: string[];
-}
-
-interface LanguageDefinition {
-  modules: Record<string, ModuleDefinition>;
-}
-
-interface TargetDefinition {
-  output: string;
-  root_output?: string;
-  mode?: string;
-  display?: string;
-  frontmatter?: {
-    root?: string;
-    workspace?: string;
-  };
-}
-
-interface SlotDefinition {
-  kind?: 'exclusive' | 'composable';
-  description?: string;
-}
-
-interface SlotAliasMeta {
-  replacement: string;
-  deprecated_since?: string;
-  remove_in?: string;
-}
-
-interface Registry {
-  version: string;
-  slots?: string[];
-  slot_defs?: Record<string, SlotDefinition>;
-  slot_aliases?: Record<string, string>;
-  slot_alias_meta?: Record<string, SlotAliasMeta>;
-  languages: Record<string, LanguageDefinition>;
-  targets: Record<string, TargetDefinition>;
-}
-
-interface WorkspaceConfig {
-  $schema?: string;
-  extends?: string;
-  registry_ref?: string;
-  on_conflict?: string;
-  language?: string;
-  modules?: string[];
-  targets?: string[];
-  targets_removed?: string[];
-  docs_path?: string;
-  workspaces?: string[];
-}
-
-interface ListOverrideScope {
-  add?: string[];
-  remove?: string[];
-  set?: string[];
-}
-
-interface SlotOverrideRule {
-  set?: string;
-  remove?: boolean;
-}
-
-interface WorkspaceOverrideConfig {
-  targets?: ListOverrideScope;
-  modules?: ListOverrideScope;
-  slots?: Record<string, SlotOverrideRule>;
-}
-
-interface LocalOverrideConfig {
-  version: string;
-  default_override?: WorkspaceOverrideConfig;
-  workspace_overrides?: Record<string, WorkspaceOverrideConfig>;
-}
-
-interface EffectiveWorkspaceConfig extends WorkspaceConfig {
-  language: string;
-  modules: string[];
-  targets: string[];
-  docs_path: string;
-  inheritedModules: string[];
-  localModules: string[];
-  warnings: string[];
-}
-
-interface WorkspaceState {
-  effective: EffectiveWorkspaceConfig;
-  inheritedModules: string[];
-  localModules: string[];
-  requiredFiles: string[];
-  warnings: string[];
-}
-
-interface CommandContext {
-  cwd: string;
-  packageRoot: string;
-  flags: CliFlags;
-}
 
 export async function run(argv: string[], options: RunOptions = {}) {
   const cwd = options.cwd ?? process.cwd();
@@ -162,47 +73,6 @@ export async function run(argv: string[], options: RunOptions = {}) {
     default:
       throw new Error(`Unknown command: ${command}`);
   }
-}
-
-function printHelp() {
-  process.stdout.write(
-    'ailib commands:\n' +
-      '  ailib init [--language=<lang>] [--targets=a,b] [--modules=m1,m2] [--workspaces=a/*,b/*] [--bare] [--no-inherit] [--on-conflict=overwrite|merge|skip|abort]\n' +
-      '  ailib update [--workspace=<path>]\n' +
-      '  ailib add <module> [--workspace=<path>]\n' +
-      '  ailib remove <module> [--workspace=<path>]\n' +
-      '  ailib doctor [--workspace=<path>]\n' +
-      '  ailib uninstall [--all]\n' +
-      '  ailib slots list\n' +
-      '  ailib modules list [--language=<lang>]\n' +
-      '  ailib modules explain <module> [--language=<lang>]\n'
-  );
-}
-
-function parseFlags(args: string[]): CliFlags {
-  const flags: CliFlags = { _: [] };
-  for (const arg of args) {
-    if (!arg.startsWith('--')) {
-      flags._.push(arg);
-      continue;
-    }
-    const eqIndex = arg.indexOf('=');
-    if (eqIndex < 0) {
-      flags[arg.slice(2)] = true;
-      continue;
-    }
-    const k = arg.slice(2, eqIndex);
-    const raw = arg.slice(eqIndex + 1);
-    if (raw === 'true') flags[k] = true;
-    else if (raw === 'false') flags[k] = false;
-    else flags[k] = raw;
-  }
-  return flags;
-}
-
-function getStringFlag(flags: CliFlags, key: string): string | undefined {
-  const value = flags[key];
-  return typeof value === 'string' ? value : undefined;
 }
 
 async function slotsCommand({ packageRoot, flags }: Pick<CommandContext, 'packageRoot' | 'flags'>) {

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -1,0 +1,27 @@
+import type { CliFlags } from './types.ts';
+
+export function parseFlags(args: string[]): CliFlags {
+  const flags: CliFlags = { _: [] };
+  for (const arg of args) {
+    if (!arg.startsWith('--')) {
+      flags._.push(arg);
+      continue;
+    }
+    const eqIndex = arg.indexOf('=');
+    if (eqIndex < 0) {
+      flags[arg.slice(2)] = true;
+      continue;
+    }
+    const key = arg.slice(2, eqIndex);
+    const raw = arg.slice(eqIndex + 1);
+    if (raw === 'true') flags[key] = true;
+    else if (raw === 'false') flags[key] = false;
+    else flags[key] = raw;
+  }
+  return flags;
+}
+
+export function getStringFlag(flags: CliFlags, key: string): string | undefined {
+  const value = flags[key];
+  return typeof value === 'string' ? value : undefined;
+}

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -1,0 +1,14 @@
+export function printHelp() {
+  process.stdout.write(
+    'ailib commands:\n' +
+      '  ailib init [--language=<lang>] [--targets=a,b] [--modules=m1,m2] [--workspaces=a/*,b/*] [--bare] [--no-inherit] [--on-conflict=overwrite|merge|skip|abort]\n' +
+      '  ailib update [--workspace=<path>]\n' +
+      '  ailib add <module> [--workspace=<path>]\n' +
+      '  ailib remove <module> [--workspace=<path>]\n' +
+      '  ailib doctor [--workspace=<path>]\n' +
+      '  ailib uninstall [--all]\n' +
+      '  ailib slots list\n' +
+      '  ailib modules list [--language=<lang>]\n' +
+      '  ailib modules explain <module> [--language=<lang>]\n'
+  );
+}

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -1,0 +1,108 @@
+export type CliFlags = { _: string[] } & Record<string, string | boolean | string[] | undefined>;
+
+export interface RunOptions {
+  cwd?: string;
+  packageRoot?: string;
+}
+
+export interface ModuleDefinition {
+  slot: string;
+  requires?: string[];
+  conflicts_with?: string[];
+}
+
+export interface LanguageDefinition {
+  modules: Record<string, ModuleDefinition>;
+}
+
+export interface TargetDefinition {
+  output: string;
+  root_output?: string;
+  mode?: string;
+  display?: string;
+  frontmatter?: {
+    root?: string;
+    workspace?: string;
+  };
+}
+
+export interface SlotDefinition {
+  kind?: 'exclusive' | 'composable';
+  description?: string;
+}
+
+export interface SlotAliasMeta {
+  replacement: string;
+  deprecated_since?: string;
+  remove_in?: string;
+}
+
+export interface Registry {
+  version: string;
+  slots?: string[];
+  slot_defs?: Record<string, SlotDefinition>;
+  slot_aliases?: Record<string, string>;
+  slot_alias_meta?: Record<string, SlotAliasMeta>;
+  languages: Record<string, LanguageDefinition>;
+  targets: Record<string, TargetDefinition>;
+}
+
+export interface WorkspaceConfig {
+  $schema?: string;
+  extends?: string;
+  registry_ref?: string;
+  on_conflict?: string;
+  language?: string;
+  modules?: string[];
+  targets?: string[];
+  targets_removed?: string[];
+  docs_path?: string;
+  workspaces?: string[];
+}
+
+export interface ListOverrideScope {
+  add?: string[];
+  remove?: string[];
+  set?: string[];
+}
+
+export interface SlotOverrideRule {
+  set?: string;
+  remove?: boolean;
+}
+
+export interface WorkspaceOverrideConfig {
+  targets?: ListOverrideScope;
+  modules?: ListOverrideScope;
+  slots?: Record<string, SlotOverrideRule>;
+}
+
+export interface LocalOverrideConfig {
+  version: string;
+  default_override?: WorkspaceOverrideConfig;
+  workspace_overrides?: Record<string, WorkspaceOverrideConfig>;
+}
+
+export interface EffectiveWorkspaceConfig extends WorkspaceConfig {
+  language: string;
+  modules: string[];
+  targets: string[];
+  docs_path: string;
+  inheritedModules: string[];
+  localModules: string[];
+  warnings: string[];
+}
+
+export interface WorkspaceState {
+  effective: EffectiveWorkspaceConfig;
+  inheritedModules: string[];
+  localModules: string[];
+  requiredFiles: string[];
+  warnings: string[];
+}
+
+export interface CommandContext {
+  cwd: string;
+  packageRoot: string;
+  flags: CliFlags;
+}

--- a/test/cli-extracted-modules.test.ts
+++ b/test/cli-extracted-modules.test.ts
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getStringFlag, parseFlags } from '../src/cli/flags.ts';
+import { printHelp } from '../src/cli/help.ts';
+
+function captureStdoutSync(fn: () => void): string {
+  const chunks: string[] = [];
+  const mutableStdout = process.stdout as unknown as { write: typeof process.stdout.write };
+  const originalWrite = mutableStdout.write.bind(process.stdout);
+  mutableStdout.write = ((chunk, encoding, callback) => {
+    chunks.push(typeof chunk === 'string' ? chunk : chunk.toString());
+    const done = typeof encoding === 'function' ? encoding : callback;
+    if (typeof done === 'function') done();
+    return true;
+  }) as typeof process.stdout.write;
+
+  try {
+    fn();
+    return chunks.join('');
+  } finally {
+    mutableStdout.write = originalWrite;
+  }
+}
+
+test('parseFlags parses positional and typed boolean values', () => {
+  const flags = parseFlags(['init', '--language=typescript', '--dry-run=true', '--cache=false', '--verbose']);
+
+  assert.deepEqual(flags._, ['init']);
+  assert.equal(getStringFlag(flags, 'language'), 'typescript');
+  assert.equal(flags['dry-run'], true);
+  assert.equal(flags.cache, false);
+  assert.equal(flags.verbose, true);
+});
+
+test('getStringFlag returns undefined for non-string values', () => {
+  const flags = parseFlags(['--enabled=true', '--count=3']);
+  assert.equal(getStringFlag(flags, 'enabled'), undefined);
+  assert.equal(getStringFlag(flags, 'missing'), undefined);
+  assert.equal(getStringFlag(flags, 'count'), '3');
+});
+
+test('printHelp renders expected command listing', () => {
+  const output = captureStdoutSync(() => {
+    printHelp();
+  });
+
+  assert.match(output, /ailib commands:/);
+  assert.match(output, /ailib init/);
+  assert.match(output, /ailib modules explain <module>/);
+});


### PR DESCRIPTION
## Summary
- Decompose `src/cli.ts` by extracting flags parsing, help rendering, and shared CLI types into dedicated modules.
- Add TDD evidence expectations to workflow docs and PR template so test-first behavior is explicit.
- Add targeted tests for extracted helper modules while preserving command behavior.

## TDD evidence
- [x] Refactor/docs/chore only: no behavior change, so Red step is not applicable.
- Red evidence:
  - N/A (behavior-preserving decomposition)
- Green evidence:
  - `bun test test/cli-extracted-modules.test.ts`
  - `bun run check`

## Test plan
- [x] Run `bun test test/cli-extracted-modules.test.ts`
- [x] Run `bun run check`

Refs #85
Refs #84

Made with [Cursor](https://cursor.com)