### PR TITLE
refactor: extract workspace discovery module

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { executeCommand } from './cli/dispatch.ts';
 import { getStringFlag, parseFlags } from './cli/flags.ts';
 import { printHelp } from './cli/help.ts';
 import { isRecord, validateWorkspaceOverride } from './cli/override-validation.ts';
+import { listWorkspaceDirs } from './cli/workspace-discovery.ts';
 import type {
   CliFlags,
   CommandContext,
@@ -31,9 +32,6 @@ const AILIB_BLOCK_END = '<!-- ailib:end -->';
 const CONFIG_FILE = 'ailib.config.json';
 const LOCAL_OVERRIDE_FILE = 'ailib.local.json';
 const LOCK_FILE = 'ailib.lock';
-const AUTO_DISCOVERY_MAX_DEPTH = 4;
-const GLOB_DISCOVERY_MAX_DEPTH = 32;
-const SKIP_DIRS = new Set(['.git', 'node_modules', 'dist', 'build', '.venv']);
 const WARNED_SLOT_ALIASES = new Set();
 
 export async function run(argv: string[], options: RunOptions = {}) {
@@ -1288,152 +1286,6 @@ async function writeRootLock({
   }
 
   await fs.writeFile(path.join(rootDir, LOCK_FILE), `${JSON.stringify(lock, null, 2)}\n`, 'utf8');
-}
-
-async function listWorkspaceDirs({
-  rootDir,
-  rootConfig,
-  workspaceOverride
-}: {
-  rootDir: string;
-  rootConfig: WorkspaceConfig;
-  workspaceOverride?: string;
-}) {
-  if (workspaceOverride) {
-    const abs = resolveWorkspacePath(rootDir, workspaceOverride);
-    ensure(await exists(path.join(abs, CONFIG_FILE)), `Workspace has no ${CONFIG_FILE}: ${workspaceOverride}`);
-    return [abs];
-  }
-
-  const dirs = [path.resolve(rootDir)];
-  const discovered = await discoverServiceWorkspaces({ rootDir, rootConfig });
-  for (const dir of discovered) {
-    if (!dirs.includes(dir)) dirs.push(dir);
-  }
-  return dirs;
-}
-
-async function discoverServiceWorkspaces({ rootDir, rootConfig }: { rootDir: string; rootConfig: WorkspaceConfig }) {
-  const hasPatterns = Array.isArray(rootConfig.workspaces) && rootConfig.workspaces.length > 0;
-  const allConfigs = await walkForWorkspaceConfigs({
-    rootDir,
-    maxDepth: hasPatterns ? GLOB_DISCOVERY_MAX_DEPTH : AUTO_DISCOVERY_MAX_DEPTH,
-    applyGitignore: !hasPatterns
-  });
-  const out = [];
-
-  for (const dir of allConfigs) {
-    if (path.resolve(dir) === path.resolve(rootDir)) continue;
-    if (!hasPatterns) {
-      out.push(dir);
-      continue;
-    }
-
-    const rel = toPosix(path.relative(rootDir, dir));
-    if (rootConfig.workspaces.some((pattern) => globMatch(rel, pattern))) {
-      out.push(dir);
-    }
-  }
-
-  out.sort();
-  return out;
-}
-
-async function walkForWorkspaceConfigs({
-  rootDir,
-  maxDepth,
-  applyGitignore
-}: {
-  rootDir: string;
-  maxDepth: number;
-  applyGitignore: boolean;
-}) {
-  const matches = [];
-  const ignoreMatchers = applyGitignore ? await loadGitignoreMatchers(rootDir) : [];
-
-  async function walk(currentDir, depth) {
-    if (depth > maxDepth) return;
-
-    const relDir = toPosix(path.relative(rootDir, currentDir));
-    const base = path.basename(currentDir);
-    if (SKIP_DIRS.has(base)) return;
-    if (relDir && ignoreMatchers.some((m) => m(relDir, base))) return;
-
-    if (await exists(path.join(currentDir, CONFIG_FILE))) matches.push(path.resolve(currentDir));
-
-    let entries = [];
-    try {
-      entries = await fs.readdir(currentDir, { withFileTypes: true });
-    } catch {
-      return;
-    }
-
-    await Promise.all(
-      entries.map(async (entry) => {
-        if (!entry.isDirectory()) return;
-        const child = path.join(currentDir, entry.name);
-        try {
-          const stat = await fs.lstat(child);
-          if (stat.isSymbolicLink()) return;
-        } catch {
-          return;
-        }
-        await walk(child, depth + 1);
-      })
-    );
-  }
-
-  await walk(path.resolve(rootDir), 0);
-  return matches;
-}
-
-async function loadGitignoreMatchers(rootDir: string) {
-  const ignorePath = path.join(rootDir, '.gitignore');
-  if (!(await exists(ignorePath))) return [];
-  const raw = await fs.readFile(ignorePath, 'utf8');
-  const patterns = raw
-    .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line && !line.startsWith('#') && !line.startsWith('!'));
-
-  return patterns.map((pattern) => {
-    const normalized = toPosix(pattern.replace(/\/$/u, ''));
-    return (relPath, baseName) => {
-      if (normalized.includes('/')) {
-        return globMatch(relPath, normalized) || relPath.startsWith(`${normalized}/`);
-      }
-      if (normalized.includes('*')) {
-        return globMatch(baseName, normalized);
-      }
-      return baseName === normalized;
-    };
-  });
-}
-
-function globMatch(relPath, pattern) {
-  const regex = globToRegex(pattern);
-  return regex.test(toPosix(relPath));
-}
-
-function globToRegex(pattern) {
-  const normalized = toPosix(pattern);
-  let out = '^';
-  for (let i = 0; i < normalized.length; i += 1) {
-    const c = normalized[i];
-    if (c === '*') {
-      if (normalized[i + 1] === '*') {
-        out += '.*';
-        i += 1;
-      } else {
-        out += '[^/]*';
-      }
-      continue;
-    }
-    if ('\\^$+?.()|{}[]'.includes(c)) out += `\\${c}`;
-    else out += c;
-  }
-  out += '$';
-  return new RegExp(out);
 }
 
 async function resolveContext(cwd: string): Promise<{ rootDir: string; workspaceDir: string }> {

--- a/src/cli/workspace-discovery.test.ts
+++ b/src/cli/workspace-discovery.test.ts
@@ -1,0 +1,155 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { listWorkspaceDirs } from './workspace-discovery.ts';
+import type { WorkspaceConfig } from './types.ts';
+
+const CONFIG_FILE = 'ailib.config.json';
+
+async function makeRoot(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'ailib-ws-discovery-'));
+}
+
+async function writeConfig(dir: string, config: WorkspaceConfig) {
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, CONFIG_FILE), `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+}
+
+test('listWorkspaceDirs resolves explicit workspace override', async () => {
+  const root = await makeRoot();
+  const target = path.join(root, 'apps', 'web');
+  await writeConfig(target, { language: 'typescript', modules: ['eslint'], targets: ['claude-code'] });
+
+  const dirs = await listWorkspaceDirs({
+    rootDir: root,
+    rootConfig: { language: 'typescript', modules: ['eslint'], targets: ['claude-code'] },
+    workspaceOverride: 'apps/web'
+  });
+
+  assert.deepEqual(dirs, [path.resolve(target)]);
+});
+
+test('listWorkspaceDirs rejects explicit override without config', async () => {
+  const root = await makeRoot();
+  await fs.mkdir(path.join(root, 'apps', 'missing'), { recursive: true });
+
+  await assert.rejects(
+    listWorkspaceDirs({
+      rootDir: root,
+      rootConfig: { language: 'typescript', modules: ['eslint'], targets: ['claude-code'] },
+      workspaceOverride: 'apps/missing'
+    }),
+    /Workspace has no ailib\.config\.json: apps\/missing/
+  );
+});
+
+test('listWorkspaceDirs auto-discovery honors .gitignore wildcard patterns', async () => {
+  const root = await makeRoot();
+  await writeConfig(root, {
+    language: 'typescript',
+    modules: ['eslint'],
+    targets: ['claude-code']
+  });
+
+  const keepDir = path.join(root, 'service-keep');
+  const ignoreDir = path.join(root, 'service-ignore');
+  await writeConfig(keepDir, { language: 'typescript', modules: ['biome'], targets: ['claude-code'] });
+  await writeConfig(ignoreDir, { language: 'typescript', modules: ['prettier'], targets: ['claude-code'] });
+  await fs.writeFile(path.join(root, '.gitignore'), 'service-ign*\n', 'utf8');
+
+  const dirs = await listWorkspaceDirs({
+    rootDir: root,
+    rootConfig: { language: 'typescript', modules: ['eslint'], targets: ['claude-code'] }
+  });
+
+  assert.equal(dirs.includes(path.resolve(root)), true);
+  assert.equal(dirs.includes(path.resolve(keepDir)), true);
+  assert.equal(dirs.includes(path.resolve(ignoreDir)), false);
+});
+
+test('listWorkspaceDirs filters by workspace glob patterns', async () => {
+  const root = await makeRoot();
+  await writeConfig(root, {
+    language: 'typescript',
+    modules: ['eslint'],
+    targets: ['claude-code'],
+    workspaces: ['apps/*']
+  });
+
+  const appWeb = path.join(root, 'apps', 'web');
+  const appApi = path.join(root, 'apps', 'api');
+  const serviceMl = path.join(root, 'services', 'ml');
+  await writeConfig(appWeb, { language: 'typescript', modules: ['biome'], targets: ['claude-code'] });
+  await writeConfig(appApi, { language: 'typescript', modules: ['eslint'], targets: ['claude-code'] });
+  await writeConfig(serviceMl, { language: 'python', modules: ['ruff'], targets: ['claude-code'] });
+
+  const dirs = await listWorkspaceDirs({
+    rootDir: root,
+    rootConfig: {
+      language: 'typescript',
+      modules: ['eslint'],
+      targets: ['claude-code'],
+      workspaces: ['apps/*']
+    }
+  });
+
+  assert.deepEqual(dirs, [path.resolve(root), path.resolve(appApi), path.resolve(appWeb)]);
+});
+
+test('listWorkspaceDirs supports double-star workspace patterns', async () => {
+  const root = await makeRoot();
+  await writeConfig(root, {
+    language: 'typescript',
+    modules: ['eslint'],
+    targets: ['claude-code'],
+    workspaces: ['apps/**']
+  });
+
+  const nestedApp = path.join(root, 'apps', 'group-a', 'service-a');
+  await writeConfig(nestedApp, { language: 'typescript', modules: ['biome'], targets: ['claude-code'] });
+
+  const dirs = await listWorkspaceDirs({
+    rootDir: root,
+    rootConfig: {
+      language: 'typescript',
+      modules: ['eslint'],
+      targets: ['claude-code'],
+      workspaces: ['apps/**']
+    }
+  });
+
+  assert.equal(dirs.includes(path.resolve(nestedApp)), true);
+});
+
+test('listWorkspaceDirs supports slash and basename gitignore rules', async () => {
+  const root = await makeRoot();
+  await writeConfig(root, {
+    language: 'typescript',
+    modules: ['eslint'],
+    targets: ['claude-code']
+  });
+
+  const slashIgnored = path.join(root, 'apps', 'ignore', 'web');
+  const nameIgnored = path.join(root, 'tmpignore');
+  const kept = path.join(root, 'apps', 'keep', 'web');
+  await writeConfig(slashIgnored, { language: 'typescript', modules: ['biome'], targets: ['claude-code'] });
+  await writeConfig(nameIgnored, { language: 'typescript', modules: ['prettier'], targets: ['claude-code'] });
+  await writeConfig(kept, { language: 'typescript', modules: ['eslint'], targets: ['claude-code'] });
+  await fs.writeFile(path.join(root, '.gitignore'), 'apps/ignore/\ntmpignore\n', 'utf8');
+
+  const dirs = await listWorkspaceDirs({
+    rootDir: root,
+    rootConfig: {
+      language: 'typescript',
+      modules: ['eslint'],
+      targets: ['claude-code']
+    }
+  });
+
+  assert.equal(dirs.includes(path.resolve(slashIgnored)), false);
+  assert.equal(dirs.includes(path.resolve(nameIgnored)), false);
+  assert.equal(dirs.includes(path.resolve(kept)), true);
+});

--- a/src/cli/workspace-discovery.ts
+++ b/src/cli/workspace-discovery.ts
@@ -1,0 +1,177 @@
+import fs from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import type { Dirent } from 'node:fs';
+import path from 'node:path';
+import type { WorkspaceConfig } from './types.ts';
+
+const CONFIG_FILE = 'ailib.config.json';
+const AUTO_DISCOVERY_MAX_DEPTH = 4;
+const GLOB_DISCOVERY_MAX_DEPTH = 32;
+const SKIP_DIRS = new Set(['.git', 'node_modules', 'dist', 'build', '.venv']);
+
+export async function listWorkspaceDirs({
+  rootDir,
+  rootConfig,
+  workspaceOverride
+}: {
+  rootDir: string;
+  rootConfig: WorkspaceConfig;
+  workspaceOverride?: string;
+}) {
+  if (workspaceOverride) {
+    const abs = resolveWorkspacePath(rootDir, workspaceOverride);
+    ensure(await exists(path.join(abs, CONFIG_FILE)), `Workspace has no ${CONFIG_FILE}: ${workspaceOverride}`);
+    return [abs];
+  }
+
+  const dirs = [path.resolve(rootDir)];
+  const discovered = await discoverServiceWorkspaces({ rootDir, rootConfig });
+  for (const dir of discovered) {
+    if (!dirs.includes(dir)) dirs.push(dir);
+  }
+  return dirs;
+}
+
+async function discoverServiceWorkspaces({ rootDir, rootConfig }: { rootDir: string; rootConfig: WorkspaceConfig }) {
+  const hasPatterns = Array.isArray(rootConfig.workspaces) && rootConfig.workspaces.length > 0;
+  const allConfigs = await walkForWorkspaceConfigs({
+    rootDir,
+    maxDepth: hasPatterns ? GLOB_DISCOVERY_MAX_DEPTH : AUTO_DISCOVERY_MAX_DEPTH,
+    applyGitignore: !hasPatterns
+  });
+  const out = [];
+
+  for (const dir of allConfigs) {
+    if (path.resolve(dir) === path.resolve(rootDir)) continue;
+    if (!hasPatterns) {
+      out.push(dir);
+      continue;
+    }
+
+    const rel = toPosix(path.relative(rootDir, dir));
+    if (rootConfig.workspaces?.some((pattern) => globMatch(rel, pattern))) {
+      out.push(dir);
+    }
+  }
+
+  out.sort();
+  return out;
+}
+
+async function walkForWorkspaceConfigs({
+  rootDir,
+  maxDepth,
+  applyGitignore
+}: {
+  rootDir: string;
+  maxDepth: number;
+  applyGitignore: boolean;
+}) {
+  const matches: string[] = [];
+  const ignoreMatchers = applyGitignore ? await loadGitignoreMatchers(rootDir) : [];
+
+  async function walk(currentDir: string, depth: number) {
+    if (depth > maxDepth) return;
+
+    const relDir = toPosix(path.relative(rootDir, currentDir));
+    const base = path.basename(currentDir);
+    if (SKIP_DIRS.has(base)) return;
+    if (relDir && ignoreMatchers.some((m) => m(relDir, base))) return;
+
+    if (await exists(path.join(currentDir, CONFIG_FILE))) matches.push(path.resolve(currentDir));
+
+    let entries: Dirent[] = [];
+    try {
+      entries = await fs.readdir(currentDir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    await Promise.all(
+      entries.map(async (entry) => {
+        if (!entry.isDirectory()) return;
+        const child = path.join(currentDir, entry.name);
+        try {
+          const stat = await fs.lstat(child);
+          if (stat.isSymbolicLink()) return;
+        } catch {
+          return;
+        }
+        await walk(child, depth + 1);
+      })
+    );
+  }
+
+  await walk(path.resolve(rootDir), 0);
+  return matches;
+}
+
+async function loadGitignoreMatchers(rootDir: string) {
+  const ignorePath = path.join(rootDir, '.gitignore');
+  if (!(await exists(ignorePath))) return [];
+  const raw = await fs.readFile(ignorePath, 'utf8');
+  const patterns = raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#') && !line.startsWith('!'));
+
+  return patterns.map((pattern) => {
+    const normalized = toPosix(pattern.replace(/\/$/u, ''));
+    return (relPath: string, baseName: string) => {
+      if (normalized.includes('/')) {
+        return globMatch(relPath, normalized) || relPath.startsWith(`${normalized}/`);
+      }
+      if (normalized.includes('*')) {
+        return globMatch(baseName, normalized);
+      }
+      return baseName === normalized;
+    };
+  });
+}
+
+function globMatch(relPath: string, pattern: string) {
+  const regex = globToRegex(pattern);
+  return regex.test(toPosix(relPath));
+}
+
+function globToRegex(pattern: string) {
+  const normalized = toPosix(pattern);
+  let out = '^';
+  for (let i = 0; i < normalized.length; i += 1) {
+    const c = normalized[i];
+    if (c === '*') {
+      if (normalized[i + 1] === '*') {
+        out += '.*';
+        i += 1;
+      } else {
+        out += '[^/]*';
+      }
+      continue;
+    }
+    if ('\\^$+?.()|{}[]'.includes(c)) out += `\\${c}`;
+    else out += c;
+  }
+  out += '$';
+  return new RegExp(out);
+}
+
+function resolveWorkspacePath(rootDir: string, value: string) {
+  return path.resolve(rootDir, value);
+}
+
+function toPosix(value: string) {
+  return value.split(path.sep).join('/');
+}
+
+async function exists(filePath: string) {
+  try {
+    await fs.access(filePath, fsConstants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function ensure(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}


### PR DESCRIPTION
## Summary
- extract workspace discovery and gitignore/glob traversal logic from `src/cli.ts` into `src/cli/workspace-discovery.ts`
- add colocated tests in `src/cli/workspace-discovery.test.ts` covering explicit overrides, wildcard patterns, `**` matching, and gitignore rule modes
- preserve existing CLI behavior while improving SOLID separation and readability

## TDD Evidence
- [ ] Behavior change: I added/updated a failing test first (Red), then implemented (Green), then refactored.
- [x] Refactor/docs/chore only: no behavior change, so Red step is not applicable.
- Red evidence:
  - Not applicable (behavior-preserving refactor)
- Green evidence:
  - `bun test src/cli/workspace-discovery.test.ts test/cli.test.ts`
  - `bun run check`

## Test plan
- [x] `bun test src/cli/workspace-discovery.test.ts test/cli.test.ts`
- [x] `bun run check`

Refs #85
Refs #87
Refs #84
Refs #83

Made with [Cursor](https://cursor.com)