### PR TITLE
refactor: extract module selection helpers

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ import {
 } from './cli/context-resolution.ts';
 import { copySourceFile, parseFrontmatter, writeManagedFile } from './cli/file-helpers.ts';
 import { applyListOverride, applySlotOverrides, mergeWorkspaceOverrides } from './cli/local-overrides.ts';
+import { diffSlots, mergeModules, mergeTargets } from './cli/module-selection.ts';
 import { isRecord, validateWorkspaceOverride } from './cli/override-validation.ts';
 import { resolveExtendsBase } from './cli/workspace-config.ts';
 import { listWorkspaceDirs } from './cli/workspace-discovery.ts';
@@ -351,7 +352,13 @@ async function doctorCommand({ cwd, packageRoot, flags }: CommandContext) {
     }
 
     if (path.resolve(workspaceDir) !== path.resolve(context.rootDir)) {
-      const slotDiffs = diffSlots(rootEffective.modules, state.effective.modules, registry, state.effective.language);
+      const slotDiffs = diffSlots({
+        rootModules: rootEffective.modules,
+        workspaceModules: state.effective.modules,
+        registry,
+        language: state.effective.language,
+        canonicalSlot: (slot) => canonicalSlot(registry, slot)
+      });
       for (const msg of slotDiffs) warnings.push(`[${workspaceLabel}] ${msg}`);
     }
   }
