### PR TITLE
refactor: extract context resolution module

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,16 @@ import process from 'node:process';
 import { executeCommand } from './cli/dispatch.ts';
 import { getStringFlag, parseFlags } from './cli/flags.ts';
 import { printHelp } from './cli/help.ts';
+import {
+  detectProjectRoot,
+  findNearestMonorepoRoot,
+  isRootWorkspaceConfig,
+  relativePathForPointers,
+  resolveContext,
+  resolveDefaultWorkspaceForMutation,
+  resolveWorkspacePath,
+  workspaceLabelFor
+} from './cli/context-resolution.ts';
 import { isRecord, validateWorkspaceOverride } from './cli/override-validation.ts';
 import { listWorkspaceDirs } from './cli/workspace-discovery.ts';
 import type {
@@ -1288,71 +1298,6 @@ async function writeRootLock({
   await fs.writeFile(path.join(rootDir, LOCK_FILE), `${JSON.stringify(lock, null, 2)}\n`, 'utf8');
 }
 
-async function resolveContext(cwd: string): Promise<{ rootDir: string; workspaceDir: string }> {
-  const workspaceDir = await findNearestWorkspace(path.resolve(cwd));
-  if (!workspaceDir) {
-    const rootDir = await detectProjectRoot(cwd);
-    return { rootDir, workspaceDir: rootDir };
-  }
-
-  const rootDir = (await findNearestMonorepoRoot(path.resolve(cwd))) || workspaceDir;
-  return { rootDir, workspaceDir };
-}
-
-async function findNearestWorkspace(startDir: string): Promise<string | null> {
-  let current = path.resolve(startDir);
-  while (true) {
-    if (await exists(path.join(current, CONFIG_FILE))) return current;
-    const parent = path.dirname(current);
-    if (parent === current) return null;
-    current = parent;
-  }
-}
-
-async function findNearestMonorepoRoot(startDir: string): Promise<string | null> {
-  let current = path.resolve(startDir);
-  let found = null;
-  while (true) {
-    const cfgPath = path.join(current, CONFIG_FILE);
-    if (await exists(cfgPath)) {
-      const cfg = await readJson<WorkspaceConfig>(cfgPath);
-      if (cfg.workspaces) found = current;
-    }
-    const parent = path.dirname(current);
-    if (parent === current) break;
-    current = parent;
-  }
-  return found;
-}
-
-function resolveDefaultWorkspaceForMutation(
-  context: { rootDir: string; workspaceDir: string },
-  workspaceFlag?: string
-) {
-  if (workspaceFlag) return resolveWorkspacePath(context.rootDir, workspaceFlag);
-  if (path.resolve(context.workspaceDir) !== path.resolve(context.rootDir)) return context.workspaceDir;
-  return context.rootDir;
-}
-
-function resolveWorkspacePath(rootDir: string, value: string) {
-  const resolved = path.isAbsolute(value) ? path.resolve(value) : path.resolve(rootDir, value);
-  return resolved;
-}
-
-function isRootWorkspaceConfig(config: WorkspaceConfig | null | undefined) {
-  return Boolean(config?.workspaces);
-}
-
-function workspaceLabelFor(rootDir: string, workspaceDir: string) {
-  const rel = toPosix(path.relative(rootDir, workspaceDir));
-  return rel || '.';
-}
-
-function relativePathForPointers(fromDir: string, toDir: string) {
-  const rel = toPosix(path.relative(fromDir, toDir));
-  return rel || '.';
-}
-
 async function writeManagedFile({
   outPath,
   rendered,
@@ -1420,23 +1365,6 @@ function parseFrontmatter(markdown: string): Record<string, string | string[]> |
     fields[key] = value;
   }
   return fields;
-}
-
-async function detectProjectRoot(startDir: string): Promise<string> {
-  let current = path.resolve(startDir);
-  while (true) {
-    if (
-      (await exists(path.join(current, '.git'))) ||
-      (await exists(path.join(current, 'package.json'))) ||
-      (await exists(path.join(current, 'pyproject.toml')))
-    ) {
-      return current;
-    }
-    const parent = path.dirname(current);
-    if (parent === current) break;
-    current = parent;
-  }
-  throw new Error('Could not detect project root');
 }
 
 function sha256(value: string) {

--- a/src/cli/context-resolution.test.ts
+++ b/src/cli/context-resolution.test.ts
@@ -1,0 +1,106 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  detectProjectRoot,
+  findNearestMonorepoRoot,
+  isRootWorkspaceConfig,
+  relativePathForPointers,
+  resolveContext,
+  resolveDefaultWorkspaceForMutation,
+  resolveWorkspacePath,
+  workspaceLabelFor
+} from './context-resolution.ts';
+
+const CONFIG_FILE = 'ailib.config.json';
+
+async function makeTempRoot() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'ailib-context-'));
+}
+
+async function writeJson(filePath: string, value: unknown) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+test('resolveWorkspacePath handles relative and absolute values', () => {
+  const root = '/tmp/project';
+  assert.equal(resolveWorkspacePath(root, 'apps/web'), path.resolve(root, 'apps/web'));
+  assert.equal(resolveWorkspacePath(root, '/var/tmp/alt'), path.resolve('/var/tmp/alt'));
+});
+
+test('workspaceLabelFor and relativePathForPointers return dot for same dir', () => {
+  const root = '/tmp/project';
+  assert.equal(workspaceLabelFor(root, root), '.');
+  assert.equal(relativePathForPointers(root, root), '.');
+});
+
+test('isRootWorkspaceConfig reflects workspaces presence', () => {
+  assert.equal(isRootWorkspaceConfig(undefined), false);
+  assert.equal(isRootWorkspaceConfig({ language: 'typescript' }), false);
+  assert.equal(isRootWorkspaceConfig({ language: 'typescript', workspaces: ['apps/*'] }), true);
+});
+
+test('detectProjectRoot finds package markers', async () => {
+  const root = await makeTempRoot();
+  const nested = path.join(root, 'services', 'ml');
+  await fs.mkdir(nested, { recursive: true });
+  await fs.writeFile(path.join(root, 'package.json'), '{"name":"tmp"}\n', 'utf8');
+
+  const detected = await detectProjectRoot(nested);
+  assert.equal(detected, path.resolve(root));
+});
+
+test('detectProjectRoot throws when no markers exist', async () => {
+  const orphan = await makeTempRoot();
+  await assert.rejects(detectProjectRoot(orphan), /Could not detect project root/);
+});
+
+test('findNearestMonorepoRoot returns nearest config with workspaces', async () => {
+  const root = await makeTempRoot();
+  const appDir = path.join(root, 'apps', 'web');
+  await fs.mkdir(appDir, { recursive: true });
+  await writeJson(path.join(root, CONFIG_FILE), { language: 'typescript', workspaces: ['apps/*'] });
+  await writeJson(path.join(appDir, CONFIG_FILE), { language: 'typescript' });
+
+  const found = await findNearestMonorepoRoot(appDir);
+  assert.equal(found, path.resolve(root));
+});
+
+test('resolveContext uses workspace and monorepo root when available', async () => {
+  const root = await makeTempRoot();
+  const appDir = path.join(root, 'apps', 'web');
+  const nested = path.join(appDir, 'src');
+  await fs.mkdir(nested, { recursive: true });
+  await fs.writeFile(path.join(root, 'package.json'), '{"name":"tmp"}\n', 'utf8');
+  await writeJson(path.join(root, CONFIG_FILE), { language: 'typescript', workspaces: ['apps/*'] });
+  await writeJson(path.join(appDir, CONFIG_FILE), { language: 'typescript' });
+
+  const resolved = await resolveContext(nested);
+  assert.deepEqual(resolved, { rootDir: path.resolve(root), workspaceDir: path.resolve(appDir) });
+});
+
+test('resolveContext falls back to project root when no workspace config', async () => {
+  const root = await makeTempRoot();
+  const nested = path.join(root, 'service', 'code');
+  await fs.mkdir(nested, { recursive: true });
+  await fs.writeFile(path.join(root, 'pyproject.toml'), '[tool]\nname="tmp"\n', 'utf8');
+
+  const resolved = await resolveContext(nested);
+  assert.deepEqual(resolved, { rootDir: path.resolve(root), workspaceDir: path.resolve(root) });
+});
+
+test('resolveDefaultWorkspaceForMutation prioritizes flag then workspace', () => {
+  const context = {
+    rootDir: '/tmp/project',
+    workspaceDir: '/tmp/project/apps/web'
+  };
+  assert.equal(resolveDefaultWorkspaceForMutation(context, 'apps/api'), path.resolve('/tmp/project/apps/api'));
+  assert.equal(resolveDefaultWorkspaceForMutation(context), '/tmp/project/apps/web');
+  assert.equal(
+    resolveDefaultWorkspaceForMutation({ rootDir: '/tmp/project', workspaceDir: '/tmp/project' }),
+    '/tmp/project'
+  );
+});

