### PR TITLE
refactor: extract cli file helper module

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ import {
   resolveWorkspacePath,
   workspaceLabelFor
 } from './cli/context-resolution.ts';
+import { copySourceFile, parseFrontmatter, writeManagedFile } from './cli/file-helpers.ts';
 import { isRecord, validateWorkspaceOverride } from './cli/override-validation.ts';
 import { listWorkspaceDirs } from './cli/workspace-discovery.ts';
 import type {
@@ -37,8 +38,6 @@ import type {
   WorkspaceState
 } from './cli/types.ts';
 
-const AILIB_BLOCK_START = '<!-- ailib:start -->';
-const AILIB_BLOCK_END = '<!-- ailib:end -->';
 const CONFIG_FILE = 'ailib.config.json';
 const LOCAL_OVERRIDE_FILE = 'ailib.local.json';
 const LOCK_FILE = 'ailib.lock';
@@ -1296,75 +1295,6 @@ async function writeRootLock({
   }
 
   await fs.writeFile(path.join(rootDir, LOCK_FILE), `${JSON.stringify(lock, null, 2)}\n`, 'utf8');
-}
-
-async function writeManagedFile({
-  outPath,
-  rendered,
-  onConflict
-}: {
-  outPath: string;
-  rendered: string;
-  onConflict: string;
-}) {
-  await fs.mkdir(path.dirname(outPath), { recursive: true });
-
-  if (await exists(outPath)) {
-    if (onConflict === 'skip') return;
-    if (onConflict === 'abort') {
-      throw new Error(`Conflict detected for ${outPath}; rerun with --on-conflict=overwrite|merge|skip`);
-    }
-    if (onConflict === 'merge') {
-      const existing = await fs.readFile(outPath, 'utf8');
-      const withoutOld = existing.includes(AILIB_BLOCK_START)
-        ? `${existing.slice(0, existing.indexOf(AILIB_BLOCK_START)).trimEnd()}\n`
-        : `${existing.trimEnd()}\n`;
-      const merged = `${withoutOld}\n${AILIB_BLOCK_START}\n${rendered.trim()}\n${AILIB_BLOCK_END}\n`;
-      await fs.copyFile(outPath, `${outPath}.bak`);
-      await fs.writeFile(outPath, merged, 'utf8');
-      return;
-    }
-    await fs.copyFile(outPath, `${outPath}.bak`);
-  }
-
-  await fs.writeFile(outPath, `${rendered.trim()}\n`, 'utf8');
-}
-
-async function copySourceFile({
-  packageRoot,
-  sourceRel,
-  target
-}: {
-  packageRoot: string;
-  sourceRel: string;
-  target: string;
-}) {
-  const source = path.join(packageRoot, sourceRel);
-  ensure(await exists(source), `Missing module source: ${sourceRel}`);
-  await fs.mkdir(path.dirname(target), { recursive: true });
-  await fs.copyFile(source, target);
-}
-
-function parseFrontmatter(markdown: string): Record<string, string | string[]> | null {
-  const match = markdown.match(/^---\n([\s\S]*?)\n---\n/u);
-  if (!match) return null;
-  const fields: Record<string, string | string[]> = {};
-  for (const line of match[1].split('\n')) {
-    if (!line.trim() || line.trim().startsWith('#')) continue;
-    const idx = line.indexOf(':');
-    if (idx < 0) continue;
-    const key = line.slice(0, idx).trim();
-    let value: string | string[] = line.slice(idx + 1).trim();
-    if (value.startsWith('[') && value.endsWith(']')) {
-      value = value
-        .slice(1, -1)
-        .split(',')
-        .map((x) => x.trim())
-        .filter(Boolean);
-    }
-    fields[key] = value;
-  }
-  return fields;
 }
 
 function sha256(value: string) {

--- a/src/cli/file-helpers.test.ts
+++ b/src/cli/file-helpers.test.ts
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { copySourceFile, parseFrontmatter, writeManagedFile } from './file-helpers.ts';
+
+async function tempDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'ailib-file-helpers-'));
+}
+
+test('parseFrontmatter parses key-value and list fields', () => {
+  const parsed = parseFrontmatter(
+    ['---', 'id: eslint', 'tags: [lint, style]', '# comment', 'language: typescript', '---', '# body'].join('\n')
+  );
+  assert.deepEqual(parsed, { id: 'eslint', tags: ['lint', 'style'], language: 'typescript' });
+});
+
+test('parseFrontmatter returns null when block missing', () => {
+  assert.equal(parseFrontmatter('# no frontmatter\n'), null);
+});
+
+test('writeManagedFile supports overwrite, skip, merge, and abort modes', async () => {
+  const root = await tempDir();
+  const target = path.join(root, 'rules.md');
+
+  await writeManagedFile({ outPath: target, rendered: 'first', onConflict: 'overwrite' });
+  assert.equal(await fs.readFile(target, 'utf8'), 'first\n');
+
+  await writeManagedFile({ outPath: target, rendered: 'second', onConflict: 'skip' });
+  assert.equal(await fs.readFile(target, 'utf8'), 'first\n');
+
+  await writeManagedFile({ outPath: target, rendered: 'merged-content', onConflict: 'merge' });
+  const merged = await fs.readFile(target, 'utf8');
+  assert.match(merged, /<!-- ailib:start -->/);
+  assert.match(merged, /merged-content/);
+  assert.equal(await fs.readFile(`${target}.bak`, 'utf8'), 'first\n');
+
+  await assert.rejects(
+    writeManagedFile({ outPath: target, rendered: 'ignored', onConflict: 'abort' }),
+    /Conflict detected/
+  );
+});
+
+test('copySourceFile copies from package source and validates existence', async () => {
+  const root = await tempDir();
+  const packageRoot = path.join(root, 'pkg');
+  const targetRoot = path.join(root, 'out');
+  await fs.mkdir(path.join(packageRoot, 'core'), { recursive: true });
+  await fs.writeFile(path.join(packageRoot, 'core', 'behavior.md'), '# behavior\n', 'utf8');
+
+  const target = path.join(targetRoot, 'behavior.md');
+  await copySourceFile({ packageRoot, sourceRel: 'core/behavior.md', target });
+  assert.equal(await fs.readFile(target, 'utf8'), '# behavior\n');
+
+  await assert.rejects(
+    copySourceFile({ packageRoot, sourceRel: 'core/missing.md', target: path.join(targetRoot, 'missing.md') }),
+    /Missing module source: core\/missing\.md/
+  );
+});