@@ -685,7 +692,8 @@ async function getEffectiveWorkspaceConfig({
     registry,
     language,
     parentModules: isRootWorkspace ? [] : base.modules || [],
-    localModules: workspaceRaw.modules || (isRootWorkspace ? base.modules || [] : [])
+    localModules: workspaceRaw.modules || (isRootWorkspace ? base.modules || [] : []),
+    canonicalSlot: (slot) => canonicalSlot(registry, slot)
   });
 
   const targets = mergeTargets({
@@ -898,126 +906,6 @@ async function assertLocalOverridesValid({
   registry: Registry;
 }) {
   await loadLocalOverrideConfig({ rootDir, rootConfig, registry });
-}
-
-function mergeModules({
-  registry,
-  language,
-  parentModules,
-  localModules
-}: {
-  registry: Registry;
-  language: string;
-  parentModules: string[];
-  localModules: string[];
-}): {
-  modules: string[];
-  inheritedModules: string[];
-  localModules: string[];
-  warnings: string[];
-} {
-  const lang = registry.languages[language];
-  const result: string[] = [];
-  const owners: Array<'inherited' | 'local'> = [];
-  const warnings: string[] = [];
-
-  for (const mod of uniqueList(parentModules)) {
-    if (!lang.modules[mod]) continue;
-    result.push(mod);
-    owners.push('inherited');
-  }
-
-  for (const mod of uniqueList(localModules)) {
-    const localDef = lang.modules[mod];
-    if (!localDef) {
-      result.push(mod);
-      owners.push('local');
-      continue;
-    }
-
-    const existingIdx = result.indexOf(mod);
-    if (existingIdx >= 0) {
-      continue;
-    }
-
-    const localSlot = canonicalSlot(registry, localDef.slot);
-    if (localSlot) {
-      const slotIdx = result.findIndex((existingMod) => {
-        const def = lang.modules[existingMod];
-        const existingSlot = canonicalSlot(registry, def?.slot);
-        return existingSlot && existingSlot === localSlot;
-      });
-
-      if (slotIdx >= 0) {
-        warnings.push(`Slot override '${localSlot}': ${result[slotIdx]} -> ${mod}`);
-        result[slotIdx] = mod;
-        owners[slotIdx] = 'local';
-        continue;
-      }
-    }
-
-    result.push(mod);
-    owners.push('local');
-  }
-
-  const inheritedModules: string[] = [];
-  const localOut: string[] = [];
-  for (let i = 0; i < result.length; i += 1) {
-    if (owners[i] === 'inherited') inheritedModules.push(result[i]);
-    else localOut.push(result[i]);
-  }
-
-  return {
-    modules: result,
-    inheritedModules,
-    localModules: localOut,
-    warnings
-  };
-}
-
-function mergeTargets({
-  parentTargets,
-  localTargets,
-  targetsRemoved
-}: {
-  parentTargets: string[];
-  localTargets: string[];
-  targetsRemoved: string[];
-}) {
-  const parent = uniqueList(parentTargets || []);
-  const removed = new Set(targetsRemoved || []);
-  const local = uniqueList(localTargets || []);
-  const merged = new Set(parent);
-  for (const target of local) merged.add(target);
-  for (const rem of removed) merged.delete(rem);
-  return [...merged];
-}
-
-function diffSlots(rootModules: string[], workspaceModules: string[], registry: Registry, language: string) {
-  const lang = registry.languages[language];
-  if (!lang) return [];
-
-  const slotOf = (mod) => canonicalSlot(registry, lang.modules[mod]?.slot);
-  const rootBySlot = new Map();
-  const wsBySlot = new Map();
-
-  for (const mod of rootModules) {
-    const slot = slotOf(mod);
-    if (slot) rootBySlot.set(slot, mod);
-  }
-  for (const mod of workspaceModules) {
-    const slot = slotOf(mod);
-    if (slot) wsBySlot.set(slot, mod);
-  }
-
-  const diffs = [];
-  for (const [slot, rootMod] of rootBySlot.entries()) {
-    const wsMod = wsBySlot.get(slot);
-    if (wsMod && wsMod !== rootMod) {
-      diffs.push(`slot '${slot}' differs from root (${rootMod} -> ${wsMod})`);
-    }
-  }
-  return diffs;
 }
 
 function validateModuleSelection({

--- a/src/cli/module-selection.test.ts
+++ b/src/cli/module-selection.test.ts
@@ -1,0 +1,76 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { diffSlots, mergeModules, mergeTargets } from './module-selection.ts';
+import type { Registry } from './types.ts';
+
+const registry: Registry = {
+  version: '1.0.0',
+  slots: ['frontend_framework', 'linter'],
+  languages: {
+    typescript: {
+      modules: {
+        react: { slot: 'frontend_framework' },
+        nextjs: { slot: 'frontend_framework' },
+        eslint: { slot: 'linter' },
+        biome: { slot: 'linter' }
+      }
+    }
+  },
+  targets: {
+    'claude-code': { output: 'CLAUDE.md' },
+    cursor: { output: '.cursor/rules/ailib.mdc' }
+  }
+};
+
+const canonicalSlot = (slot: string | undefined) => slot ?? null;
+
+test('mergeModules replaces inherited module by slot with local override', () => {
+  const result = mergeModules({
+    registry,
+    language: 'typescript',
+    parentModules: ['react', 'eslint'],
+    localModules: ['nextjs', 'biome'],
+    canonicalSlot
+  });
+
+  assert.deepEqual(result.modules, ['nextjs', 'biome']);
+  assert.deepEqual(result.inheritedModules, []);
+  assert.deepEqual(result.localModules, ['nextjs', 'biome']);
+  assert.match(result.warnings.join('\n'), /Slot override 'frontend_framework': react -> nextjs/);
+  assert.match(result.warnings.join('\n'), /Slot override 'linter': eslint -> biome/);
+});
+
+test('mergeModules keeps unknown local modules for later validation', () => {
+  const result = mergeModules({
+    registry,
+    language: 'typescript',
+    parentModules: ['eslint'],
+    localModules: ['custom-module'],
+    canonicalSlot
+  });
+
+  assert.deepEqual(result.modules, ['eslint', 'custom-module']);
+  assert.deepEqual(result.inheritedModules, ['eslint']);
+  assert.deepEqual(result.localModules, ['custom-module']);
+});
+
+test('mergeTargets applies dedupe and removals', () => {
+  const merged = mergeTargets({
+    parentTargets: ['claude-code', 'cursor'],
+    localTargets: ['cursor', 'claude-code'],
+    targetsRemoved: ['cursor']
+  });
+  assert.deepEqual(merged, ['claude-code']);
+});
+
+test('diffSlots reports slot differences between root and workspace', () => {
+  const diffs = diffSlots({
+    rootModules: ['react', 'eslint'],
+    workspaceModules: ['nextjs', 'eslint'],
+    registry,
+    language: 'typescript',
+    canonicalSlot
+  });
+
+  assert.deepEqual(diffs, ["slot 'frontend_framework' differs from root (react -> nextjs)"]);
+});

--- a/src/cli/module-selection.ts
+++ b/src/cli/module-selection.ts
@@ -1,0 +1,139 @@
+import type { Registry } from './types.ts';
+
+export function mergeModules({
+  registry,
+  language,
+  parentModules,
+  localModules,
+  canonicalSlot
+}: {
+  registry: Registry;
+  language: string;
+  parentModules: string[];
+  localModules: string[];
+  canonicalSlot: (slot: string | undefined) => string | null;
+}): {
+  modules: string[];
+  inheritedModules: string[];
+  localModules: string[];
+  warnings: string[];
+} {
+  const lang = registry.languages[language];
+  const result: string[] = [];
+  const owners: Array<'inherited' | 'local'> = [];
+  const warnings: string[] = [];
+
+  for (const mod of uniqueList(parentModules)) {
+    if (!lang.modules[mod]) continue;
+    result.push(mod);
+    owners.push('inherited');
+  }
+
+  for (const mod of uniqueList(localModules)) {
+    const localDef = lang.modules[mod];
+    if (!localDef) {
+      result.push(mod);
+      owners.push('local');
+      continue;
+    }
+
+    const existingIdx = result.indexOf(mod);
+    if (existingIdx >= 0) {
+      continue;
+    }
+
+    const localSlot = canonicalSlot(localDef.slot);
+    if (localSlot) {
+      const slotIdx = result.findIndex((existingMod) => {
+        const def = lang.modules[existingMod];
+        const existingSlot = canonicalSlot(def?.slot);
+        return existingSlot && existingSlot === localSlot;
+      });
+
+      if (slotIdx >= 0) {
+        warnings.push(`Slot override '${localSlot}': ${result[slotIdx]} -> ${mod}`);
+        result[slotIdx] = mod;
+        owners[slotIdx] = 'local';
+        continue;
+      }
+    }
+
+    result.push(mod);
+    owners.push('local');
+  }
+
+  const inheritedModules: string[] = [];
+  const localOut: string[] = [];
+  for (let i = 0; i < result.length; i += 1) {
+    if (owners[i] === 'inherited') inheritedModules.push(result[i]);
+    else localOut.push(result[i]);
+  }
+
+  return {
+    modules: result,
+    inheritedModules,
+    localModules: localOut,
+    warnings
+  };
+}
+
+export function mergeTargets({
+  parentTargets,
+  localTargets,
+  targetsRemoved
+}: {
+  parentTargets: string[];
+  localTargets: string[];
+  targetsRemoved: string[];
+}) {
+  const parent = uniqueList(parentTargets || []);
+  const removed = new Set(targetsRemoved || []);
+  const local = uniqueList(localTargets || []);
+  const merged = new Set(parent);
+  for (const target of local) merged.add(target);
+  for (const rem of removed) merged.delete(rem);
+  return [...merged];
+}
+
+export function diffSlots({
+  rootModules,
+  workspaceModules,
+  registry,
+  language,
+  canonicalSlot
+}: {
+  rootModules: string[];
+  workspaceModules: string[];
+  registry: Registry;
+  language: string;
+  canonicalSlot: (slot: string | undefined) => string | null;
+}) {
+  const lang = registry.languages[language];
+  if (!lang) return [];
+
+  const slotOf = (mod: string) => canonicalSlot(lang.modules[mod]?.slot);
+  const rootBySlot = new Map<string, string>();
+  const wsBySlot = new Map<string, string>();
+
+  for (const mod of rootModules) {
+    const slot = slotOf(mod);
+    if (slot) rootBySlot.set(slot, mod);
+  }
+  for (const mod of workspaceModules) {
+    const slot = slotOf(mod);
+    if (slot) wsBySlot.set(slot, mod);
+  }
+
+  const diffs: string[] = [];
+  for (const [slot, rootMod] of rootBySlot.entries()) {
+    const wsMod = wsBySlot.get(slot);
+    if (wsMod && wsMod !== rootMod) {
+      diffs.push(`slot '${slot}' differs from root (${rootMod} -> ${wsMod})`);
+    }
+  }
+  return diffs;
+}
+
+function uniqueList(items: string[]) {
+  return [...new Set(items)];
+}


### PR DESCRIPTION
## Summary
- extract module/target merge and slot-diff helpers from `src/cli.ts` into `src/cli/module-selection.ts`
- add colocated tests in `src/cli/module-selection.test.ts` for slot override replacement, unknown-module carry-through, target merge behavior, and slot diff detection
- keep CLI behavior unchanged while shrinking core command orchestration complexity

## TDD Evidence
- [ ] Behavior change: I added/updated a failing test first (Red), then implemented (Green), then refactored.
- [x] Refactor/docs/chore only: no behavior change, so Red step is not applicable.
- Red evidence:
  - Not applicable (behavior-preserving refactor)
- Green evidence:
  - `bun test src/cli/module-selection.test.ts src/cli/workspace-config.test.ts src/cli/local-overrides.test.ts src/cli/file-helpers.test.ts src/cli/context-resolution.test.ts src/cli/workspace-discovery.test.ts test/cli.test.ts`
  - `bun run check`

## Test plan
- [x] `bun test src/cli/module-selection.test.ts src/cli/workspace-config.test.ts src/cli/local-overrides.test.ts src/cli/file-helpers.test.ts src/cli/context-resolution.test.ts src/cli/workspace-discovery.test.ts test/cli.test.ts`
- [x] `bun run check`

Refs #85
Refs #87
Refs #84
Refs #83

Made with [Cursor](https://cursor.com)