### PR TITLE
refactor: extract module validation helper

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ import {
 import { copySourceFile, parseFrontmatter, writeManagedFile } from './cli/file-helpers.ts';
 import { applyListOverride, applySlotOverrides, mergeWorkspaceOverrides } from './cli/local-overrides.ts';
 import { diffSlots, mergeModules, mergeTargets } from './cli/module-selection.ts';
+import { validateModuleSelection } from './cli/module-validation.ts';
 import { isRecord, validateWorkspaceOverride } from './cli/override-validation.ts';
 import { resolveExtendsBase } from './cli/workspace-config.ts';
 import { listWorkspaceDirs } from './cli/workspace-discovery.ts';
@@ -157,7 +158,7 @@ async function initCommand({ cwd, packageRoot, flags }: CommandContext) {
   const targets = uniqueList(splitCsv(flags.targets).length ? splitCsv(flags.targets) : Object.keys(registry.targets));
   const onConflict = getStringFlag(flags, 'on-conflict') || 'merge';
 
-  validateModuleSelection({ registry, language, modules });
+  validateModuleSelection({ registry, language, modules, canonicalSlot: (slot) => canonicalSlot(registry, slot) });
 
   if (inServiceContext && flags['no-inherit'] !== true) {
     const projectRoot = path.resolve(cwd);
@@ -236,7 +237,8 @@ async function addCommand({ cwd, packageRoot, flags }: CommandContext) {
   validateModuleSelection({
     registry,
     language: effective.language,
-    modules: uniqueList([...(config.modules || []), moduleId])
+    modules: uniqueList([...(config.modules || []), moduleId]),
+    canonicalSlot: (slot) => canonicalSlot(registry, slot)
   });
 
   config.modules = uniqueList([...(config.modules || []), moduleId]);
@@ -650,7 +652,12 @@ async function buildWorkspaceState({
   registry: Registry;
 }): Promise<WorkspaceState> {
   const effective = await getEffectiveWorkspaceConfig({ workspaceDir, rootDir, rootConfig, registry });
-  validateModuleSelection({ registry, language: effective.language, modules: effective.modules });
+  validateModuleSelection({
+    registry,
+    language: effective.language,
+    modules: effective.modules,
+    canonicalSlot: (slot) => canonicalSlot(registry, slot)
+  });
 
   const requiredFiles = [
     '.ailib/development-standards.md',
@@ -906,43 +913,6 @@ async function assertLocalOverridesValid({
   registry: Registry;
 }) {
   await loadLocalOverrideConfig({ rootDir, rootConfig, registry });
-}
-
-function validateModuleSelection({
-  registry,
-  language,
-  modules
-}: {
-  registry: Registry;
-  language: string;
-  modules: string[];
-}) {
-  const lang = registry.languages[language];
-  ensure(lang, `Unsupported language: ${language}`);
-
-  const slotMap = new Map();
-  const validSlots = new Set(registry.slots || []);
-  for (const moduleId of modules) {
-    const moduleDef = lang.modules[moduleId];
-    ensure(moduleDef, `Unsupported module for ${language}: ${moduleId}`);
-
-    const slot = canonicalSlot(registry, moduleDef.slot);
-    if (slot) {
-      ensure(validSlots.has(slot), `Unknown slot '${slot}' for module '${moduleId}'`);
-      const existing = slotMap.get(slot);
-      ensure(!existing, `Slot conflict '${slot}': ${existing} vs ${moduleId}`);
-      slotMap.set(slot, moduleId);
-    }
-  }
-
-  for (const moduleId of modules) {
-    const conflicts = new Set(lang.modules[moduleId].conflicts_with || []);
-    for (const other of modules) {
-      if (other !== moduleId && conflicts.has(other)) {
-        throw new Error(`Module conflict: ${moduleId} conflicts with ${other}`);
-      }
-    }
-  }
 }
 
 async function writeRootLock({

--- a/src/cli/module-validation.test.ts
+++ b/src/cli/module-validation.test.ts
@@ -1,0 +1,111 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { validateModuleSelection } from './module-validation.ts';
+import type { Registry } from './types.ts';
+
+const registry: Registry = {
+  version: '1.0.0',
+  slots: ['frontend_framework', 'linter', 'runtime_platform', 'formatter'],
+  languages: {
+    typescript: {
+      modules: {
+        nextjs: { slot: 'frontend_framework' },
+        react: { slot: 'frontend_framework' },
+        eslint: { slot: 'linter' },
+        biome: { slot: 'linter' },
+        bun: { slot: 'runtime_platform', conflicts_with: ['nodejs'] },
+        nodejs: { slot: 'runtime_platform' },
+        prettier: { slot: 'formatter', conflicts_with: ['eslint'] }
+      }
+    }
+  },
+  targets: {
+    'claude-code': { output: 'CLAUDE.md' }
+  }
+};
+
+const canonicalSlot = (slot: string | undefined) => slot ?? null;
+
+test('validateModuleSelection accepts valid non-conflicting module set', () => {
+  assert.doesNotThrow(() => {
+    validateModuleSelection({
+      registry,
+      language: 'typescript',
+      modules: ['nextjs', 'eslint', 'bun'],
+      canonicalSlot
+    });
+  });
+});
+
+test('validateModuleSelection rejects unsupported language and module', () => {
+  assert.throws(
+    () =>
+      validateModuleSelection({
+        registry,
+        language: 'python',
+        modules: ['pytest'],
+        canonicalSlot
+      }),
+    /Unsupported language: python/
+  );
+
+  assert.throws(
+    () =>
+      validateModuleSelection({
+        registry,
+        language: 'typescript',
+        modules: ['unknown-module'],
+        canonicalSlot
+      }),
+    /Unsupported module for typescript: unknown-module/
+  );
+});
+
+test('validateModuleSelection rejects slot conflicts and unknown slot mapping', () => {
+  assert.throws(
+    () =>
+      validateModuleSelection({
+        registry,
+        language: 'typescript',
+        modules: ['nextjs', 'react'],
+        canonicalSlot
+      }),
+    /Slot conflict 'frontend_framework': nextjs vs react/
+  );
+
+  const badRegistry: Registry = {
+    ...registry,
+    languages: {
+      ...registry.languages,
+      typescript: {
+        modules: {
+          ...registry.languages.typescript.modules,
+          badslot: { slot: 'missing_slot' }
+        }
+      }
+    }
+  };
+  assert.throws(
+    () =>
+      validateModuleSelection({
+        registry: badRegistry,
+        language: 'typescript',
+        modules: ['badslot'],
+        canonicalSlot
+      }),
+    /Unknown slot 'missing_slot' for module 'badslot'/
+  );
+});
+
+test('validateModuleSelection rejects explicit module conflicts', () => {
+  assert.throws(
+    () =>
+      validateModuleSelection({
+        registry,
+        language: 'typescript',
+        modules: ['eslint', 'prettier'],
+        canonicalSlot
+      }),
+    /Module conflict: prettier conflicts with eslint/
+  );
+});

--- a/src/cli/module-validation.ts
+++ b/src/cli/module-validation.ts
@@ -1,0 +1,48 @@
+import type { Registry } from './types.ts';
+
+export function validateModuleSelection({
+  registry,
+  language,
+  modules,
+  canonicalSlot
+}: {
+  registry: Registry;
+  language: string;
+  modules: string[];
+  canonicalSlot: (slot: string | undefined) => string | null;
+}) {
+  const lang = registry.languages[language];
+  if (!lang) {
+    throw new Error(`Unsupported language: ${language}`);
+  }
+
+  const slotMap = new Map<string, string>();
+  const validSlots = new Set(registry.slots || []);
+  for (const moduleId of modules) {
+    const moduleDef = lang.modules[moduleId];
+    if (!moduleDef) {
+      throw new Error(`Unsupported module for ${language}: ${moduleId}`);
+    }
+
+    const slot = canonicalSlot(moduleDef.slot);
+    if (slot) {
+      if (!validSlots.has(slot)) {
+        throw new Error(`Unknown slot '${slot}' for module '${moduleId}'`);
+      }
+      const existing = slotMap.get(slot);
+      if (existing) {
+        throw new Error(`Slot conflict '${slot}': ${existing} vs ${moduleId}`);
+      }
+      slotMap.set(slot, moduleId);
+    }
+  }
+
+  for (const moduleId of modules) {
+    const conflicts = new Set(lang.modules[moduleId].conflicts_with || []);
+    for (const other of modules) {
+      if (other !== moduleId && conflicts.has(other)) {
+        throw new Error(`Module conflict: ${moduleId} conflicts with ${other}`);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- extract module selection validation logic from `src/cli.ts` into `src/cli/module-validation.ts`
- add colocated tests in `src/cli/module-validation.test.ts` for unsupported language/module, slot conflicts, unknown slots, and explicit conflict rules
- keep CLI behavior unchanged while reducing responsibility density in `src/cli.ts`

## TDD Evidence
- [ ] Behavior change: I added/updated a failing test first (Red), then implemented (Green), then refactored.
- [x] Refactor/docs/chore only: no behavior change, so Red step is not applicable.
- Red evidence:
  - Not applicable (behavior-preserving refactor)
- Green evidence:
  - `bun test src/cli/module-validation.test.ts src/cli/module-selection.test.ts src/cli/workspace-config.test.ts src/cli/local-overrides.test.ts src/cli/file-helpers.test.ts src/cli/context-resolution.test.ts src/cli/workspace-discovery.test.ts test/cli.test.ts`
  - `bun run check`

## Test plan
- [x] `bun test src/cli/module-validation.test.ts src/cli/module-selection.test.ts src/cli/workspace-config.test.ts src/cli/local-overrides.test.ts src/cli/file-helpers.test.ts src/cli/context-resolution.test.ts src/cli/workspace-discovery.test.ts test/cli.test.ts`
- [x] `bun run check`

Refs #85
Refs #87
Refs #84
Refs #83

Made with [Cursor](https://cursor.com)