### PR TITLE
refactor: extract override validation module

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import process from 'node:process';
 import { executeCommand } from './cli/dispatch.ts';
 import { getStringFlag, parseFlags } from './cli/flags.ts';
 import { printHelp } from './cli/help.ts';
+import { isRecord, validateWorkspaceOverride } from './cli/override-validation.ts';
 import type {
   CliFlags,
   CommandContext,
@@ -841,7 +842,8 @@ async function validateLocalOverrideConfig({
       ...validateWorkspaceOverride({
         override: config.default_override,
         label: 'default_override',
-        registry
+        registry,
+        canonicalSlot: (slot) => canonicalSlot(registry, slot)
       })
     );
   }
@@ -862,7 +864,8 @@ async function validateLocalOverrideConfig({
           ...validateWorkspaceOverride({
             override,
             label: `workspace_overrides.${workspaceKey}`,
-            registry
+            registry,
+            canonicalSlot: (slot) => canonicalSlot(registry, slot)
           })
         );
       }
@@ -870,129 +873,6 @@ async function validateLocalOverrideConfig({
   }
 
   return errors;
-}
-
-function validateWorkspaceOverride({
-  override,
-  label,
-  registry
-}: {
-  override: unknown;
-  label: string;
-  registry: Registry;
-}): string[] {
-  const errors: string[] = [];
-  if (!isRecord(override)) {
-    return [`'${label}' must be an object`];
-  }
-
-  const allowed = new Set(['targets', 'modules', 'slots']);
-  for (const key of Object.keys(override)) {
-    if (!allowed.has(key)) {
-      errors.push(`'${label}' has unsupported key '${key}'`);
-    }
-  }
-
-  if (override.targets !== undefined) {
-    errors.push(
-      ...validateListOverrideScope({
-        scope: override.targets,
-        label: `${label}.targets`,
-        validSet: new Set(Object.keys(registry.targets || {})),
-        valueLabel: 'target'
-      })
-    );
-  }
-
-  if (override.modules !== undefined) {
-    errors.push(
-      ...validateListOverrideScope({
-        scope: override.modules,
-        label: `${label}.modules`,
-        valueLabel: 'module'
-      })
-    );
-  }
-
-  if (override.slots !== undefined) {
-    if (!isRecord(override.slots)) {
-      errors.push(`'${label}.slots' must be an object`);
-    } else {
-      const knownSlots = new Set(registry.slots || []);
-      for (const [slotKey, rule] of Object.entries(override.slots)) {
-        const slot = canonicalSlot(registry, slotKey);
-        if (!slot || !knownSlots.has(slot)) {
-          errors.push(`'${label}.slots.${slotKey}' references unknown slot`);
-        }
-        if (!isRecord(rule)) {
-          errors.push(`'${label}.slots.${slotKey}' must be an object`);
-          continue;
-        }
-        for (const key of Object.keys(rule)) {
-          if (key !== 'set' && key !== 'remove') {
-            errors.push(`'${label}.slots.${slotKey}' has unsupported key '${key}'`);
-          }
-        }
-        if (rule.set !== undefined && typeof rule.set !== 'string') {
-          errors.push(`'${label}.slots.${slotKey}.set' must be a string`);
-        }
-        if (rule.remove !== undefined && typeof rule.remove !== 'boolean') {
-          errors.push(`'${label}.slots.${slotKey}.remove' must be a boolean`);
-        }
-      }
-    }
-  }
-
-  return errors;
-}
-
-function validateListOverrideScope({
-  scope,
-  label,
-  validSet,
-  valueLabel
-}: {
-  scope: unknown;
-  label: string;
-  validSet?: Set<string>;
-  valueLabel: string;
-}): string[] {
-  const errors: string[] = [];
-  if (!isRecord(scope)) {
-    return [`'${label}' must be an object`];
-  }
-
-  const allowed = new Set(['set', 'add', 'remove']);
-  for (const key of Object.keys(scope)) {
-    if (!allowed.has(key)) {
-      errors.push(`'${label}' has unsupported key '${key}'`);
-    }
-  }
-
-  const validateList = (value: unknown, key: string) => {
-    if (!Array.isArray(value)) {
-      errors.push(`'${label}.${key}' must be an array`);
-      return;
-    }
-    for (const item of value) {
-      if (typeof item !== 'string' || !item.trim()) {
-        errors.push(`'${label}.${key}' must contain non-empty strings`);
-        continue;
-      }
-      if (validSet && !validSet.has(item)) {
-        errors.push(`'${label}.${key}' contains unknown ${valueLabel} '${item}'`);
-      }
-    }
-  };
-
-  if (scope.set !== undefined) validateList(scope.set, 'set');
-  if (scope.add !== undefined) validateList(scope.add, 'add');
-  if (scope.remove !== undefined) validateList(scope.remove, 'remove');
-  return errors;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 async function assertLocalOverridesValid({

--- a/src/cli/override-validation.test.ts
+++ b/src/cli/override-validation.test.ts
@@ -1,0 +1,131 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isRecord, validateListOverrideScope, validateWorkspaceOverride } from './override-validation.ts';
+import type { Registry } from './types.ts';
+
+const registry: Registry = {
+  version: '1.0.0',
+  slots: ['frontend_framework', 'linter'],
+  slot_aliases: { framework: 'frontend_framework' },
+  slot_alias_meta: {
+    framework: {
+      replacement: 'frontend_framework',
+      deprecated_since: '1.0.0',
+      remove_in: '2.0.0'
+    }
+  },
+  languages: {
+    typescript: {
+      modules: {
+        eslint: { slot: 'linter' },
+        nextjs: { slot: 'frontend_framework' }
+      }
+    }
+  },
+  targets: {
+    'claude-code': { output: 'CLAUDE.md' },
+    cursor: { output: '.cursor/rules/ailib.mdc' }
+  }
+};
+
+test('isRecord detects plain objects only', () => {
+  assert.equal(isRecord({}), true);
+  assert.equal(isRecord(null), false);
+  assert.equal(isRecord([]), false);
+  assert.equal(isRecord('text'), false);
+});
+
+test('validateListOverrideScope validates shape and unknown values', () => {
+  const errors = validateListOverrideScope({
+    scope: { set: ['claude-code', 'unknown'], add: 'invalid' },
+    label: 'default_override.targets',
+    validSet: new Set(['claude-code', 'cursor']),
+    valueLabel: 'target'
+  });
+
+  assert.match(errors.join('\n'), /contains unknown target 'unknown'/);
+  assert.match(errors.join('\n'), /'default_override\.targets\.add' must be an array/);
+});
+
+test('validateWorkspaceOverride validates non-object values and unsupported keys', () => {
+  const nonObjectErrors = validateWorkspaceOverride({
+    override: false,
+    label: 'default_override',
+    registry,
+    canonicalSlot: (slot) => slot ?? null
+  });
+  assert.match(nonObjectErrors.join('\n'), /'default_override' must be an object/);
+
+  const errors = validateWorkspaceOverride({
+    override: { unknown: true },
+    label: 'default_override',
+    registry,
+    canonicalSlot: (slot) => slot ?? null
+  });
+
+  assert.match(errors.join('\n'), /'default_override' has unsupported key 'unknown'/);
+});
+
+test('validateWorkspaceOverride validates slots and alias resolution', () => {
+  const errors = validateWorkspaceOverride({
+    override: {
+      slots: {
+        framework: { set: 123, remove: 'nope', extra: true },
+        invalid_slot: { set: 'nextjs' }
+      }
+    },
+    label: 'workspace_overrides.apps/web',
+    registry,
+    canonicalSlot: (slot) => {
+      if (!slot) return null;
+      return registry.slot_aliases?.[slot] || slot;
+    }
+  });
+
+  const output = errors.join('\n');
+  assert.match(output, /references unknown slot/);
+  assert.match(output, /has unsupported key 'extra'/);
+  assert.match(output, /\.set' must be a string/);
+  assert.match(output, /\.remove' must be a boolean/);
+});
+
+test('validateWorkspaceOverride validates slot scopes and slot rule objects', () => {
+  const errors = validateWorkspaceOverride({
+    override: {
+      slots: {
+        linter: 'invalid'
+      }
+    },
+    label: 'workspace_overrides.apps/web',
+    registry,
+    canonicalSlot: (slot) => slot ?? null
+  });
+
+  assert.match(errors.join('\n'), /'workspace_overrides\.apps\/web\.slots\.linter' must be an object/);
+
+  const nonObjectSlotsErrors = validateWorkspaceOverride({
+    override: { slots: true },
+    label: 'workspace_overrides.apps/web',
+    registry,
+    canonicalSlot: (slot) => slot ?? null
+  });
+  assert.match(nonObjectSlotsErrors.join('\n'), /'workspace_overrides\.apps\/web\.slots' must be an object/);
+});
+
+test('validateListOverrideScope validates non-object and unsupported keys', () => {
+  const nonObjectErrors = validateListOverrideScope({
+    scope: null,
+    label: 'workspace_overrides.apps/web.modules',
+    valueLabel: 'module'
+  });
+  assert.match(nonObjectErrors.join('\n'), /must be an object/);
+
+  const unsupportedErrors = validateListOverrideScope({
+    scope: { invalid: ['eslint'], set: [''] },
+    label: 'workspace_overrides.apps/web.modules',
+    valueLabel: 'module'
+  });
+  assert.match(unsupportedErrors.join('\n'), /has unsupported key 'invalid'/);
+  assert.match(unsupportedErrors.join('\n'), /must contain non-empty strings/);
+});

--- a/src/cli/override-validation.ts
+++ b/src/cli/override-validation.ts
@@ -1,0 +1,126 @@
+import type { Registry } from './types.ts';
+
+export function validateWorkspaceOverride({
+  override,
+  label,
+  registry,
+  canonicalSlot
+}: {
+  override: unknown;
+  label: string;
+  registry: Registry;
+  canonicalSlot: (slot: string | undefined) => string | null;
+}): string[] {
+  const errors: string[] = [];
+  if (!isRecord(override)) {
+    return [`'${label}' must be an object`];
+  }
+
+  const allowed = new Set(['targets', 'modules', 'slots']);
+  for (const key of Object.keys(override)) {
+    if (!allowed.has(key)) {
+      errors.push(`'${label}' has unsupported key '${key}'`);
+    }
+  }
+
+  if (override.targets !== undefined) {
+    errors.push(
+      ...validateListOverrideScope({
+        scope: override.targets,
+        label: `${label}.targets`,
+        validSet: new Set(Object.keys(registry.targets || {})),
+        valueLabel: 'target'
+      })
+    );
+  }
+
+  if (override.modules !== undefined) {
+    errors.push(
+      ...validateListOverrideScope({
+        scope: override.modules,
+        label: `${label}.modules`,
+        valueLabel: 'module'
+      })
+    );
+  }
+
+  if (override.slots !== undefined) {
+    if (!isRecord(override.slots)) {
+      errors.push(`'${label}.slots' must be an object`);
+    } else {
+      const knownSlots = new Set(registry.slots || []);
+      for (const [slotKey, rule] of Object.entries(override.slots)) {
+        const slot = canonicalSlot(slotKey);
+        if (!slot || !knownSlots.has(slot)) {
+          errors.push(`'${label}.slots.${slotKey}' references unknown slot`);
+        }
+        if (!isRecord(rule)) {
+          errors.push(`'${label}.slots.${slotKey}' must be an object`);
+          continue;
+        }
+        for (const key of Object.keys(rule)) {
+          if (key !== 'set' && key !== 'remove') {
+            errors.push(`'${label}.slots.${slotKey}' has unsupported key '${key}'`);
+          }
+        }
+        if (rule.set !== undefined && typeof rule.set !== 'string') {
+          errors.push(`'${label}.slots.${slotKey}.set' must be a string`);
+        }
+        if (rule.remove !== undefined && typeof rule.remove !== 'boolean') {
+          errors.push(`'${label}.slots.${slotKey}.remove' must be a boolean`);
+        }
+      }
+    }
+  }
+
+  return errors;
+}
+
+export function validateListOverrideScope({
+  scope,
+  label,
+  validSet,
+  valueLabel
+}: {
+  scope: unknown;
+  label: string;
+  validSet?: Set<string>;
+  valueLabel: string;
+}): string[] {
+  const errors: string[] = [];
+  if (!isRecord(scope)) {
+    return [`'${label}' must be an object`];
+  }
+
+  const allowed = new Set(['set', 'add', 'remove']);
+  for (const key of Object.keys(scope)) {
+    if (!allowed.has(key)) {
+      errors.push(`'${label}' has unsupported key '${key}'`);
+    }
+  }
+
+  const validateList = (value: unknown, key: string) => {
+    if (!Array.isArray(value)) {
+      errors.push(`'${label}.${key}' must be an array`);
+      return;
+    }
+    for (const item of value) {
+      if (typeof item !== 'string' || !item.trim()) {
+        errors.push(`'${label}.${key}' must contain non-empty strings`);
+        continue;
+      }
+      if (validSet && !validSet.has(item)) {
+        errors.push(`'${label}.${key}' contains unknown ${valueLabel} '${item}'`);
+      }
+    }
+  };
+
+  if (scope.set !== undefined) validateList(scope.set, 'set');
+  if (scope.add !== undefined) validateList(scope.add, 'add');
+  if (scope.remove !== undefined) validateList(scope.remove, 'remove');
+  return errors;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Summary
- extract local override validation logic into `src/cli/override-validation.ts` to reduce `src/cli.ts` responsibility scope
- add colocated tests in `src/cli/override-validation.test.ts` for validation shape, slot alias resolution, and error branch coverage
- keep runtime behavior intact while improving readability, SOLID boundaries, and maintainability

## TDD Evidence
- [ ] Behavior change: I added/updated a failing test first (Red), then implemented (Green), then refactored.
- [x] Refactor/docs/chore only: no behavior change, so Red step is not applicable.
- Red evidence:
  - Not applicable (refactor with behavior-parity intent)
- Green evidence:
  - `bun test src/cli/override-validation.test.ts test/cli.test.ts`
  - `bun run check`

## Test plan
- [x] `bun test src/cli/override-validation.test.ts test/cli.test.ts`
- [x] `bun run check`

Refs #85
Refs #84
Refs #87
Refs #83

Made with [Cursor](https://cursor.com)