--- a/src/cli/context-resolution.ts
+++ b/src/cli/context-resolution.ts
@@ -1,0 +1,107 @@
+import fs from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import path from 'node:path';
+import type { WorkspaceConfig } from './types.ts';
+
+const CONFIG_FILE = 'ailib.config.json';
+
+export interface ResolvedContext {
+  rootDir: string;
+  workspaceDir: string;
+}
+
+export async function resolveContext(cwd: string): Promise<ResolvedContext> {
+  const workspaceDir = await findNearestWorkspace(path.resolve(cwd));
+  if (!workspaceDir) {
+    const rootDir = await detectProjectRoot(cwd);
+    return { rootDir, workspaceDir: rootDir };
+  }
+
+  const rootDir = (await findNearestMonorepoRoot(path.resolve(cwd))) || workspaceDir;
+  return { rootDir, workspaceDir };
+}
+
+export function resolveDefaultWorkspaceForMutation(context: ResolvedContext, workspaceFlag?: string) {
+  if (workspaceFlag) return resolveWorkspacePath(context.rootDir, workspaceFlag);
+  if (path.resolve(context.workspaceDir) !== path.resolve(context.rootDir)) return context.workspaceDir;
+  return context.rootDir;
+}
+
+export function resolveWorkspacePath(rootDir: string, value: string) {
+  const resolved = path.isAbsolute(value) ? path.resolve(value) : path.resolve(rootDir, value);
+  return resolved;
+}
+
+export function isRootWorkspaceConfig(config: WorkspaceConfig | null | undefined) {
+  return Boolean(config?.workspaces);
+}
+
+export function workspaceLabelFor(rootDir: string, workspaceDir: string) {
+  const rel = toPosix(path.relative(rootDir, workspaceDir));
+  return rel || '.';
+}
+
+export function relativePathForPointers(fromDir: string, toDir: string) {
+  const rel = toPosix(path.relative(fromDir, toDir));
+  return rel || '.';
+}
+
+export async function findNearestMonorepoRoot(startDir: string): Promise<string | null> {
+  let current = path.resolve(startDir);
+  let found = null;
+  while (true) {
+    const cfgPath = path.join(current, CONFIG_FILE);
+    if (await exists(cfgPath)) {
+      const cfg = await readJson<WorkspaceConfig>(cfgPath);
+      if (cfg.workspaces) found = current;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return found;
+}
+
+export async function detectProjectRoot(startDir: string): Promise<string> {
+  let current = path.resolve(startDir);
+  while (true) {
+    if (
+      (await exists(path.join(current, '.git'))) ||
+      (await exists(path.join(current, 'package.json'))) ||
+      (await exists(path.join(current, 'pyproject.toml')))
+    ) {
+      return current;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  throw new Error('Could not detect project root');
+}
+
+async function findNearestWorkspace(startDir: string): Promise<string | null> {
+  let current = path.resolve(startDir);
+  while (true) {
+    if (await exists(path.join(current, CONFIG_FILE))) return current;
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function toPosix(value: string) {
+  return value.split(path.sep).join('/');
+}
+
+async function exists(filePath: string) {
+  try {
+    await fs.access(filePath, fsConstants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readJson<T = unknown>(filePath: string): Promise<T> {
+  return JSON.parse(await fs.readFile(filePath, 'utf8')) as T;
+}


### PR DESCRIPTION
## Summary
- extract context/root/workspace resolution logic from `src/cli.ts` into `src/cli/context-resolution.ts`
- add colocated tests in `src/cli/context-resolution.test.ts` for monorepo root detection, project root fallback, and workspace-path helpers
- keep CLI behavior unchanged while reducing responsibility concentration in `src/cli.ts`

## TDD Evidence
- [ ] Behavior change: I added/updated a failing test first (Red), then implemented (Green), then refactored.
- [x] Refactor/docs/chore only: no behavior change, so Red step is not applicable.
- Red evidence:
  - Not applicable (behavior-preserving refactor)
- Green evidence:
  - `bun test src/cli/context-resolution.test.ts src/cli/workspace-discovery.test.ts test/cli.test.ts`
  - `bun run check`

## Test plan
- [x] `bun test src/cli/context-resolution.test.ts src/cli/workspace-discovery.test.ts test/cli.test.ts`
- [x] `bun run check`

Refs #85
Refs #87
Refs #84
Refs #83

Made with [Cursor](https://cursor.com)