### PR TITLE
refactor: extract cli utility helpers

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,4 @@
 import fs from 'node:fs/promises';
-import { constants as fsConstants } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { executeCommand } from './cli/dispatch.ts';
@@ -21,6 +20,16 @@ import { applyListOverride, applySlotOverrides, mergeWorkspaceOverrides } from '
 import { diffSlots, mergeModules, mergeTargets } from './cli/module-selection.ts';
 import { validateModuleSelection } from './cli/module-validation.ts';
 import { isRecord, validateWorkspaceOverride } from './cli/override-validation.ts';
+import {
+  canonicalSlot,
+  exists,
+  readJson,
+  rmIfExists,
+  sanitizeForFilename,
+  splitCsv,
+  toPosix,
+  uniqueList
+} from './cli/utils.ts';
 import { resolveExtendsBase } from './cli/workspace-config.ts';
 import { listWorkspaceDirs } from './cli/workspace-discovery.ts';
 import type {
@@ -45,7 +54,11 @@ import type {
 const CONFIG_FILE = 'ailib.config.json';
 const LOCAL_OVERRIDE_FILE = 'ailib.local.json';
 const LOCK_FILE = 'ailib.lock';
-const WARNED_SLOT_ALIASES = new Set();
+const WARNED_SLOT_ALIASES = new Set<string>();
+
+function resolveCanonicalSlot(registry: Registry, slot: string | undefined) {
+  return canonicalSlot({ registry, slot, warnedSlotAliases: WARNED_SLOT_ALIASES });
+}
 
 export async function run(argv: string[], options: RunOptions = {}) {
   const cwd = options.cwd ?? process.cwd();
@@ -158,7 +171,12 @@ async function initCommand({ cwd, packageRoot, flags }: CommandContext) {
   const targets = uniqueList(splitCsv(flags.targets).length ? splitCsv(flags.targets) : Object.keys(registry.targets));
   const onConflict = getStringFlag(flags, 'on-conflict') || 'merge';
 
-  validateModuleSelection({ registry, language, modules, canonicalSlot: (slot) => canonicalSlot(registry, slot) });
+  validateModuleSelection({
+    registry,
+    language,
+    modules,
+    canonicalSlot: (slot) => resolveCanonicalSlot(registry, slot)
+  });
 
   if (inServiceContext && flags['no-inherit'] !== true) {
     const projectRoot = path.resolve(cwd);
@@ -238,7 +256,7 @@ async function addCommand({ cwd, packageRoot, flags }: CommandContext) {
     registry,
     language: effective.language,
     modules: uniqueList([...(config.modules || []), moduleId]),
-    canonicalSlot: (slot) => canonicalSlot(registry, slot)
+    canonicalSlot: (slot) => resolveCanonicalSlot(registry, slot)
   });
 
   config.modules = uniqueList([...(config.modules || []), moduleId]);
@@ -359,7 +377,7 @@ async function doctorCommand({ cwd, packageRoot, flags }: CommandContext) {
         workspaceModules: state.effective.modules,
         registry,
         language: state.effective.language,
-        canonicalSlot: (slot) => canonicalSlot(registry, slot)
+        canonicalSlot: (slot) => resolveCanonicalSlot(registry, slot)
       });
       for (const msg of slotDiffs) warnings.push(`[${workspaceLabel}] ${msg}`);
     }
@@ -656,7 +674,7 @@ async function buildWorkspaceState({
     registry,
     language: effective.language,
     modules: effective.modules,
-    canonicalSlot: (slot) => canonicalSlot(registry, slot)
+    canonicalSlot: (slot) => resolveCanonicalSlot(registry, slot)
   });
 
   const requiredFiles = [
@@ -700,7 +718,7 @@ async function getEffectiveWorkspaceConfig({
     language,
     parentModules: isRootWorkspace ? [] : base.modules || [],
     localModules: workspaceRaw.modules || (isRootWorkspace ? base.modules || [] : []),
-    canonicalSlot: (slot) => canonicalSlot(registry, slot)
+    canonicalSlot: (slot) => resolveCanonicalSlot(registry, slot)
   });
 
   const targets = mergeTargets({
@@ -789,7 +807,7 @@ async function applyLocalOverrides({
     modules: moduleResult.values,
     slots: override.slots || {},
     localOverrideFile: LOCAL_OVERRIDE_FILE,
-    canonicalSlot: (slot) => canonicalSlot(registry, slot)
+    canonicalSlot: (slot) => resolveCanonicalSlot(registry, slot)
   });
 
   return {
@@ -871,7 +889,7 @@ async function validateLocalOverrideConfig({
         override: config.default_override,
         label: 'default_override',
         registry,
-        canonicalSlot: (slot) => canonicalSlot(registry, slot)
+        canonicalSlot: (slot) => resolveCanonicalSlot(registry, slot)
       })
     );
   }
@@ -893,7 +911,7 @@ async function validateLocalOverrideConfig({
             override,
             label: `workspace_overrides.${workspaceKey}`,
             registry,
-            canonicalSlot: (slot) => canonicalSlot(registry, slot)
+            canonicalSlot: (slot) => resolveCanonicalSlot(registry, slot)
           })
         );
       }
@@ -915,59 +933,6 @@ async function assertLocalOverridesValid({
   await loadLocalOverrideConfig({ rootDir, rootConfig, registry });
 }
 
-function sanitizeForFilename(input: string) {
-  return toPosix(input).replaceAll('/', '__').replaceAll(':', '_');
-}
-
-function toPosix(value: string) {
-  return value.split(path.sep).join('/');
-}
-
-async function exists(filePath: string) {
-  try {
-    await fs.access(filePath, fsConstants.F_OK);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function rmIfExists(filePath: string) {
-  if (!(await exists(filePath))) return;
-  await fs.rm(filePath, { recursive: true, force: true });
-}
-
-async function readJson<T = unknown>(filePath: string): Promise<T> {
-  return JSON.parse(await fs.readFile(filePath, 'utf8')) as T;
-}
-
 function ensure(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(message);
-}
-
-function splitCsv(value: string | boolean | string[] | undefined) {
-  if (!value) return [];
-  if (Array.isArray(value)) return value;
-  if (typeof value !== 'string') return [];
-  return value
-    .split(',')
-    .map((v) => v.trim())
-    .filter(Boolean);
-}
-
-function uniqueList(items: string[]) {
-  return [...new Set(items)];
-}
-
-function canonicalSlot(registry: Registry, slot: string | undefined) {
-  if (!slot) return null;
-  const aliases = registry.slot_aliases || {};
-  const resolved = aliases[slot] || slot;
-  if (resolved !== slot && !WARNED_SLOT_ALIASES.has(slot)) {
-    const aliasMeta = registry.slot_alias_meta?.[slot];
-    const removeIn = aliasMeta?.remove_in ? ` and is planned for removal in ${aliasMeta.remove_in}` : '';
-    process.stderr.write(`warning: slot alias '${slot}' is deprecated; use '${resolved}'${removeIn}\n`);
-    WARNED_SLOT_ALIASES.add(slot);
-  }
-  return resolved;
 }

--- a/src/cli/utils.test.ts
+++ b/src/cli/utils.test.ts
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  canonicalSlot,
+  exists,
+  readJson,
+  rmIfExists,
+  sanitizeForFilename,
+  splitCsv,
+  toPosix,
+  uniqueList
+} from './utils.ts';
+import type { Registry } from './types.ts';
+
+async function tempDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'ailib-utils-'));
+}
+
+test('string utilities normalize values as expected', () => {
+  assert.equal(sanitizeForFilename('apps/api:v1'), 'apps__api_v1');
+  assert.equal(toPosix(`apps${path.sep}api`), 'apps/api');
+  assert.deepEqual(splitCsv(' a, b ,,c '), ['a', 'b', 'c']);
+  assert.deepEqual(splitCsv(['x', 'y']), ['x', 'y']);
+  assert.deepEqual(splitCsv(true), []);
+  assert.deepEqual(uniqueList(['a', 'b', 'a']), ['a', 'b']);
+});
+
+test('file utilities support existence checks, reads, and safe removals', async () => {
+  const root = await tempDir();
+  const jsonFile = path.join(root, 'data.json');
+  const nestedDir = path.join(root, 'nested');
+  await fs.mkdir(nestedDir, { recursive: true });
+  await fs.writeFile(jsonFile, '{"ok":true}', 'utf8');
+  await fs.writeFile(path.join(nestedDir, 'file.txt'), 'hello', 'utf8');
+
+  assert.equal(await exists(jsonFile), true);
+  assert.deepEqual(await readJson<{ ok: boolean }>(jsonFile), { ok: true });
+  await rmIfExists(nestedDir);
+  assert.equal(await exists(nestedDir), false);
+  await rmIfExists(path.join(root, 'missing'));
+});
+
+test('canonicalSlot resolves aliases and warns only once', () => {
+  const registry: Registry = {
+    version: 'test',
+    slots: ['runtime'],
+    slot_aliases: { platform: 'runtime' },
+    slot_alias_meta: { platform: { replacement: 'runtime', remove_in: '2.0.0' } },
+    languages: { typescript: { modules: {} } },
+    targets: { cursor: { output: '.cursor/rules' } }
+  };
+
+  const warnedSlotAliases = new Set<string>();
+  const warnings: string[] = [];
+  const writeWarning = (line: string) => {
+    warnings.push(line);
+  };
+
+  assert.equal(canonicalSlot({ registry, slot: 'platform', warnedSlotAliases, writeWarning }), 'runtime');
+  assert.equal(canonicalSlot({ registry, slot: 'platform', warnedSlotAliases, writeWarning }), 'runtime');
+  assert.equal(canonicalSlot({ registry, slot: 'runtime', warnedSlotAliases, writeWarning }), 'runtime');
+  assert.equal(canonicalSlot({ registry, slot: undefined, warnedSlotAliases, writeWarning }), null);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /slot alias 'platform' is deprecated/);
+});

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -1,0 +1,70 @@
+import fs from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import type { Registry } from './types.ts';
+
+export function sanitizeForFilename(input: string) {
+  return toPosix(input).replaceAll('/', '__').replaceAll(':', '_');
+}
+
+export function toPosix(value: string) {
+  return value.split(path.sep).join('/');
+}
+
+export async function exists(filePath: string) {
+  try {
+    await fs.access(filePath, fsConstants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function rmIfExists(filePath: string) {
+  if (!(await exists(filePath))) return;
+  await fs.rm(filePath, { recursive: true, force: true });
+}
+
+export async function readJson<T = unknown>(filePath: string): Promise<T> {
+  return JSON.parse(await fs.readFile(filePath, 'utf8')) as T;
+}
+
+export function splitCsv(value: string | boolean | string[] | undefined) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+  if (typeof value !== 'string') return [];
+  return value
+    .split(',')
+    .map((v) => v.trim())
+    .filter(Boolean);
+}
+
+export function uniqueList(items: string[]) {
+  return [...new Set(items)];
+}
+
+export function canonicalSlot({
+  registry,
+  slot,
+  warnedSlotAliases,
+  writeWarning
+}: {
+  registry: Registry;
+  slot: string | undefined;
+  warnedSlotAliases: Set<string>;
+  writeWarning?: (line: string) => void;
+}) {
+  if (!slot) return null;
+  const aliases = registry.slot_aliases || {};
+  const resolved = aliases[slot] || slot;
+  if (resolved !== slot && !warnedSlotAliases.has(slot)) {
+    const aliasMeta = registry.slot_alias_meta?.[slot];
+    const removeIn = aliasMeta?.remove_in ? ` and is planned for removal in ${aliasMeta.remove_in}` : '';
+    (writeWarning || ((line: string) => process.stderr.write(line)))(
+      `warning: slot alias '${slot}' is deprecated; use '${resolved}'${removeIn}\n`
+    );
+    warnedSlotAliases.add(slot);
+  }
+  return resolved;
+}


### PR DESCRIPTION
## Summary
- extract shared CLI utility helpers into `src/cli/utils.ts` (`exists`, `rmIfExists`, `readJson`, CSV/list helpers, filename sanitization)
- move slot alias canonicalization and deprecation warning behavior into a reusable utility function
- add colocated tests in `src/cli/utils.test.ts` and wire `src/cli.ts` to use the new utility module

## TDD Evidence
- [ ] Behavior change: I added/updated a failing test first (Red), then implemented (Green), then refactored.
- [x] Refactor/docs/chore only: no behavior change, so Red step is not applicable.
- Red evidence:
  - Not applicable (behavior-preserving refactor)
- Green evidence:
  - `bun test src/cli/utils.test.ts src/cli.test.ts`
  - `bun run check`

## Test plan
- [x] `bun test src/cli/utils.test.ts src/cli.test.ts`
- [x] `bun run check`

Refs #85
Refs #86
Refs #84
Refs #87
Refs #83

Made with [Cursor](https://cursor.com)