### PR TITLE
refactor: extract lockfile writer module

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,3 @@
-import crypto from 'node:crypto';
 import fs from 'node:fs/promises';
 import { constants as fsConstants } from 'node:fs';
 import path from 'node:path';
@@ -17,6 +16,7 @@ import {
   workspaceLabelFor
 } from './cli/context-resolution.ts';
 import { copySourceFile, parseFrontmatter, writeManagedFile } from './cli/file-helpers.ts';
+import { writeRootLock } from './cli/lockfile.ts';
 import { applyListOverride, applySlotOverrides, mergeWorkspaceOverrides } from './cli/local-overrides.ts';
 import { diffSlots, mergeModules, mergeTargets } from './cli/module-selection.ts';
 import { validateModuleSelection } from './cli/module-validation.ts';
@@ -913,75 +913,6 @@ async function assertLocalOverridesValid({
   registry: Registry;
 }) {
   await loadLocalOverrideConfig({ rootDir, rootConfig, registry });
-}
-
-async function writeRootLock({
-  rootDir,
-  packageRoot,
-  packageVersion,
-  registryRef,
-  allStates
-}: {
-  rootDir: string;
-  packageRoot: string;
-  packageVersion: string;
-  registryRef: string;
-  allStates: Map<string, WorkspaceState>;
-}) {
-  const registryText = await fs.readFile(path.join(packageRoot, 'registry.json'), 'utf8');
-  const lock = {
-    lockfile_version: 1,
-    cli_version: packageVersion,
-    registry_ref: registryRef,
-    registry_sha256: sha256(registryText),
-    workspaces: {}
-  };
-
-  for (const [workspaceDir, state] of allStates.entries()) {
-    const relWorkspace = workspaceLabelFor(rootDir, workspaceDir);
-    const files = {};
-
-    if (path.resolve(workspaceDir) === path.resolve(rootDir)) {
-      const rel = '.ailib/behavior.md';
-      const text = await fs.readFile(path.join(workspaceDir, rel), 'utf8');
-      files[rel] = { source: 'core/behavior.md', sha256: sha256(text) };
-    }
-
-    {
-      const rel = '.ailib/development-standards.md';
-      const text = await fs.readFile(path.join(workspaceDir, rel), 'utf8');
-      files[rel] = { source: 'core/development-standards.md', sha256: sha256(text) };
-    }
-
-    {
-      const rel = '.ailib/test-standards.md';
-      const text = await fs.readFile(path.join(workspaceDir, rel), 'utf8');
-      files[rel] = { source: 'core/test-standards.md', sha256: sha256(text) };
-    }
-
-    {
-      const rel = '.ailib/standards.md';
-      const text = await fs.readFile(path.join(workspaceDir, rel), 'utf8');
-      files[rel] = { source: `languages/${state.effective.language}/core.md`, sha256: sha256(text) };
-    }
-
-    for (const mod of state.localModules) {
-      const rel = `.ailib/modules/${mod}.md`;
-      const full = path.join(workspaceDir, rel);
-      const text = await fs.readFile(full, 'utf8');
-      let source = `languages/${state.effective.language}/modules/${mod}.md`;
-      if (!(await exists(path.join(packageRoot, source)))) source = 'local';
-      files[rel] = { source, sha256: sha256(text) };
-    }
-
-    lock.workspaces[relWorkspace] = { files };
-  }
-
-  await fs.writeFile(path.join(rootDir, LOCK_FILE), `${JSON.stringify(lock, null, 2)}\n`, 'utf8');
-}
-
-function sha256(value: string) {
-  return crypto.createHash('sha256').update(value).digest('hex');
 }
 
 function sanitizeForFilename(input: string) {

--- a/src/cli/lockfile.test.ts
+++ b/src/cli/lockfile.test.ts
@@ -1,0 +1,88 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { writeRootLock } from './lockfile.ts';
+import type { WorkspaceState } from './types.ts';
+
+async function tempDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'ailib-lockfile-'));
+}
+
+async function writeWorkspaceFiles(workspaceDir: string, modules: string[]) {
+  await fs.mkdir(path.join(workspaceDir, '.ailib/modules'), { recursive: true });
+  await fs.writeFile(path.join(workspaceDir, '.ailib/development-standards.md'), 'dev-standards', 'utf8');
+  await fs.writeFile(path.join(workspaceDir, '.ailib/test-standards.md'), 'test-standards', 'utf8');
+  await fs.writeFile(path.join(workspaceDir, '.ailib/standards.md'), 'lang-standards', 'utf8');
+  if (modules.length > 0) {
+    for (const mod of modules) {
+      await fs.writeFile(path.join(workspaceDir, `.ailib/modules/${mod}.md`), `module:${mod}`, 'utf8');
+    }
+  }
+}
+
+function state(language: string, localModules: string[]): WorkspaceState {
+  return {
+    effective: {
+      $schema: 'https://ailib.dev/schema/config.schema.json',
+      registry_ref: 'test-registry',
+      on_conflict: 'merge',
+      language,
+      modules: localModules,
+      targets: ['cursor'],
+      docs_path: 'docs/',
+      inheritedModules: [],
+      localModules,
+      warnings: []
+    },
+    inheritedModules: [],
+    localModules,
+    requiredFiles: [],
+    warnings: []
+  };
+}
+
+test('writeRootLock writes root and workspace entries with source fallback', async () => {
+  const rootDir = await tempDir();
+  const packageRoot = path.join(rootDir, 'pkg');
+  const workspaceDir = path.join(rootDir, 'apps', 'api');
+
+  await fs.mkdir(path.join(packageRoot, 'languages', 'typescript', 'modules'), { recursive: true });
+  await fs.writeFile(path.join(packageRoot, 'registry.json'), '{"version":"test"}\n', 'utf8');
+  await fs.writeFile(path.join(packageRoot, 'languages', 'typescript', 'modules', 'eslint.md'), '# eslint', 'utf8');
+
+  await fs.mkdir(workspaceDir, { recursive: true });
+  await writeWorkspaceFiles(rootDir, ['eslint']);
+  await fs.writeFile(path.join(rootDir, '.ailib/behavior.md'), 'behavior', 'utf8');
+  await writeWorkspaceFiles(workspaceDir, ['eslint', 'custom-module']);
+
+  const allStates = new Map<string, WorkspaceState>([
+    [rootDir, state('typescript', ['eslint'])],
+    [workspaceDir, state('typescript', ['eslint', 'custom-module'])]
+  ]);
+
+  await writeRootLock({
+    rootDir,
+    packageRoot,
+    packageVersion: '1.2.3',
+    registryRef: 'test-registry',
+    allStates
+  });
+
+  const lock = JSON.parse(await fs.readFile(path.join(rootDir, 'ailib.lock'), 'utf8')) as {
+    cli_version: string;
+    registry_ref: string;
+    workspaces: Record<string, { files: Record<string, { source: string; sha256: string }> }>;
+  };
+
+  assert.equal(lock.cli_version, '1.2.3');
+  assert.equal(lock.registry_ref, 'test-registry');
+  assert.ok(lock.workspaces['.']?.files['.ailib/behavior.md']);
+  assert.equal(
+    lock.workspaces['.']?.files['.ailib/modules/eslint.md']?.source,
+    'languages/typescript/modules/eslint.md'
+  );
+  assert.equal(lock.workspaces['apps/api']?.files['.ailib/modules/custom-module.md']?.source, 'local');
+  assert.match(lock.workspaces['apps/api']?.files['.ailib/modules/custom-module.md']?.sha256 || '', /^[a-f0-9]{64}$/);
+});