--- a/src/cli/file-helpers.ts
+++ b/src/cli/file-helpers.ts
@@ -1,0 +1,88 @@
+import fs from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import path from 'node:path';
+
+const AILIB_BLOCK_START = '<!-- ailib:start -->';
+const AILIB_BLOCK_END = '<!-- ailib:end -->';
+
+export async function writeManagedFile({
+  outPath,
+  rendered,
+  onConflict
+}: {
+  outPath: string;
+  rendered: string;
+  onConflict: string;
+}) {
+  await fs.mkdir(path.dirname(outPath), { recursive: true });
+
+  if (await exists(outPath)) {
+    if (onConflict === 'skip') return;
+    if (onConflict === 'abort') {
+      throw new Error(`Conflict detected for ${outPath}; rerun with --on-conflict=overwrite|merge|skip`);
+    }
+    if (onConflict === 'merge') {
+      const existing = await fs.readFile(outPath, 'utf8');
+      const withoutOld = existing.includes(AILIB_BLOCK_START)
+        ? `${existing.slice(0, existing.indexOf(AILIB_BLOCK_START)).trimEnd()}\n`
+        : `${existing.trimEnd()}\n`;
+      const merged = `${withoutOld}\n${AILIB_BLOCK_START}\n${rendered.trim()}\n${AILIB_BLOCK_END}\n`;
+      await fs.copyFile(outPath, `${outPath}.bak`);
+      await fs.writeFile(outPath, merged, 'utf8');
+      return;
+    }
+    await fs.copyFile(outPath, `${outPath}.bak`);
+  }
+
+  await fs.writeFile(outPath, `${rendered.trim()}\n`, 'utf8');
+}
+
+export async function copySourceFile({
+  packageRoot,
+  sourceRel,
+  target
+}: {
+  packageRoot: string;
+  sourceRel: string;
+  target: string;
+}) {
+  const source = path.join(packageRoot, sourceRel);
+  ensure(await exists(source), `Missing module source: ${sourceRel}`);
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  await fs.copyFile(source, target);
+}
+
+export function parseFrontmatter(markdown: string): Record<string, string | string[]> | null {
+  const match = markdown.match(/^---\n([\s\S]*?)\n---\n/u);
+  if (!match) return null;
+  const fields: Record<string, string | string[]> = {};
+  for (const line of match[1].split('\n')) {
+    if (!line.trim() || line.trim().startsWith('#')) continue;
+    const idx = line.indexOf(':');
+    if (idx < 0) continue;
+    const key = line.slice(0, idx).trim();
+    let value: string | string[] = line.slice(idx + 1).trim();
+    if (value.startsWith('[') && value.endsWith(']')) {
+      value = value
+        .slice(1, -1)
+        .split(',')
+        .map((x) => x.trim())
+        .filter(Boolean);
+    }
+    fields[key] = value;
+  }
+  return fields;
+}
+
+async function exists(filePath: string) {
+  try {
+    await fs.access(filePath, fsConstants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function ensure(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}


### PR DESCRIPTION
## Summary
- extract file-write, source-copy, and frontmatter parsing helpers from `src/cli.ts` into `src/cli/file-helpers.ts`
- add colocated tests in `src/cli/file-helpers.test.ts` for conflict behaviors and source validation paths
- preserve runtime behavior while reducing `src/cli.ts` size and responsibility overlap

## TDD Evidence
- [ ] Behavior change: I added/updated a failing test first (Red), then implemented (Green), then refactored.
- [x] Refactor/docs/chore only: no behavior change, so Red step is not applicable.
- Red evidence:
  - Not applicable (behavior-preserving refactor)
- Green evidence:
  - `bun test src/cli/file-helpers.test.ts src/cli/context-resolution.test.ts src/cli/workspace-discovery.test.ts test/cli.test.ts`
  - `bun run check`

## Test plan
- [x] `bun test src/cli/file-helpers.test.ts src/cli/context-resolution.test.ts src/cli/workspace-discovery.test.ts test/cli.test.ts`
- [x] `bun run check`

Refs #85
Refs #87
Refs #84
Refs #83

Made with [Cursor](https://cursor.com)