### PR TITLE
test: colocate ts tests with source files

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { run } from './cli.ts';
+
+function captureStdoutSync(fn: () => void): string {
+  const chunks: string[] = [];
+  const mutableStdout = process.stdout as unknown as { write: typeof process.stdout.write };
+  const originalWrite = mutableStdout.write.bind(process.stdout);
+  mutableStdout.write = ((chunk, encoding, callback) => {
+    chunks.push(typeof chunk === 'string' ? chunk : chunk.toString());
+    const done = typeof encoding === 'function' ? encoding : callback;
+    if (typeof done === 'function') done();
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    fn();
+    return chunks.join('');
+  } finally {
+    mutableStdout.write = originalWrite;
+  }
+}
+
+test('run prints help for --help flag', async () => {
+  const output = captureStdoutSync(() => {
+    run(['--help'], { cwd: process.cwd(), packageRoot: process.cwd() });
+  });
+  assert.match(output, /ailib commands:/);
+});
+
+test('run rejects unknown command', async () => {
+  await assert.rejects(
+    async () => run(['unknown-command'], { cwd: process.cwd(), packageRoot: process.cwd() }),
+    /Unknown command: unknown-command/
+  );
+});

--- a/src/cli/flags.test.ts
+++ b/src/cli/flags.test.ts
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getStringFlag, parseFlags } from './flags.ts';
+
+test('parseFlags parses positional and typed boolean values', () => {
+  const flags = parseFlags(['init', '--language=typescript', '--dry-run=true', '--cache=false', '--verbose']);
+
+  assert.deepEqual(flags._, ['init']);
+  assert.equal(getStringFlag(flags, 'language'), 'typescript');
+  assert.equal(flags['dry-run'], true);
+  assert.equal(flags.cache, false);
+  assert.equal(flags.verbose, true);
+});
+
+test('getStringFlag returns undefined for non-string values', () => {
+  const flags = parseFlags(['--enabled=true', '--count=3']);
+  assert.equal(getStringFlag(flags, 'enabled'), undefined);
+  assert.equal(getStringFlag(flags, 'missing'), undefined);
+  assert.equal(getStringFlag(flags, 'count'), '3');
+});

--- a/src/cli/help.test.ts
+++ b/src/cli/help.test.ts
@@ -1,8 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { getStringFlag, parseFlags } from '../src/cli/flags.ts';
-import { printHelp } from '../src/cli/help.ts';
+import { printHelp } from './help.ts';
 
 function captureStdoutSync(fn: () => void): string {
   const chunks: string[] = [];
@@ -22,23 +21,6 @@ function captureStdoutSync(fn: () => void): string {
     mutableStdout.write = originalWrite;
   }
 }