--- a/src/cli/lockfile.ts
+++ b/src/cli/lockfile.ts
@@ -1,0 +1,84 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import path from 'node:path';
+import { workspaceLabelFor } from './context-resolution.ts';
+import type { WorkspaceState } from './types.ts';
+
+export async function writeRootLock({
+  rootDir,
+  packageRoot,
+  packageVersion,
+  registryRef,
+  allStates
+}: {
+  rootDir: string;
+  packageRoot: string;
+  packageVersion: string;
+  registryRef: string;
+  allStates: Map<string, WorkspaceState>;
+}) {
+  const registryText = await fs.readFile(path.join(packageRoot, 'registry.json'), 'utf8');
+  const lock = {
+    lockfile_version: 1,
+    cli_version: packageVersion,
+    registry_ref: registryRef,
+    registry_sha256: sha256(registryText),
+    workspaces: {} as Record<string, { files: Record<string, { source: string; sha256: string }> }>
+  };
+
+  for (const [workspaceDir, state] of allStates.entries()) {
+    const relWorkspace = workspaceLabelFor(rootDir, workspaceDir);
+    const files: Record<string, { source: string; sha256: string }> = {};
+
+    if (path.resolve(workspaceDir) === path.resolve(rootDir)) {
+      const rel = '.ailib/behavior.md';
+      const text = await fs.readFile(path.join(workspaceDir, rel), 'utf8');
+      files[rel] = { source: 'core/behavior.md', sha256: sha256(text) };
+    }
+
+    {
+      const rel = '.ailib/development-standards.md';
+      const text = await fs.readFile(path.join(workspaceDir, rel), 'utf8');
+      files[rel] = { source: 'core/development-standards.md', sha256: sha256(text) };
+    }
+
+    {
+      const rel = '.ailib/test-standards.md';
+      const text = await fs.readFile(path.join(workspaceDir, rel), 'utf8');
+      files[rel] = { source: 'core/test-standards.md', sha256: sha256(text) };
+    }
+
+    {
+      const rel = '.ailib/standards.md';
+      const text = await fs.readFile(path.join(workspaceDir, rel), 'utf8');
+      files[rel] = { source: `languages/${state.effective.language}/core.md`, sha256: sha256(text) };
+    }
+
+    for (const mod of state.localModules) {
+      const rel = `.ailib/modules/${mod}.md`;
+      const full = path.join(workspaceDir, rel);
+      const text = await fs.readFile(full, 'utf8');
+      let source = `languages/${state.effective.language}/modules/${mod}.md`;
+      if (!(await exists(path.join(packageRoot, source)))) source = 'local';
+      files[rel] = { source, sha256: sha256(text) };
+    }
+
+    lock.workspaces[relWorkspace] = { files };
+  }
+
+  await fs.writeFile(path.join(rootDir, 'ailib.lock'), `${JSON.stringify(lock, null, 2)}\n`, 'utf8');
+}
+
+function sha256(value: string) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+async function exists(filePath: string) {
+  try {
+    await fs.access(filePath, fsConstants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- extract root lockfile generation from `src/cli.ts` into `src/cli/lockfile.ts`
- add colocated tests in `src/cli/lockfile.test.ts` covering source resolution and lock shape
- preserve CLI behavior while reducing orchestration complexity and improving testability

## TDD Evidence
- [ ] Behavior change: I added/updated a failing test first (Red), then implemented (Green), then refactored.
- [x] Refactor/docs/chore only: no behavior change, so Red step is not applicable.
- Red evidence:
  - Not applicable (behavior-preserving refactor)
- Green evidence:
  - `bun test src/cli/lockfile.test.ts`
  - `bun run check`

## Test plan
- [x] `bun test src/cli/lockfile.test.ts`
- [x] `bun run check`

Refs #85
Refs #86
Refs #84
Refs #87
Refs #83

Made with [Cursor](https://cursor.com)