### PR TITLE
refactor: extract cli command dispatcher

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { run } from './cli.ts';
+
+function captureStdoutSync(fn: () => void): string {
+  const chunks: string[] = [];
+  const mutableStdout = process.stdout as unknown as { write: typeof process.stdout.write };
+  const originalWrite = mutableStdout.write.bind(process.stdout);
+  mutableStdout.write = ((chunk, encoding, callback) => {
+    chunks.push(typeof chunk === 'string' ? chunk : chunk.toString());
+    const done = typeof encoding === 'function' ? encoding : callback;
+    if (typeof done === 'function') done();
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    fn();
+    return chunks.join('');
+  } finally {
+    mutableStdout.write = originalWrite;
+  }
+}
+
+test('run prints help for --help flag', async () => {
+  const output = captureStdoutSync(() => {
+    run(['--help'], { cwd: process.cwd(), packageRoot: process.cwd() });
+  });
+  assert.match(output, /ailib commands:/);
+});
+
+test('run rejects unknown command', async () => {
+  await assert.rejects(
+    async () => run(['unknown-command'], { cwd: process.cwd(), packageRoot: process.cwd() }),
+    /Unknown command: unknown-command/
+  );
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs/promises';
 import { constants as fsConstants } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
+import { executeCommand } from './cli/dispatch.ts';
 import { getStringFlag, parseFlags } from './cli/flags.ts';
 import { printHelp } from './cli/help.ts';
 import type {
@@ -39,40 +40,28 @@ export async function run(argv: string[], options: RunOptions = {}) {
   const packageRoot = options.packageRoot ?? path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
 
   const [command, ...rest] = argv;
-  if (!command || command === '--help' || command === '-h') {
-    printHelp();
-    return;
-  }
-
   const flags = parseFlags(rest);
-  switch (command) {
-    case 'init':
-      await initCommand({ cwd, packageRoot, flags });
-      break;
-    case 'update':
-      await updateCommand({ cwd, packageRoot, flags });
-      break;
-    case 'add':
-      await addCommand({ cwd, packageRoot, flags, moduleId: flags._[0] });
-      break;
-    case 'remove':
-      await removeCommand({ cwd, packageRoot, flags, moduleId: flags._[0] });
-      break;
-    case 'doctor':
-      await doctorCommand({ cwd, packageRoot, flags });
-      break;
-    case 'uninstall':
-      await uninstallCommand({ cwd, packageRoot, flags });
-      break;
-    case 'slots':
-      await slotsCommand({ packageRoot, flags });
-      break;
-    case 'modules':
-      await modulesCommand({ packageRoot, flags });
-      break;
-    default:
-      throw new Error(`Unknown command: ${command}`);
-  }
+  const context: CommandContext = { cwd, packageRoot, flags };
+
+  await executeCommand({
+    command,
+    context,
+    handlers: createCommandHandlers(),
+    printHelp
+  });
+}
+
+function createCommandHandlers() {
+  return {
+    init: async (context: CommandContext) => initCommand(context),
+    update: async (context: CommandContext) => updateCommand(context),
+    add: async (context: CommandContext) => addCommand(context),
+    remove: async (context: CommandContext) => removeCommand(context),
+    doctor: async (context: CommandContext) => doctorCommand(context),
+    uninstall: async (context: CommandContext) => uninstallCommand(context),
+    slots: async (context: CommandContext) => slotsCommand(context),
+    modules: async (context: CommandContext) => modulesCommand(context)
+  };
 }
 
 async function slotsCommand({ packageRoot, flags }: Pick<CommandContext, 'packageRoot' | 'flags'>) {
@@ -216,7 +205,8 @@ async function updateCommand({ cwd, packageRoot, flags }: CommandContext) {
   process.stdout.write('ailib updated\n');
 }
 
-async function addCommand({ cwd, packageRoot, flags, moduleId }: CommandContext & { moduleId?: string }) {
+async function addCommand({ cwd, packageRoot, flags }: CommandContext) {
+  const moduleId = flags._[0];
   ensure(moduleId, 'Usage: ailib add <module>');
   const context = await resolveContext(cwd);
   const registry = await readJson<Registry>(path.join(packageRoot, 'registry.json'));
@@ -252,7 +242,8 @@ async function addCommand({ cwd, packageRoot, flags, moduleId }: CommandContext 
   process.stdout.write(`module added: ${moduleId}\n`);
 }
 
-async function removeCommand({ cwd, packageRoot, flags, moduleId }: CommandContext & { moduleId?: string }) {
+async function removeCommand({ cwd, packageRoot, flags }: CommandContext) {
+  const moduleId = flags._[0];
   ensure(moduleId, 'Usage: ailib remove <module>');
   const context = await resolveContext(cwd);
   const targetWorkspace = resolveDefaultWorkspaceForMutation(context, getStringFlag(flags, 'workspace'));

--- a/src/cli/dispatch.test.ts
+++ b/src/cli/dispatch.test.ts
@@ -1,0 +1,87 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { executeCommand, type CommandHandlers } from './dispatch.ts';
+import { parseFlags } from './flags.ts';
+import type { CommandContext } from './types.ts';
+
+function createContext(args: string[]): CommandContext {
+  return {
+    cwd: '/tmp/workspace',
+    packageRoot: '/tmp/package',
+    flags: parseFlags(args)
+  };
+}
+
+test('executeCommand prints help when command is empty', async () => {
+  let printHelpCalls = 0;
+  const handlers: CommandHandlers = {};
+
+  await executeCommand({
+    command: undefined,
+    context: createContext([]),
+    handlers,
+    printHelp: () => {
+      printHelpCalls += 1;
+    }
+  });
+
+  assert.equal(printHelpCalls, 1);
+});
+
+test('executeCommand prints help for help aliases', async () => {
+  let printHelpCalls = 0;
+  const handlers: CommandHandlers = {};
+
+  await executeCommand({
+    command: '--help',
+    context: createContext([]),
+    handlers,
+    printHelp: () => {
+      printHelpCalls += 1;
+    }
+  });
+
+  await executeCommand({
+    command: '-h',
+    context: createContext([]),
+    handlers,
+    printHelp: () => {
+      printHelpCalls += 1;
+    }
+  });
+
+  assert.equal(printHelpCalls, 2);
+});
+
+test('executeCommand dispatches to registered handler', async () => {
+  const calls: string[] = [];
+  const handlers: CommandHandlers = {
+    update: async (context) => {
+      calls.push(context.cwd);
+      calls.push(context.packageRoot);
+      calls.push(context.flags._[0] || '');
+    }
+  };
+
+  await executeCommand({
+    command: 'update',
+    context: createContext(['service-a']),
+    handlers,
+    printHelp: () => {}
+  });
+
+  assert.deepEqual(calls, ['/tmp/workspace', '/tmp/package', 'service-a']);
+});
+
+test('executeCommand rejects unknown commands', async () => {
+  await assert.rejects(
+    executeCommand({
+      command: 'unknown',
+      context: createContext([]),
+      handlers: {},
+      printHelp: () => {}
+    }),
+    /Unknown command: unknown/
+  );
+});

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -1,0 +1,27 @@
+import type { CommandContext } from './types.ts';
+
+export type CommandHandler = (context: CommandContext) => Promise<void>;
+export type CommandHandlers = Record<string, CommandHandler>;
+
+export async function executeCommand({
+  command,
+  context,
+  handlers,
+  printHelp
+}: {
+  command: string | undefined;
+  context: CommandContext;
+  handlers: CommandHandlers;
+  printHelp: () => void;
+}): Promise<void> {
+  if (!command || command === '--help' || command === '-h') {
+    printHelp();
+    return;
+  }
+
+  const handler = handlers[command];
+  if (!handler) {
+    throw new Error(`Unknown command: ${command}`);
+  }
+  await handler(context);
+}

--- a/src/cli/flags.test.ts
+++ b/src/cli/flags.test.ts
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getStringFlag, parseFlags } from './flags.ts';
+
+test('parseFlags parses positional and typed boolean values', () => {
+  const flags = parseFlags(['init', '--language=typescript', '--dry-run=true', '--cache=false', '--verbose']);
+
+  assert.deepEqual(flags._, ['init']);
+  assert.equal(getStringFlag(flags, 'language'), 'typescript');
+  assert.equal(flags['dry-run'], true);
+  assert.equal(flags.cache, false);
+  assert.equal(flags.verbose, true);
+});
+
+test('getStringFlag returns undefined for non-string values', () => {
+  const flags = parseFlags(['--enabled=true', '--count=3']);
+  assert.equal(getStringFlag(flags, 'enabled'), undefined);
+  assert.equal(getStringFlag(flags, 'missing'), undefined);
+  assert.equal(getStringFlag(flags, 'count'), '3');
+});

--- a/src/cli/help.test.ts
+++ b/src/cli/help.test.ts
@@ -1,8 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { getStringFlag, parseFlags } from '../src/cli/flags.ts';
-import { printHelp } from '../src/cli/help.ts';
+import { printHelp } from './help.ts';
 
 function captureStdoutSync(fn: () => void): string {
   const chunks: string[] = [];
@@ -22,23 +21,6 @@ function captureStdoutSync(fn: () => void): string {
     mutableStdout.write = originalWrite;
   }
 }
-
-test('parseFlags parses positional and typed boolean values', () => {
-  const flags = parseFlags(['init', '--language=typescript', '--dry-run=true', '--cache=false', '--verbose']);
-
-  assert.deepEqual(flags._, ['init']);
-  assert.equal(getStringFlag(flags, 'language'), 'typescript');
-  assert.equal(flags['dry-run'], true);
-  assert.equal(flags.cache, false);
-  assert.equal(flags.verbose, true);
-});
-
-test('getStringFlag returns undefined for non-string values', () => {
-  const flags = parseFlags(['--enabled=true', '--count=3']);
-  assert.equal(getStringFlag(flags, 'enabled'), undefined);
-  assert.equal(getStringFlag(flags, 'missing'), undefined);
-  assert.equal(getStringFlag(flags, 'count'), '3');
-});
 
 test('printHelp renders expected command listing', () => {
   const output = captureStdoutSync(() => {

--- a/src/cli/types.test.ts
+++ b/src/cli/types.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { CliFlags, CommandContext, RunOptions, WorkspaceConfig } from './types.ts';
+
+test('types module supports expected shape usage', () => {
+  const runOptions: RunOptions = { cwd: '/tmp/project', packageRoot: '/tmp/pkg' };
+  const flags: CliFlags = { _: ['init'], language: 'typescript', dryRun: true };
+  const config: WorkspaceConfig = { language: 'typescript', modules: ['eslint'], targets: ['claude-code'] };
+  const context: CommandContext = { cwd: '/tmp/project', packageRoot: '/tmp/pkg', flags };
+
+  assert.equal(runOptions.cwd, '/tmp/project');
+  assert.equal(context.flags._[0], 'init');
+  assert.equal(config.modules?.[0], 'eslint');
+});

--- a/tools/check-coverage-threshold.test.ts
+++ b/tools/check-coverage-threshold.test.ts
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+
+test('check-coverage-threshold passes for sufficient line coverage', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ailib-coverage-pass-'));
+  const lcovPath = path.join(tmpDir, 'lcov.info');
+  await fs.writeFile(lcovPath, 'DA:1,1\nDA:2,1\nDA:3,0\n', 'utf8');
+
+  const result = spawnSync('bun', ['tools/check-coverage-threshold.ts', '--file', lcovPath, '--min-lines', '60'], {
+    cwd: packageRoot,
+    encoding: 'utf8'
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Coverage threshold check passed/);
+});
+
+test('check-coverage-threshold fails when below threshold', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ailib-coverage-fail-'));
+  const lcovPath = path.join(tmpDir, 'lcov.info');
+  await fs.writeFile(lcovPath, 'DA:1,1\nDA:2,0\nDA:3,0\n', 'utf8');
+
+  const result = spawnSync('bun', ['tools/check-coverage-threshold.ts', '--file', lcovPath, '--min-lines', '90'], {
+    cwd: packageRoot,
+    encoding: 'utf8'
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /below threshold/);
+});

--- a/tools/check-standards.test.ts
+++ b/tools/check-standards.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+
+test('check-standards succeeds for required project standards files', () => {
+  const result = spawnSync('bun', ['tools/check-standards.ts'], {
+    cwd: packageRoot,
+    encoding: 'utf8'
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /standards checks passed/);
+});

--- a/tools/generate-coverage-audit.test.ts
+++ b/tools/generate-coverage-audit.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+
+test('generate-coverage-audit check mode succeeds', () => {
+  const result = spawnSync('bun', ['tools/generate-coverage-audit.ts', '--check'], {
+    cwd: packageRoot,
+    encoding: 'utf8'
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /module-coverage-audit\.md is up to date/);
+});

--- a/tools/generate-module-catalog.test.ts
+++ b/tools/generate-module-catalog.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+
+test('generate-module-catalog check mode succeeds', () => {
+  const result = spawnSync('bun', ['tools/generate-module-catalog.ts', '--check'], {
+    cwd: packageRoot,
+    encoding: 'utf8'
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /module-catalog\.md is up to date/);
+});

--- a/tools/sync-registry.test.ts
+++ b/tools/sync-registry.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+
+test('sync-registry check mode succeeds', () => {
+  const result = spawnSync('bun', ['tools/sync-registry.ts', '--check'], {
+    cwd: packageRoot,
+    encoding: 'utf8'
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /registry\.json is up to date/);
+});


### PR DESCRIPTION
## Summary
- extract command routing into `src/cli/dispatch.ts` to separate orchestration from command implementations
- replace `run` switch-case with an explicit command handler map for clearer extension points
- align `add`/`remove` command signatures to read module inputs from parsed flags in one place
- add colocated tests for dispatch behavior in `src/cli/dispatch.test.ts`

## TDD Evidence
- [x] Behavior change: I added/updated a failing test first (Red), then implemented (Green), then refactored.
- [ ] Refactor/docs/chore only: no behavior change, so Red step is not applicable.
- Red evidence:
  - `bun test src/cli/dispatch.test.ts` (fails before adding dispatcher implementation and handler wiring)
- Green evidence:
  - `bun test src/cli/dispatch.test.ts src/cli.test.ts test/cli.test.ts`
  - `bun run check`

## Test plan
- [x] `bun test src/cli/dispatch.test.ts src/cli.test.ts test/cli.test.ts`
- [x] `bun run check`

Refs #86
Refs #83

Made with [Cursor](https://cursor.com)