-
-test('parseFlags parses positional and typed boolean values', () => {
-  const flags = parseFlags(['init', '--language=typescript', '--dry-run=true', '--cache=false', '--verbose']);
-
-  assert.deepEqual(flags._, ['init']);
-  assert.equal(getStringFlag(flags, 'language'), 'typescript');
-  assert.equal(flags['dry-run'], true);
-  assert.equal(flags.cache, false);
-  assert.equal(flags.verbose, true);
-});
-
-test('getStringFlag returns undefined for non-string values', () => {
-  const flags = parseFlags(['--enabled=true', '--count=3']);
-  assert.equal(getStringFlag(flags, 'enabled'), undefined);
-  assert.equal(getStringFlag(flags, 'missing'), undefined);
-  assert.equal(getStringFlag(flags, 'count'), '3');
-});
 
 test('printHelp renders expected command listing', () => {
   const output = captureStdoutSync(() => {

--- a/src/cli/types.test.ts
+++ b/src/cli/types.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { CliFlags, CommandContext, RunOptions, WorkspaceConfig } from './types.ts';
+
+test('types module supports expected shape usage', () => {
+  const runOptions: RunOptions = { cwd: '/tmp/project', packageRoot: '/tmp/pkg' };
+  const flags: CliFlags = { _: ['init'], language: 'typescript', dryRun: true };
+  const config: WorkspaceConfig = { language: 'typescript', modules: ['eslint'], targets: ['claude-code'] };
+  const context: CommandContext = { cwd: '/tmp/project', packageRoot: '/tmp/pkg', flags };
+
+  assert.equal(runOptions.cwd, '/tmp/project');
+  assert.equal(context.flags._[0], 'init');
+  assert.equal(config.modules?.[0], 'eslint');
+});

--- a/tools/check-coverage-threshold.test.ts
+++ b/tools/check-coverage-threshold.test.ts
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+
+test('check-coverage-threshold passes for sufficient line coverage', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ailib-coverage-pass-'));
+  const lcovPath = path.join(tmpDir, 'lcov.info');
+  await fs.writeFile(lcovPath, 'DA:1,1\nDA:2,1\nDA:3,0\n', 'utf8');
+
+  const result = spawnSync('bun', ['tools/check-coverage-threshold.ts', '--file', lcovPath, '--min-lines', '60'], {
+    cwd: packageRoot,
+    encoding: 'utf8'
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Coverage threshold check passed/);
+});
+
+test('check-coverage-threshold fails when below threshold', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ailib-coverage-fail-'));
+  const lcovPath = path.join(tmpDir, 'lcov.info');
+  await fs.writeFile(lcovPath, 'DA:1,1\nDA:2,0\nDA:3,0\n', 'utf8');
+
+  const result = spawnSync('bun', ['tools/check-coverage-threshold.ts', '--file', lcovPath, '--min-lines', '90'], {
+    cwd: packageRoot,
+    encoding: 'utf8'
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /below threshold/);
+});

--- a/tools/check-standards.test.ts
+++ b/tools/check-standards.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+
+test('check-standards succeeds for required project standards files', () => {
+  const result = spawnSync('bun', ['tools/check-standards.ts'], {
+    cwd: packageRoot,
+    encoding: 'utf8'
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /standards checks passed/);
+});

--- a/tools/generate-coverage-audit.test.ts
+++ b/tools/generate-coverage-audit.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+
+test('generate-coverage-audit check mode succeeds', () => {
+  const result = spawnSync('bun', ['tools/generate-coverage-audit.ts', '--check'], {
+    cwd: packageRoot,
+    encoding: 'utf8'
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /module-coverage-audit\.md is up to date/);
+});

--- a/tools/generate-module-catalog.test.ts
+++ b/tools/generate-module-catalog.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+
+test('generate-module-catalog check mode succeeds', () => {
+  const result = spawnSync('bun', ['tools/generate-module-catalog.ts', '--check'], {
+    cwd: packageRoot,
+    encoding: 'utf8'
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /module-catalog\.md is up to date/);
+});

--- a/tools/sync-registry.test.ts
+++ b/tools/sync-registry.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+
+test('sync-registry check mode succeeds', () => {
+  const result = spawnSync('bun', ['tools/sync-registry.ts', '--check'], {
+    cwd: packageRoot,
+    encoding: 'utf8'
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /registry\.json is up to date/);
+});


### PR DESCRIPTION
## Summary
- colocate tests beside source files for extracted CLI modules (`src/cli/*.test.ts`)
- add colocated tests for TypeScript tooling scripts under `tools/*.test.ts`
- remove centralized extracted-modules test in favor of source-local test ownership

## Test plan
- [x] `bun test src/cli.test.ts src/cli/flags.test.ts src/cli/help.test.ts src/cli/types.test.ts tools/sync-registry.test.ts tools/check-coverage-threshold.test.ts tools/generate-coverage-audit.test.ts tools/check-standards.test.ts tools/generate-module-catalog.test.ts`
- [x] `bun run check`
- [x] verified `MISSING_COUNT=0` for colocated `src`/`tools` TypeScript tests

Refs #87
Refs #85
Refs #84

Made with [Cursor](https://cursor.com)