### PR TITLE
refactor: extract local override config

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,10 +16,10 @@ import {
 } from './cli/context-resolution.ts';
 import { copySourceFile, parseFrontmatter, writeManagedFile } from './cli/file-helpers.ts';
 import { writeRootLock } from './cli/lockfile.ts';
+import { assertLocalOverridesValid, loadLocalOverrideConfig } from './cli/local-override-config.ts';
 import { applyListOverride, applySlotOverrides, mergeWorkspaceOverrides } from './cli/local-overrides.ts';
 import { diffSlots, mergeModules, mergeTargets } from './cli/module-selection.ts';
 import { validateModuleSelection } from './cli/module-validation.ts';
-import { isRecord, validateWorkspaceOverride } from './cli/override-validation.ts';
 import {
   canonicalSlot,
   exists,
@@ -38,7 +38,6 @@ import type {
   EffectiveWorkspaceConfig,
   LanguageDefinition,
   ListOverrideScope,
-  LocalOverrideConfig,
   ModuleDefinition,
   Registry,
   RunOptions,
@@ -309,7 +308,13 @@ async function doctorCommand({ cwd, packageRoot, flags }: CommandContext) {
   const errors: string[] = [];
   const warnings: string[] = [];
   try {
-    await assertLocalOverridesValid({ rootDir: context.rootDir, rootConfig, registry });
+    await assertLocalOverridesValid({
+      rootDir: context.rootDir,
+      rootConfig,
+      registry,
+      canonicalSlot: (slot) => resolveCanonicalSlot(registry, slot),
+      localOverrideFile: LOCAL_OVERRIDE_FILE
+    });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     errors.push(message);
@@ -469,7 +474,13 @@ async function applyWorkspaceUpdate({
   const registry = await readJson<Registry>(path.join(packageRoot, 'registry.json'));
   const packageJson = await readJson<{ version: string }>(path.join(packageRoot, 'package.json'));
   const rootConfig = await readJson<WorkspaceConfig>(rootConfigPath);
-  await assertLocalOverridesValid({ rootDir, rootConfig, registry });
+  await assertLocalOverridesValid({
+    rootDir,
+    rootConfig,
+    registry,
+    canonicalSlot: (slot) => resolveCanonicalSlot(registry, slot),
+    localOverrideFile: LOCAL_OVERRIDE_FILE
+  });
 
   const workspaceDirs = await listWorkspaceDirs({ rootDir, rootConfig, workspaceOverride });
   const allWorkspaceDirs = await listWorkspaceDirs({ rootDir, rootConfig });
@@ -772,7 +783,13 @@ async function applyLocalOverrides({
   targets: string[];
 }): Promise<{ modules: string[]; targets: string[]; warnings: string[] }> {
   const warnings: string[] = [];
-  const config = await loadLocalOverrideConfig({ rootDir, rootConfig, registry });
+  const config = await loadLocalOverrideConfig({
+    rootDir,
+    rootConfig,
+    registry,
+    canonicalSlot: (slot) => resolveCanonicalSlot(registry, slot),
+    localOverrideFile: LOCAL_OVERRIDE_FILE
+  });
   if (!config) {
     return { modules, targets, warnings };
   }
@@ -815,122 +832,6 @@ async function applyLocalOverrides({
     targets: targetResult.values,
     warnings
   };
-}
-
-async function loadLocalOverrideConfig({
-  rootDir,
-  rootConfig,
-  registry
-}: {
-  rootDir: string;
-  rootConfig: WorkspaceConfig;
-  registry: Registry;
-}): Promise<LocalOverrideConfig | null> {
-  const overridePath = path.join(rootDir, LOCAL_OVERRIDE_FILE);
-  if (!(await exists(overridePath))) {
-    return null;
-  }
-
-  const prefix = `Invalid ${LOCAL_OVERRIDE_FILE}`;
-  let config: LocalOverrideConfig;
-  try {
-    config = await readJson<LocalOverrideConfig>(overridePath);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`${prefix}: invalid JSON (${message})`);
-  }
-
-  const errors = await validateLocalOverrideConfig({ rootDir, rootConfig, registry, config });
-  if (errors.length) {
-    throw new Error(`${prefix}:\n- ${errors.join('\n- ')}`);
-  }
-
-  return config;
-}
-
-async function validateLocalOverrideConfig({
-  rootDir,
-  rootConfig,
-  registry,
-  config
-}: {
-  rootDir: string;
-  rootConfig: WorkspaceConfig;
-  registry: Registry;
-  config: LocalOverrideConfig;
-}): Promise<string[]> {
-  const errors: string[] = [];
-  if (!isRecord(config)) {
-    return ['expected object at root'];
-  }
-
-  const allowedRootKeys = new Set(['version', 'default_override', 'workspace_overrides']);
-  for (const key of Object.keys(config)) {
-    if (!allowedRootKeys.has(key)) {
-      errors.push(`unexpected root key '${key}'`);
-    }
-  }
-
-  if (typeof config.version !== 'string' || !config.version.trim()) {
-    errors.push(`missing required string 'version'`);
-  }
-
-  const workspaceDirs = await listWorkspaceDirs({ rootDir, rootConfig });
-  const workspaceKeys = new Set([
-    '.',
-    ...workspaceDirs
-      .filter((workspaceDir) => path.resolve(workspaceDir) !== path.resolve(rootDir))
-      .map((workspaceDir) => toPosix(path.relative(rootDir, workspaceDir)))
-  ]);
-
-  if (config.default_override !== undefined) {
-    errors.push(
-      ...validateWorkspaceOverride({
-        override: config.default_override,
-        label: 'default_override',
-        registry,
-        canonicalSlot: (slot) => resolveCanonicalSlot(registry, slot)
-      })
-    );
-  }
-
-  if (config.workspace_overrides !== undefined) {
-    if (!isRecord(config.workspace_overrides)) {
-      errors.push(`'workspace_overrides' must be an object`);
-    } else {
-      for (const [workspaceKey, override] of Object.entries(config.workspace_overrides)) {
-        if (typeof workspaceKey !== 'string' || !workspaceKey.trim()) {
-          errors.push(`workspace override key must be a non-empty string`);
-          continue;
-        }
-        if (!workspaceKeys.has(workspaceKey)) {
-          errors.push(`unknown workspace override key '${workspaceKey}'`);
-        }
-        errors.push(
-          ...validateWorkspaceOverride({
-            override,
-            label: `workspace_overrides.${workspaceKey}`,
-            registry,
-            canonicalSlot: (slot) => resolveCanonicalSlot(registry, slot)
-          })
-        );
-      }
-    }
-  }
-
-  return errors;
-}
-
-async function assertLocalOverridesValid({
-  rootDir,
-  rootConfig,
-  registry
-}: {
-  rootDir: string;
-  rootConfig: WorkspaceConfig;
-  registry: Registry;
-}) {
-  await loadLocalOverrideConfig({ rootDir, rootConfig, registry });
 }
 
 function ensure(condition: unknown, message: string): asserts condition {

--- a/src/cli/local-override-config.test.ts
+++ b/src/cli/local-override-config.test.ts
@@ -1,0 +1,100 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { loadLocalOverrideConfig, validateLocalOverrideConfig } from './local-override-config.ts';
+import type { LocalOverrideConfig, Registry, WorkspaceConfig } from './types.ts';
+
+async function tempDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'ailib-local-override-config-'));
+}
+
+const rootConfig: WorkspaceConfig = {
+  language: 'typescript',
+  modules: [],
+  targets: ['cursor'],
+  docs_path: 'docs/'
+};
+
+const registry: Registry = {
+  version: 'test',
+  slots: ['linter'],
+  slot_aliases: { lint: 'linter' },
+  languages: {
+    typescript: {
+      modules: {
+        eslint: { slot: 'linter' }
+      }
+    }
+  },
+  targets: {
+    cursor: { output: '.cursor/rules' }
+  }
+};
+
+const canonicalSlot = (slot: string | undefined) => {
+  if (!slot) return null;
+  return registry.slot_aliases?.[slot] || slot;
+};
+
+test('loadLocalOverrideConfig returns null when file is missing', async () => {
+  const rootDir = await tempDir();
+  const result = await loadLocalOverrideConfig({
+    rootDir,
+    rootConfig,
+    registry,
+    canonicalSlot,
+    localOverrideFile: 'ailib.local.json'
+  });
+  assert.equal(result, null);
+});
+
+test('loadLocalOverrideConfig throws for invalid JSON', async () => {
+  const rootDir = await tempDir();
+  await fs.writeFile(path.join(rootDir, 'ailib.local.json'), '{broken', 'utf8');
+  await assert.rejects(
+    loadLocalOverrideConfig({
+      rootDir,
+      rootConfig,
+      registry,
+      canonicalSlot,
+      localOverrideFile: 'ailib.local.json'
+    }),
+    /Invalid ailib\.local\.json: invalid JSON/
+  );
+});
+
+test('validateLocalOverrideConfig reports unknown workspace and shape issues', async () => {
+  const rootDir = await tempDir();
+  const config = {
+    version: '',
+    workspace_overrides: {
+      'apps/missing': { targets: { set: ['cursor'] } }
+    }
+  } as unknown as LocalOverrideConfig;
+
+  const errors = await validateLocalOverrideConfig({ rootDir, rootConfig, registry, config, canonicalSlot });
+  assert.ok(errors.some((error) => error.includes("missing required string 'version'")));
+  assert.ok(errors.some((error) => error.includes("unknown workspace override key 'apps/missing'")));
+});
+
+test('loadLocalOverrideConfig accepts a valid override file', async () => {
+  const rootDir = await tempDir();
+  const config: LocalOverrideConfig = {
+    version: '1',
+    default_override: {
+      modules: { set: ['eslint'] }
+    }
+  };
+  await fs.writeFile(path.join(rootDir, 'ailib.local.json'), `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+
+  const loaded = await loadLocalOverrideConfig({
+    rootDir,
+    rootConfig,
+    registry,
+    canonicalSlot,
+    localOverrideFile: 'ailib.local.json'
+  });
+  assert.deepEqual(loaded, config);
+});

--- a/src/cli/local-override-config.ts
+++ b/src/cli/local-override-config.ts
@@ -1,0 +1,122 @@
+import path from 'node:path';
+import { listWorkspaceDirs } from './workspace-discovery.ts';
+import { isRecord, validateWorkspaceOverride } from './override-validation.ts';
+import { exists, readJson, toPosix } from './utils.ts';
+import type { LocalOverrideConfig, Registry, WorkspaceConfig } from './types.ts';
+
+export async function loadLocalOverrideConfig({
+  rootDir,
+  rootConfig,
+  registry,
+  canonicalSlot,
+  localOverrideFile
+}: {
+  rootDir: string;
+  rootConfig: WorkspaceConfig;
+  registry: Registry;
+  canonicalSlot: (slot: string | undefined) => string | null;
+  localOverrideFile: string;
+}): Promise<LocalOverrideConfig | null> {
+  const overridePath = path.join(rootDir, localOverrideFile);
+  if (!(await exists(overridePath))) return null;
+
+  const prefix = `Invalid ${localOverrideFile}`;
+  let config: LocalOverrideConfig;
+  try {
+    config = await readJson<LocalOverrideConfig>(overridePath);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`${prefix}: invalid JSON (${message})`);
+  }
+
+  const errors = await validateLocalOverrideConfig({ rootDir, rootConfig, registry, config, canonicalSlot });
+  if (errors.length) throw new Error(`${prefix}:\n- ${errors.join('\n- ')}`);
+  return config;
+}
+
+export async function validateLocalOverrideConfig({
+  rootDir,
+  rootConfig,
+  registry,
+  config,
+  canonicalSlot
+}: {
+  rootDir: string;
+  rootConfig: WorkspaceConfig;
+  registry: Registry;
+  config: LocalOverrideConfig;
+  canonicalSlot: (slot: string | undefined) => string | null;
+}): Promise<string[]> {
+  const errors: string[] = [];
+  if (!isRecord(config)) return ['expected object at root'];
+
+  const allowedRootKeys = new Set(['version', 'default_override', 'workspace_overrides']);
+  for (const key of Object.keys(config)) {
+    if (!allowedRootKeys.has(key)) errors.push(`unexpected root key '${key}'`);
+  }
+
+  if (typeof config.version !== 'string' || !config.version.trim()) {
+    errors.push(`missing required string 'version'`);
+  }
+
+  const workspaceDirs = await listWorkspaceDirs({ rootDir, rootConfig });
+  const workspaceKeys = new Set([
+    '.',
+    ...workspaceDirs
+      .filter((workspaceDir) => path.resolve(workspaceDir) !== path.resolve(rootDir))
+      .map((workspaceDir) => toPosix(path.relative(rootDir, workspaceDir)))
+  ]);
+
+  if (config.default_override !== undefined) {
+    errors.push(
+      ...validateWorkspaceOverride({
+        override: config.default_override,
+        label: 'default_override',
+        registry,
+        canonicalSlot
+      })
+    );
+  }
+
+  if (config.workspace_overrides !== undefined) {
+    if (!isRecord(config.workspace_overrides)) {
+      errors.push(`'workspace_overrides' must be an object`);
+    } else {
+      for (const [workspaceKey, override] of Object.entries(config.workspace_overrides)) {
+        if (typeof workspaceKey !== 'string' || !workspaceKey.trim()) {
+          errors.push(`workspace override key must be a non-empty string`);
+          continue;
+        }
+        if (!workspaceKeys.has(workspaceKey)) {
+          errors.push(`unknown workspace override key '${workspaceKey}'`);
+        }
+        errors.push(
+          ...validateWorkspaceOverride({
+            override,
+            label: `workspace_overrides.${workspaceKey}`,
+            registry,
+            canonicalSlot
+          })
+        );
+      }
+    }
+  }
+
+  return errors;
+}
+
+export async function assertLocalOverridesValid({
+  rootDir,
+  rootConfig,
+  registry,
+  canonicalSlot,
+  localOverrideFile
+}: {
+  rootDir: string;
+  rootConfig: WorkspaceConfig;
+  registry: Registry;
+  canonicalSlot: (slot: string | undefined) => string | null;
+  localOverrideFile: string;
+}) {
+  await loadLocalOverrideConfig({ rootDir, rootConfig, registry, canonicalSlot, localOverrideFile });
+}


### PR DESCRIPTION
## Summary
- extract local override loading/validation from `src/cli.ts` into `src/cli/local-override-config.ts`
- keep runtime behavior unchanged while reducing command orchestration responsibility in `src/cli.ts`
- add colocated tests in `src/cli/local-override-config.test.ts` for missing file, invalid JSON, validation errors, and valid config load

## TDD Evidence
- [ ] Behavior change: I added/updated a failing test first (Red), then implemented (Green), then refactored.
- [x] Refactor/docs/chore only: no behavior change, so Red step is not applicable.
- Red evidence:
  - Not applicable (behavior-preserving refactor)
- Green evidence:
  - `bun test src/cli/local-override-config.test.ts src/cli.test.ts test/cli.test.ts`
  - `bun run check`

## Test plan
- [x] `bun test src/cli/local-override-config.test.ts src/cli.test.ts test/cli.test.ts`
- [x] `bun run check`

Refs #85
Refs #84
Refs #87
Refs #83

Made with [Cursor](https://cursor.com)