### PR TITLE
refactor: extract workspace config module

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ import {
 import { copySourceFile, parseFrontmatter, writeManagedFile } from './cli/file-helpers.ts';
 import { applyListOverride, applySlotOverrides, mergeWorkspaceOverrides } from './cli/local-overrides.ts';
 import { isRecord, validateWorkspaceOverride } from './cli/override-validation.ts';
+import { resolveExtendsBase } from './cli/workspace-config.ts';
 import { listWorkspaceDirs } from './cli/workspace-discovery.ts';
 import type {
   CliFlags,
@@ -897,62 +898,6 @@ async function assertLocalOverridesValid({
   registry: Registry;
 }) {
   await loadLocalOverrideConfig({ rootDir, rootConfig, registry });
-}
-
-async function resolveExtendsBase({
-  workspaceDir,
-  rootDir,
-  rootConfig,
-  registry
-}: {
-  workspaceDir: string;
-  rootDir: string;
-  rootConfig: WorkspaceConfig;
-  registry: Registry;
-}): Promise<WorkspaceConfig> {
-  const raw = await readJson<WorkspaceConfig>(path.join(workspaceDir, CONFIG_FILE));
-  if (path.resolve(workspaceDir) === path.resolve(rootDir)) {
-    return normalizeRootConfig(rootConfig, registry);
-  }
-
-  if (raw.extends) {
-    const seen = new Set([path.resolve(path.join(workspaceDir, CONFIG_FILE))]);
-    const resolved = await resolveConfigByExtends(path.resolve(workspaceDir), raw.extends, seen);
-    return normalizeRootConfig(resolved, registry);
-  }
-
-  return normalizeRootConfig(rootConfig, registry);
-}
-
-async function resolveConfigByExtends(
-  workspaceDir: string,
-  extendsValue: string,
-  seen: Set<string>
-): Promise<WorkspaceConfig> {
-  const targetPath = extendsValue.endsWith('.json')
-    ? path.resolve(workspaceDir, extendsValue)
-    : path.join(path.resolve(workspaceDir, extendsValue), CONFIG_FILE);
-  const absTarget = path.resolve(targetPath);
-  ensure(await exists(absTarget), `Invalid extends path: ${extendsValue}`);
-  if (seen.has(absTarget)) throw new Error('Circular extends detected');
-  seen.add(absTarget);
-
-  const raw = await readJson<WorkspaceConfig>(absTarget);
-  if (!raw.extends) return raw;
-  return resolveConfigByExtends(path.dirname(absTarget), raw.extends, seen);
-}
-
-function normalizeRootConfig(rootConfig: WorkspaceConfig, registry: Registry): WorkspaceConfig {
-  return {
-    $schema: rootConfig.$schema || 'https://ailib.dev/schema/config.schema.json',
-    registry_ref: rootConfig.registry_ref || registry.version,
-    on_conflict: rootConfig.on_conflict || 'merge',
-    language: rootConfig.language,
-    modules: rootConfig.modules || [],
-    targets: rootConfig.targets || Object.keys(registry.targets),
-    docs_path: rootConfig.docs_path || 'docs/',
-    workspaces: rootConfig.workspaces
-  };
 }
 
 function mergeModules({

--- a/src/cli/workspace-config.test.ts
+++ b/src/cli/workspace-config.test.ts
@@ -1,0 +1,104 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { normalizeRootConfig, resolveExtendsBase } from './workspace-config.ts';
+import type { Registry, WorkspaceConfig } from './types.ts';
+
+const registry: Registry = {
+  version: '2.1.0',
+  languages: {
+    typescript: {
+      modules: {
+        eslint: { slot: 'linter' }
+      }
+    }
+  },
+  targets: {
+    'claude-code': { output: 'CLAUDE.md' },
+    cursor: { output: '.cursor/rules/ailib.mdc' }
+  }
+};
+
+const CONFIG_FILE = 'ailib.config.json';
+
+async function makeDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'ailib-workspace-config-'));
+}
+
+async function writeConfig(dir: string, config: WorkspaceConfig) {
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, CONFIG_FILE), `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+}
+
+test('normalizeRootConfig applies defaults', () => {
+  const normalized = normalizeRootConfig({ language: 'typescript' }, registry);
+  assert.equal(normalized.registry_ref, '2.1.0');
+  assert.equal(normalized.on_conflict, 'merge');
+  assert.deepEqual(normalized.targets, ['claude-code', 'cursor']);
+  assert.equal(normalized.docs_path, 'docs/');
+});
+
+test('resolveExtendsBase returns normalized root config for root workspace', async () => {
+  const root = await makeDir();
+  await writeConfig(root, { language: 'typescript', modules: ['eslint'] });
+
+  const resolved = await resolveExtendsBase({
+    workspaceDir: root,
+    rootDir: root,
+    rootConfig: { language: 'typescript', modules: ['eslint'] },
+    registry
+  });
+  assert.deepEqual(resolved.modules, ['eslint']);
+  assert.equal(resolved.registry_ref, '2.1.0');
+});
+
+test('resolveExtendsBase resolves extends chains for workspace configs', async () => {
+  const root = await makeDir();
+  const shared = path.join(root, 'shared');
+  const app = path.join(root, 'apps', 'web');
+
+  await writeConfig(root, { language: 'typescript', modules: ['eslint'] });
+  await writeConfig(shared, { language: 'typescript', modules: ['eslint'], targets: ['cursor'] });
+  await writeConfig(app, { extends: '../../shared' });
+
+  const resolved = await resolveExtendsBase({
+    workspaceDir: app,
+    rootDir: root,
+    rootConfig: { language: 'typescript', modules: ['eslint'], targets: ['claude-code'] },
+    registry
+  });
+
+  assert.deepEqual(resolved.targets, ['cursor']);
+  assert.deepEqual(resolved.modules, ['eslint']);
+});
+
+test('resolveExtendsBase fails for invalid extends path and circular extends', async () => {
+  const root = await makeDir();
+  const app = path.join(root, 'apps', 'web');
+  await writeConfig(root, { language: 'typescript', modules: ['eslint'] });
+  await writeConfig(app, { extends: './missing-base' });
+
+  await assert.rejects(
+    resolveExtendsBase({
+      workspaceDir: app,
+      rootDir: root,
+      rootConfig: { language: 'typescript', modules: ['eslint'] },
+      registry
+    }),
+    /Invalid extends path/
+  );
+
+  const circular = path.join(root, 'apps', 'circular');
+  await writeConfig(circular, { extends: './' });
+  await assert.rejects(
+    resolveExtendsBase({
+      workspaceDir: circular,
+      rootDir: root,
+      rootConfig: { language: 'typescript', modules: ['eslint'] },
+      registry
+    }),
+    /Circular extends detected/
+  );
+});

--- a/src/cli/workspace-config.ts
+++ b/src/cli/workspace-config.ts
@@ -1,0 +1,79 @@
+import fs from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import path from 'node:path';
+import type { Registry, WorkspaceConfig } from './types.ts';
+
+const CONFIG_FILE = 'ailib.config.json';
+
+export async function resolveExtendsBase({
+  workspaceDir,
+  rootDir,
+  rootConfig,
+  registry
+}: {
+  workspaceDir: string;
+  rootDir: string;
+  rootConfig: WorkspaceConfig;
+  registry: Registry;
+}): Promise<WorkspaceConfig> {
+  const raw = await readJson<WorkspaceConfig>(path.join(workspaceDir, CONFIG_FILE));
+  if (path.resolve(workspaceDir) === path.resolve(rootDir)) {
+    return normalizeRootConfig(rootConfig, registry);
+  }
+
+  if (raw.extends) {
+    const seen = new Set([path.resolve(path.join(workspaceDir, CONFIG_FILE))]);
+    const resolved = await resolveConfigByExtends(path.resolve(workspaceDir), raw.extends, seen);
+    return normalizeRootConfig(resolved, registry);
+  }
+
+  return normalizeRootConfig(rootConfig, registry);
+}
+
+async function resolveConfigByExtends(
+  workspaceDir: string,
+  extendsValue: string,
+  seen: Set<string>
+): Promise<WorkspaceConfig> {
+  const targetPath = extendsValue.endsWith('.json')
+    ? path.resolve(workspaceDir, extendsValue)
+    : path.join(path.resolve(workspaceDir, extendsValue), CONFIG_FILE);
+  const absTarget = path.resolve(targetPath);
+  ensure(await exists(absTarget), `Invalid extends path: ${extendsValue}`);
+  if (seen.has(absTarget)) throw new Error('Circular extends detected');
+  seen.add(absTarget);
+
+  const raw = await readJson<WorkspaceConfig>(absTarget);
+  if (!raw.extends) return raw;
+  return resolveConfigByExtends(path.dirname(absTarget), raw.extends, seen);
+}
+
+export function normalizeRootConfig(rootConfig: WorkspaceConfig, registry: Registry): WorkspaceConfig {
+  return {
+    $schema: rootConfig.$schema || 'https://ailib.dev/schema/config.schema.json',
+    registry_ref: rootConfig.registry_ref || registry.version,
+    on_conflict: rootConfig.on_conflict || 'merge',
+    language: rootConfig.language,
+    modules: rootConfig.modules || [],
+    targets: rootConfig.targets || Object.keys(registry.targets),
+    docs_path: rootConfig.docs_path || 'docs/',
+    workspaces: rootConfig.workspaces
+  };
+}
+
+async function exists(filePath: string) {
+  try {
+    await fs.access(filePath, fsConstants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readJson<T = unknown>(filePath: string): Promise<T> {
+  return JSON.parse(await fs.readFile(filePath, 'utf8')) as T;
+}
+
+function ensure(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}


### PR DESCRIPTION
## Summary
- extract workspace `extends` resolution and root normalization from `src/cli.ts` into `src/cli/workspace-config.ts`
- add colocated tests in `src/cli/workspace-config.test.ts` for default normalization, extends chain resolution, invalid path handling, and circular extends detection
- preserve CLI behavior while further reducing `src/cli.ts` responsibility concentration

## TDD Evidence
- [ ] Behavior change: I added/updated a failing test first (Red), then implemented (Green), then refactored.
- [x] Refactor/docs/chore only: no behavior change, so Red step is not applicable.
- Red evidence:
  - Not applicable (behavior-preserving refactor)
- Green evidence:
  - `bun test src/cli/workspace-config.test.ts src/cli/local-overrides.test.ts src/cli/file-helpers.test.ts src/cli/context-resolution.test.ts src/cli/workspace-discovery.test.ts test/cli.test.ts`
  - `bun run check`

## Test plan
- [x] `bun test src/cli/workspace-config.test.ts src/cli/local-overrides.test.ts src/cli/file-helpers.test.ts src/cli/context-resolution.test.ts src/cli/workspace-discovery.test.ts test/cli.test.ts`
- [x] `bun run check`

Refs #85
Refs #87
Refs #84
Refs #83

Made with [Cursor](https://cursor.com)