### PR TITLE
refactor: extract local override merge module

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ import {
   workspaceLabelFor
 } from './cli/context-resolution.ts';
 import { copySourceFile, parseFrontmatter, writeManagedFile } from './cli/file-helpers.ts';
+import { applyListOverride, applySlotOverrides, mergeWorkspaceOverrides } from './cli/local-overrides.ts';
 import { isRecord, validateWorkspaceOverride } from './cli/override-validation.ts';
 import { listWorkspaceDirs } from './cli/workspace-discovery.ts';
 import type {
@@ -753,14 +754,16 @@ async function applyLocalOverrides({
     values: targets,
     scope: override.targets,
     validSet: validTargets,
-    label: 'target'
+    label: 'targets',
+    localOverrideFile: LOCAL_OVERRIDE_FILE
   });
 
   const moduleResult = applyListOverride({
     values: modules,
     scope: override.modules,
     validSet: validModules,
-    label: 'module'
+    label: 'modules',
+    localOverrideFile: LOCAL_OVERRIDE_FILE
   });
   warnings.push(...moduleResult.warnings);
 
@@ -768,7 +771,9 @@ async function applyLocalOverrides({
     registry,
     language,
     modules: moduleResult.values,
-    slots: override.slots || {}
+    slots: override.slots || {},
+    localOverrideFile: LOCAL_OVERRIDE_FILE,
+    canonicalSlot: (slot) => canonicalSlot(registry, slot)
   });
 
   return {
@@ -892,131 +897,6 @@ async function assertLocalOverridesValid({
   registry: Registry;
 }) {
   await loadLocalOverrideConfig({ rootDir, rootConfig, registry });
-}
-
-function ensureValidItems({ list, validSet, label }: { list: string[]; validSet: Set<string>; label: string }) {
-  const invalid = list.filter((value) => !validSet.has(value));
-  if (invalid.length) {
-    throw new Error(`Invalid ${LOCAL_OVERRIDE_FILE}: ${label} contains unknown value(s): ${invalid.join(', ')}`);
-  }
-}
-
-function mergeWorkspaceOverrides(
-  base?: WorkspaceOverrideConfig,
-  workspace?: WorkspaceOverrideConfig
-): WorkspaceOverrideConfig {
-  return {
-    targets: mergeListOverrideScope(base?.targets, workspace?.targets),
-    modules: mergeListOverrideScope(base?.modules, workspace?.modules),
-    slots: {
-      ...(base?.slots || {}),
-      ...(workspace?.slots || {})
-    }
-  };
-}
-
-function mergeListOverrideScope(base?: ListOverrideScope, workspace?: ListOverrideScope): ListOverrideScope {
-  return {
-    set: workspace?.set ?? base?.set,
-    add: uniqueList([...(base?.add || []), ...(workspace?.add || [])]),
-    remove: uniqueList([...(base?.remove || []), ...(workspace?.remove || [])])
-  };
-}
-
-function applyListOverride({
-  values,
-  scope,
-  validSet,
-  label
-}: {
-  values: string[];
-  scope?: ListOverrideScope;
-  validSet?: Set<string>;
-  label: string;
-}): { values: string[]; warnings: string[] } {
-  const warnings: string[] = [];
-  let out = uniqueList(values || []);
-  if (!scope) return { values: out, warnings };
-  const normalize = (input: string[] | undefined, source: string): string[] => uniqueList(input || []);
-
-  if (scope.set && scope.set.length) {
-    const setValues = normalize(scope.set, `${label}.set`);
-    if (validSet) ensureValidItems({ list: setValues, validSet, label: `${label}.set` });
-    out = setValues;
-  }
-
-  const addValues = normalize(scope.add, `${label}.add`);
-  if (validSet) ensureValidItems({ list: addValues, validSet, label: `${label}.add` });
-  for (const item of addValues) {
-    if (!out.includes(item)) out.push(item);
-  }
-
-  const removeValues = normalize(scope.remove, `${label}.remove`);
-  if (validSet) ensureValidItems({ list: removeValues, validSet, label: `${label}.remove` });
-  const removed = new Set(removeValues);
-  if (removed.size) {
-    out = out.filter((value) => !removed.has(value));
-  }
-
-  return { values: out, warnings };
-}
-
-function applySlotOverrides({
-  registry,
-  language,
-  modules,
-  slots
-}: {
-  registry: Registry;
-  language: string;
-  modules: string[];
-  slots: Record<string, SlotOverrideRule>;
-}): { modules: string[]; warnings: string[] } {
-  const warnings: string[] = [];
-  const lang = registry.languages[language];
-  if (!lang) return { modules, warnings };
-
-  const out = uniqueList(modules || []);
-  const knownSlots = new Set(registry.slots || []);
-
-  const moduleSlot = (moduleId: string): string | null => {
-    const slot = lang.modules[moduleId]?.slot;
-    return canonicalSlot(registry, slot);
-  };
-
-  const findBySlot = (slot: string): number => out.findIndex((moduleId) => moduleSlot(moduleId) === slot);
-
-  for (const [rawSlot, rule] of Object.entries(slots || {})) {
-    const slot = canonicalSlot(registry, rawSlot);
-    if (!slot || !knownSlots.has(slot)) {
-      throw new Error(`Invalid ${LOCAL_OVERRIDE_FILE}: slots.${rawSlot} references unknown slot`);
-    }
-
-    if (rule.remove) {
-      const idx = findBySlot(slot);
-      if (idx >= 0) out.splice(idx, 1);
-    }
-
-    if (rule.set) {
-      const moduleId = rule.set;
-      const def = lang.modules[moduleId];
-      if (!def) {
-        throw new Error(`Invalid ${LOCAL_OVERRIDE_FILE}: slots.${slot}.set references unknown module '${moduleId}'`);
-      }
-      const moduleCanonicalSlot = canonicalSlot(registry, def.slot);
-      if (moduleCanonicalSlot !== slot) {
-        throw new Error(
-          `Invalid ${LOCAL_OVERRIDE_FILE}: slots.${slot}.set module '${moduleId}' belongs to '${moduleCanonicalSlot || '(none)'}'`
-        );
-      }
-
-      const idx = findBySlot(slot);
-      if (idx >= 0) out[idx] = moduleId;
-      else out.push(moduleId);
-    }
-  }
-
-  return { modules: uniqueList(out), warnings };
 }
 
 async function resolveExtendsBase({

--- a/src/cli/local-overrides.test.ts
+++ b/src/cli/local-overrides.test.ts
@@ -1,0 +1,106 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  applyListOverride,
+  applySlotOverrides,
+  mergeListOverrideScope,
+  mergeWorkspaceOverrides
+} from './local-overrides.ts';
+import type { Registry } from './types.ts';
+
+const registry: Registry = {
+  version: '1.0.0',
+  slots: ['frontend_framework', 'linter'],
+  slot_aliases: { framework: 'frontend_framework' },
+  languages: {
+    typescript: {
+      modules: {
+        nextjs: { slot: 'frontend_framework' },
+        react: { slot: 'frontend_framework' },
+        eslint: { slot: 'linter' },
+        biome: { slot: 'linter' }
+      }
+    }
+  },
+  targets: {
+    'claude-code': { output: 'CLAUDE.md' },
+    cursor: { output: '.cursor/rules/ailib.mdc' }
+  }
+};
+
+test('mergeWorkspaceOverrides merges list scopes and slot overrides', () => {
+  const merged = mergeWorkspaceOverrides(
+    { targets: { add: ['claude-code'] }, slots: { linter: { set: 'eslint' } } },
+    { targets: { remove: ['claude-code'] }, slots: { framework: { set: 'nextjs' } } }
+  );
+
+  assert.deepEqual(merged.targets, { set: undefined, add: ['claude-code'], remove: ['claude-code'] });
+  assert.deepEqual(merged.slots, { linter: { set: 'eslint' }, framework: { set: 'nextjs' } });
+});
+
+test('mergeListOverrideScope keeps workspace set and uniques add/remove', () => {
+  const merged = mergeListOverrideScope(
+    { set: ['a'], add: ['a', 'b'], remove: ['x'] },
+    { set: ['b'], add: ['b', 'c'], remove: ['x', 'y'] }
+  );
+  assert.deepEqual(merged, { set: ['b'], add: ['a', 'b', 'c'], remove: ['x', 'y'] });
+});
+
+test('applyListOverride applies set/add/remove and validates entries', () => {
+  const result = applyListOverride({
+    values: ['claude-code'],
+    scope: { set: ['cursor'], add: ['claude-code'], remove: ['cursor'] },
+    validSet: new Set(['claude-code', 'cursor']),
+    label: 'targets',
+    localOverrideFile: 'ailib.local.json'
+  });
+  assert.deepEqual(result.values, ['claude-code']);
+  assert.deepEqual(result.warnings, []);
+
+  assert.throws(
+    () =>
+      applyListOverride({
+        values: [],
+        scope: { add: ['unknown'] },
+        validSet: new Set(['claude-code']),
+        label: 'targets',
+        localOverrideFile: 'ailib.local.json'
+      }),
+    /contains unknown value/
+  );
+});
+
+test('applySlotOverrides applies slot replacement/removal and validates mismatches', () => {
+  const replaced = applySlotOverrides({
+    registry,
+    language: 'typescript',
+    modules: ['eslint', 'nextjs'],
+    slots: { linter: { set: 'biome' } },
+    localOverrideFile: 'ailib.local.json',
+    canonicalSlot: (slot) => (slot ? registry.slot_aliases?.[slot] || slot : null)
+  });
+  assert.deepEqual(replaced.modules.sort(), ['biome', 'nextjs']);
+
+  const removed = applySlotOverrides({
+    registry,
+    language: 'typescript',
+    modules: ['eslint', 'nextjs'],
+    slots: { linter: { remove: true } },
+    localOverrideFile: 'ailib.local.json',
+    canonicalSlot: (slot) => (slot ? registry.slot_aliases?.[slot] || slot : null)
+  });
+  assert.deepEqual(removed.modules, ['nextjs']);
+
+  assert.throws(
+    () =>
+      applySlotOverrides({
+        registry,
+        language: 'typescript',
+        modules: ['eslint'],
+        slots: { framework: { set: 'eslint' } },
+        localOverrideFile: 'ailib.local.json',
+        canonicalSlot: (slot) => (slot ? registry.slot_aliases?.[slot] || slot : null)
+      }),
+    /belongs to 'linter'/
+  );
+});

--- a/src/cli/local-overrides.ts
+++ b/src/cli/local-overrides.ts
@@ -1,0 +1,146 @@
+import type { ListOverrideScope, Registry, SlotOverrideRule, WorkspaceOverrideConfig } from './types.ts';
+
+export function mergeWorkspaceOverrides(
+  base?: WorkspaceOverrideConfig,
+  workspace?: WorkspaceOverrideConfig
+): WorkspaceOverrideConfig {
+  return {
+    targets: mergeListOverrideScope(base?.targets, workspace?.targets),
+    modules: mergeListOverrideScope(base?.modules, workspace?.modules),
+    slots: {
+      ...(base?.slots || {}),
+      ...(workspace?.slots || {})
+    }
+  };
+}
+
+export function mergeListOverrideScope(base?: ListOverrideScope, workspace?: ListOverrideScope): ListOverrideScope {
+  return {
+    set: workspace?.set ?? base?.set,
+    add: uniqueList([...(base?.add || []), ...(workspace?.add || [])]),
+    remove: uniqueList([...(base?.remove || []), ...(workspace?.remove || [])])
+  };
+}
+
+export function applyListOverride({
+  values,
+  scope,
+  validSet,
+  label,
+  localOverrideFile
+}: {
+  values: string[];
+  scope?: ListOverrideScope;
+  validSet?: Set<string>;
+  label: string;
+  localOverrideFile: string;
+}): { values: string[]; warnings: string[] } {
+  const warnings: string[] = [];
+  let out = uniqueList(values || []);
+  if (!scope) return { values: out, warnings };
+  const normalize = (input: string[] | undefined): string[] => uniqueList(input || []);
+
+  if (scope.set && scope.set.length) {
+    const setValues = normalize(scope.set);
+    if (validSet) ensureValidItems({ list: setValues, validSet, label: `${label}.set`, localOverrideFile });
+    out = setValues;
+  }
+
+  const addValues = normalize(scope.add);
+  if (validSet) ensureValidItems({ list: addValues, validSet, label: `${label}.add`, localOverrideFile });
+  for (const item of addValues) {
+    if (!out.includes(item)) out.push(item);
+  }
+
+  const removeValues = normalize(scope.remove);
+  if (validSet) ensureValidItems({ list: removeValues, validSet, label: `${label}.remove`, localOverrideFile });
+  const removed = new Set(removeValues);
+  if (removed.size) {
+    out = out.filter((value) => !removed.has(value));
+  }
+
+  return { values: out, warnings };
+}
+
+export function applySlotOverrides({
+  registry,
+  language,
+  modules,
+  slots,
+  localOverrideFile,
+  canonicalSlot
+}: {
+  registry: Registry;
+  language: string;
+  modules: string[];
+  slots: Record<string, SlotOverrideRule>;
+  localOverrideFile: string;
+  canonicalSlot: (slot: string | undefined) => string | null;
+}): { modules: string[]; warnings: string[] } {
+  const warnings: string[] = [];
+  const lang = registry.languages[language];
+  if (!lang) return { modules, warnings };
+
+  const out = uniqueList(modules || []);
+  const knownSlots = new Set(registry.slots || []);
+
+  const moduleSlot = (moduleId: string): string | null => {
+    const slot = lang.modules[moduleId]?.slot;
+    return canonicalSlot(slot);
+  };
+
+  const findBySlot = (slot: string): number => out.findIndex((moduleId) => moduleSlot(moduleId) === slot);
+
+  for (const [rawSlot, rule] of Object.entries(slots || {})) {
+    const slot = canonicalSlot(rawSlot);
+    if (!slot || !knownSlots.has(slot)) {
+      throw new Error(`Invalid ${localOverrideFile}: slots.${rawSlot} references unknown slot`);
+    }
+
+    if (rule.remove) {
+      const idx = findBySlot(slot);
+      if (idx >= 0) out.splice(idx, 1);
+    }
+
+    if (rule.set) {
+      const moduleId = rule.set;
+      const def = lang.modules[moduleId];
+      if (!def) {
+        throw new Error(`Invalid ${localOverrideFile}: slots.${slot}.set references unknown module '${moduleId}'`);
+      }
+      const moduleCanonicalSlot = canonicalSlot(def.slot);
+      if (moduleCanonicalSlot !== slot) {
+        throw new Error(
+          `Invalid ${localOverrideFile}: slots.${slot}.set module '${moduleId}' belongs to '${moduleCanonicalSlot || '(none)'}'`
+        );
+      }
+
+      const idx = findBySlot(slot);
+      if (idx >= 0) out[idx] = moduleId;
+      else out.push(moduleId);
+    }
+  }
+
+  return { modules: uniqueList(out), warnings };
+}
+
+function ensureValidItems({
+  list,
+  validSet,
+  label,
+  localOverrideFile
+}: {
+  list: string[];
+  validSet: Set<string>;
+  label: string;
+  localOverrideFile: string;
+}) {
+  const invalid = list.filter((value) => !validSet.has(value));
+  if (invalid.length) {
+    throw new Error(`Invalid ${localOverrideFile}: ${label} contains unknown value(s): ${invalid.join(', ')}`);
+  }
+}
+
+function uniqueList(items: string[]) {
+  return [...new Set(items)];
+}


### PR DESCRIPTION
## Summary
- extract local override merge/apply helpers from `src/cli.ts` into `src/cli/local-overrides.ts`
- add colocated tests in `src/cli/local-overrides.test.ts` for workspace/list/slot override merge behavior and validation errors
- preserve CLI behavior while reducing `src/cli.ts` complexity and improving SOLID boundaries

## TDD Evidence
- [ ] Behavior change: I added/updated a failing test first (Red), then implemented (Green), then refactored.
- [x] Refactor/docs/chore only: no behavior change, so Red step is not applicable.
- Red evidence:
  - Not applicable (behavior-preserving refactor)
- Green evidence:
  - `bun test src/cli/local-overrides.test.ts src/cli/file-helpers.test.ts src/cli/context-resolution.test.ts src/cli/workspace-discovery.test.ts test/cli.test.ts`
  - `bun run check`

## Test plan
- [x] `bun test src/cli/local-overrides.test.ts src/cli/file-helpers.test.ts src/cli/context-resolution.test.ts src/cli/workspace-discovery.test.ts test/cli.test.ts`
- [x] `bun run check`

Refs #85
Refs #87
Refs #84
Refs #83

Made with [Cursor](https://cursor.com)