### PR TITLE
refactor: extract router generation module

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,6 @@ import {
   detectProjectRoot,
   findNearestMonorepoRoot,
   isRootWorkspaceConfig,
-  relativePathForPointers,
   resolveContext,
   resolveDefaultWorkspaceForMutation,
   resolveWorkspacePath,
@@ -19,17 +18,9 @@ import { writeRootLock } from './cli/lockfile.ts';
 import { assertLocalOverridesValid } from './cli/local-override-config.ts';
 import { diffSlots } from './cli/module-selection.ts';
 import { validateModuleSelection } from './cli/module-validation.ts';
+import { generateWorkspaceRouters } from './cli/router-generation.ts';
 import { buildWorkspaceState, getEffectiveWorkspaceConfig } from './cli/workspace-state.ts';
-import {
-  canonicalSlot,
-  exists,
-  readJson,
-  rmIfExists,
-  sanitizeForFilename,
-  splitCsv,
-  toPosix,
-  uniqueList
-} from './cli/utils.ts';
+import { canonicalSlot, exists, readJson, rmIfExists, splitCsv, toPosix, uniqueList } from './cli/utils.ts';
 import { listWorkspaceDirs } from './cli/workspace-discovery.ts';
 import type {
   CliFlags,
@@ -592,104 +583,6 @@ async function ensureWorkspaceAssets({
       if (!localSet.has(id)) await rmIfExists(path.join(moduleDir, entry));
     }
   }
-}
-
-async function generateWorkspaceRouters({
-  workspaceDir,
-  rootDir,
-  state,
-  onConflict,
-  allStates,
-  registry
-}: {
-  workspaceDir: string;
-  rootDir: string;
-  state: WorkspaceState;
-  onConflict: string;
-  allStates: Map<string, WorkspaceState>;
-  registry: Registry;
-}) {
-  const targetSet = new Set<string>(state.effective.targets || []);
-  const atRoot = path.resolve(workspaceDir) === path.resolve(rootDir);
-
-  for (const targetId of targetSet) {
-    const targetDef = registry.targets[targetId];
-    if (!targetDef || targetDef.mode === 'copilot') continue;
-
-    const label = targetDef.display || targetId;
-    const frontmatter = targetDef.frontmatter
-      ? atRoot
-        ? targetDef.frontmatter.root
-        : targetDef.frontmatter.workspace
-      : '';
-    const rendered = `${frontmatter || ''}${renderRouterDoc({ label, workspaceDir, rootDir, state })}`;
-    await writeManagedFile({ outPath: path.join(workspaceDir, targetDef.output), rendered, onConflict });
-
-    if (atRoot && targetDef.root_output) {
-      await writeManagedFile({ outPath: path.join(workspaceDir, targetDef.root_output), rendered, onConflict });
-    }
-  }
-
-  if (atRoot && targetSet.has('copilot')) {
-    const scopedStates = [...allStates.entries()].filter(([, s]) => (s.effective.targets || []).includes('copilot'));
-    const sections = scopedStates
-      .map(([dir, s]) => {
-        const label = workspaceLabelFor(rootDir, dir);
-        return `## Workspace: ${label}\n\n${renderRouterDoc({ label: registry.targets.copilot?.display || 'GitHub Copilot', workspaceDir: dir, rootDir, state: s }).trim()}\n`;
-      })
-      .join('\n');
-
-    await writeManagedFile({
-      outPath: path.join(rootDir, registry.targets.copilot?.output || '.github/copilot-instructions.md'),
-      rendered: `# ailib Router (${registry.targets.copilot?.display || 'GitHub Copilot'})\n\n${sections}`,
-      onConflict
-    });
-
-    for (const [dir, s] of scopedStates) {
-      const rel = workspaceLabelFor(rootDir, dir);
-      const applyTo = rel === '.' ? '**' : `${toPosix(rel)}/**`;
-      const fileName = rel === '.' ? 'root.instructions.md' : `${sanitizeForFilename(rel)}.instructions.md`;
-      const content = `---\napplyTo: "${applyTo}"\n---\n\n${renderRouterDoc({ label: registry.targets.copilot?.display || 'GitHub Copilot', workspaceDir: dir, rootDir, state: s })}`;
-      await writeManagedFile({
-        outPath: path.join(rootDir, '.github/instructions', fileName),
-        rendered: content,
-        onConflict
-      });
-    }
-  }
-}
-
-function renderRouterDoc({
-  label,
-  workspaceDir,
-  rootDir,
-  state
-}: {
-  label: string;
-  workspaceDir: string;
-  rootDir: string;
-  state: WorkspaceState;
-}) {
-  const relToRoot = relativePathForPointers(workspaceDir, rootDir);
-  const behaviorRef =
-    path.resolve(workspaceDir) === path.resolve(rootDir)
-      ? '@.ailib/behavior.md'
-      : `@${toPosix(path.join(relToRoot, '.ailib/behavior.md'))}`;
-
-  const inheritedModuleLines = state.inheritedModules.map((mod) => {
-    const modPath = `@${toPosix(path.join(relToRoot, '.ailib/modules', `${mod}.md`))}`;
-    return `- ${modPath}`;
-  });
-
-  const localModuleLines = state.localModules.map((mod) => `- @.ailib/modules/${mod}.md`);
-  const moduleLines = [...inheritedModuleLines, ...localModuleLines];
-  const docsBlock =
-    path.resolve(workspaceDir) === path.resolve(rootDir)
-      ? '# PROJECT-SPECIFIC CONTEXT\nPrioritize project context in @./docs/.\n'
-      : `# PROJECT-SPECIFIC CONTEXT\nPrioritize service-local business logic in @./docs/.\nFor cross-service context, consult @${toPosix(path.join(relToRoot, 'docs/'))}.\nIf guidance conflicts, service-local docs win for service-scoped work.\n`;
-
-  const modulesText = moduleLines.length ? moduleLines.join('\n') : '- (none)';
-  return `# ailib Router (${label})\n\n# AILIB SYSTEM PROMPT\nAct as the AI Agent defined in ${behaviorRef}.\nAdhere to the coding standards in @.ailib/standards.md.\nApply development workflow rules in @.ailib/development-standards.md.\nApply test and coverage rules in @.ailib/test-standards.md.\n\n# MODULES & EXTENSIONS\n${modulesText}\n\n${docsBlock}`;
 }
 
 function ensure(condition: unknown, message: string): asserts condition {

--- a/src/cli/router-generation.test.ts
+++ b/src/cli/router-generation.test.ts
@@ -1,0 +1,110 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { generateWorkspaceRouters, renderRouterDoc } from './router-generation.ts';
+import type { Registry, WorkspaceState } from './types.ts';
+
+async function tempDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'ailib-router-generation-'));
+}
+
+function state(targets: string[], inheritedModules: string[] = [], localModules: string[] = []): WorkspaceState {
+  return {
+    effective: {
+      $schema: 'https://ailib.dev/schema/config.schema.json',
+      registry_ref: 'test-registry',
+      on_conflict: 'merge',
+      language: 'typescript',
+      modules: [...inheritedModules, ...localModules],
+      targets,
+      docs_path: 'docs/',
+      inheritedModules,
+      localModules,
+      warnings: []
+    },
+    inheritedModules,
+    localModules,
+    requiredFiles: [],
+    warnings: []
+  };
+}
+
+const registry: Registry = {
+  version: 'test-registry',
+  languages: { typescript: { modules: {} } },
+  targets: {
+    cursor: {
+      output: '.cursor/rules/ai.md',
+      root_output: '.cursor/rules/root.md',
+      display: 'Cursor',
+      frontmatter: { root: '---\nroot: true\n---\n', workspace: '---\nworkspace: true\n---\n' }
+    },
+    copilot: {
+      output: '.github/copilot-instructions.md',
+      display: 'GitHub Copilot',
+      mode: 'copilot'
+    }
+  }
+};
+
+test('renderRouterDoc renders root and service docs with correct references', () => {
+  const rootDir = '/repo';
+  const rootDoc = renderRouterDoc({
+    label: 'Cursor',
+    workspaceDir: rootDir,
+    rootDir,
+    state: state(['cursor'], ['eslint'], ['pytest'])
+  });
+  assert.match(rootDoc, /Act as the AI Agent defined in @\.ailib\/behavior\.md/);
+  assert.match(rootDoc, /- @\.ailib\/modules\/pytest\.md/);
+
+  const serviceDoc = renderRouterDoc({
+    label: 'Cursor',
+    workspaceDir: '/repo/apps/api',
+    rootDir,
+    state: state(['cursor'], ['eslint'], ['pytest'])
+  });
+  assert.match(serviceDoc, /@\.\.\/\.\.\/\.ailib\/behavior\.md/);
+  assert.match(serviceDoc, /consult @\.\.\/\.\.\/docs\//);
+});
+
+test('generateWorkspaceRouters writes target outputs and copilot bundle', async () => {
+  const rootDir = await tempDir();
+  const appDir = path.join(rootDir, 'apps', 'api');
+  await fs.mkdir(appDir, { recursive: true });
+
+  const rootState = state(['cursor', 'copilot'], ['eslint'], ['pytest']);
+  const appState = state(['copilot'], ['eslint'], ['pytest']);
+  const allStates = new Map<string, WorkspaceState>([
+    [rootDir, rootState],
+    [appDir, appState]
+  ]);
+
+  await generateWorkspaceRouters({
+    workspaceDir: rootDir,
+    rootDir,
+    state: rootState,
+    onConflict: 'overwrite',
+    allStates,
+    registry
+  });
+
+  const cursorOutput = await fs.readFile(path.join(rootDir, '.cursor/rules/ai.md'), 'utf8');
+  assert.match(cursorOutput, /^---\nroot: true\n---\n/s);
+  const rootOutput = await fs.readFile(path.join(rootDir, '.cursor/rules/root.md'), 'utf8');
+  assert.match(rootOutput, /# ailib Router \(Cursor\)/);
+
+  const copilotOutput = await fs.readFile(path.join(rootDir, '.github/copilot-instructions.md'), 'utf8');
+  assert.match(copilotOutput, /## Workspace: \./);
+  assert.match(copilotOutput, /## Workspace: apps\/api/);
+
+  const rootInstructions = await fs.readFile(path.join(rootDir, '.github/instructions/root.instructions.md'), 'utf8');
+  assert.match(rootInstructions, /applyTo: "\*\*"/);
+  const appInstructions = await fs.readFile(
+    path.join(rootDir, '.github/instructions/apps__api.instructions.md'),
+    'utf8'
+  );
+  assert.match(appInstructions, /applyTo: "apps\/api\/\*\*"/);
+});

--- a/src/cli/router-generation.ts
+++ b/src/cli/router-generation.ts
@@ -1,0 +1,103 @@
+import path from 'node:path';
+import { relativePathForPointers, workspaceLabelFor } from './context-resolution.ts';
+import { writeManagedFile } from './file-helpers.ts';
+import { sanitizeForFilename, toPosix } from './utils.ts';
+import type { Registry, WorkspaceState } from './types.ts';
+
+export async function generateWorkspaceRouters({
+  workspaceDir,
+  rootDir,
+  state,
+  onConflict,
+  allStates,
+  registry
+}: {
+  workspaceDir: string;
+  rootDir: string;
+  state: WorkspaceState;
+  onConflict: string;
+  allStates: Map<string, WorkspaceState>;
+  registry: Registry;
+}) {
+  const targetSet = new Set<string>(state.effective.targets || []);
+  const atRoot = path.resolve(workspaceDir) === path.resolve(rootDir);
+
+  for (const targetId of targetSet) {
+    const targetDef = registry.targets[targetId];
+    if (!targetDef || targetDef.mode === 'copilot') continue;
+
+    const label = targetDef.display || targetId;
+    const frontmatter = targetDef.frontmatter
+      ? atRoot
+        ? targetDef.frontmatter.root
+        : targetDef.frontmatter.workspace
+      : '';
+    const rendered = `${frontmatter || ''}${renderRouterDoc({ label, workspaceDir, rootDir, state })}`;
+    await writeManagedFile({ outPath: path.join(workspaceDir, targetDef.output), rendered, onConflict });
+
+    if (atRoot && targetDef.root_output) {
+      await writeManagedFile({ outPath: path.join(workspaceDir, targetDef.root_output), rendered, onConflict });
+    }
+  }
+
+  if (atRoot && targetSet.has('copilot')) {
+    const scopedStates = [...allStates.entries()].filter(([, s]) => (s.effective.targets || []).includes('copilot'));
+    const sections = scopedStates
+      .map(([dir, s]) => {
+        const label = workspaceLabelFor(rootDir, dir);
+        return `## Workspace: ${label}\n\n${renderRouterDoc({ label: registry.targets.copilot?.display || 'GitHub Copilot', workspaceDir: dir, rootDir, state: s }).trim()}\n`;
+      })
+      .join('\n');
+
+    await writeManagedFile({
+      outPath: path.join(rootDir, registry.targets.copilot?.output || '.github/copilot-instructions.md'),
+      rendered: `# ailib Router (${registry.targets.copilot?.display || 'GitHub Copilot'})\n\n${sections}`,
+      onConflict
+    });
+
+    for (const [dir, s] of scopedStates) {
+      const rel = workspaceLabelFor(rootDir, dir);
+      const applyTo = rel === '.' ? '**' : `${toPosix(rel)}/**`;
+      const fileName = rel === '.' ? 'root.instructions.md' : `${sanitizeForFilename(rel)}.instructions.md`;
+      const content = `---\napplyTo: "${applyTo}"\n---\n\n${renderRouterDoc({ label: registry.targets.copilot?.display || 'GitHub Copilot', workspaceDir: dir, rootDir, state: s })}`;
+      await writeManagedFile({
+        outPath: path.join(rootDir, '.github/instructions', fileName),
+        rendered: content,
+        onConflict
+      });
+    }
+  }
+}
+
+export function renderRouterDoc({
+  label,
+  workspaceDir,
+  rootDir,
+  state
+}: {
+  label: string;
+  workspaceDir: string;
+  rootDir: string;
+  state: WorkspaceState;
+}) {
+  const relToRoot = relativePathForPointers(workspaceDir, rootDir);
+  const behaviorRef =
+    path.resolve(workspaceDir) === path.resolve(rootDir)
+      ? '@.ailib/behavior.md'
+      : `@${toPosix(path.join(relToRoot, '.ailib/behavior.md'))}`;
+
+  const inheritedModuleLines = state.inheritedModules.map((mod) => {
+    const modPath = `@${toPosix(path.join(relToRoot, '.ailib/modules', `${mod}.md`))}`;
+    return `- ${modPath}`;
+  });
+
+  const localModuleLines = state.localModules.map((mod) => `- @.ailib/modules/${mod}.md`);
+  const moduleLines = [...inheritedModuleLines, ...localModuleLines];
+  const docsBlock =
+    path.resolve(workspaceDir) === path.resolve(rootDir)
+      ? '# PROJECT-SPECIFIC CONTEXT\nPrioritize project context in @./docs/.\n'
+      : `# PROJECT-SPECIFIC CONTEXT\nPrioritize service-local business logic in @./docs/.\nFor cross-service context, consult @${toPosix(path.join(relToRoot, 'docs/'))}.\nIf guidance conflicts, service-local docs win for service-scoped work.\n`;
+
+  const modulesText = moduleLines.length ? moduleLines.join('\n') : '- (none)';
+  return `# ailib Router (${label})\n\n# AILIB SYSTEM PROMPT\nAct as the AI Agent defined in ${behaviorRef}.\nAdhere to the coding standards in @.ailib/standards.md.\nApply development workflow rules in @.ailib/development-standards.md.\nApply test and coverage rules in @.ailib/test-standards.md.\n\n# MODULES & EXTENSIONS\n${modulesText}\n\n${docsBlock}`;
+}


### PR DESCRIPTION
## Summary
- extract router generation and rendering from `src/cli.ts` into `src/cli/router-generation.ts`
- keep target output behavior intact including copilot aggregate/instruction outputs
- add colocated tests in `src/cli/router-generation.test.ts` for router content and file generation paths

## TDD Evidence
- [ ] Behavior change: I added/updated a failing test first (Red), then implemented (Green), then refactored.
- [x] Refactor/docs/chore only: no behavior change, so Red step is not applicable.
- Red evidence:
  - Not applicable (behavior-preserving refactor)
- Green evidence:
  - `bun test src/cli/router-generation.test.ts src/cli.test.ts test/cli.test.ts`
  - `bun run check`

## Test plan
- [x] `bun test src/cli/router-generation.test.ts src/cli.test.ts test/cli.test.ts`
- [x] `bun run check`

Refs #85
Refs #84
Refs #87
Refs #83

Made with [Cursor](https://cursor.com)