### PR TITLE
refactor: extract workspace assets module

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,12 +13,13 @@ import {
   resolveWorkspacePath,
   workspaceLabelFor
 } from './cli/context-resolution.ts';
-import { copySourceFile, parseFrontmatter, writeManagedFile } from './cli/file-helpers.ts';
+import { parseFrontmatter } from './cli/file-helpers.ts';
 import { writeRootLock } from './cli/lockfile.ts';
 import { assertLocalOverridesValid } from './cli/local-override-config.ts';
 import { diffSlots } from './cli/module-selection.ts';
 import { validateModuleSelection } from './cli/module-validation.ts';
 import { generateWorkspaceRouters } from './cli/router-generation.ts';
+import { ensureWorkspaceAssets } from './cli/workspace-assets.ts';
 import { buildWorkspaceState, getEffectiveWorkspaceConfig } from './cli/workspace-state.ts';
 import { canonicalSlot, exists, readJson, rmIfExists, splitCsv, toPosix, uniqueList } from './cli/utils.ts';
 import { listWorkspaceDirs } from './cli/workspace-discovery.ts';
@@ -522,67 +523,6 @@ async function applyWorkspaceUpdate({
     registryRef: rootConfig.registry_ref || registry.version,
     allStates: stateMap
   });
-}
-
-async function ensureWorkspaceAssets({
-  workspaceDir,
-  packageRoot,
-  state,
-  rootDir
-}: {
-  workspaceDir: string;
-  packageRoot: string;
-  state: WorkspaceState;
-  rootDir: string;
-}) {
-  const outRoot = path.join(workspaceDir, '.ailib');
-  await fs.mkdir(path.join(outRoot, 'modules'), { recursive: true });
-
-  if (path.resolve(workspaceDir) === path.resolve(rootDir)) {
-    await copySourceFile({ packageRoot, sourceRel: 'core/behavior.md', target: path.join(outRoot, 'behavior.md') });
-  }
-
-  await copySourceFile({
-    packageRoot,
-    sourceRel: 'core/development-standards.md',
-    target: path.join(outRoot, 'development-standards.md')
-  });
-
-  await copySourceFile({
-    packageRoot,
-    sourceRel: 'core/test-standards.md',
-    target: path.join(outRoot, 'test-standards.md')
-  });
-
-  await copySourceFile({
-    packageRoot,
-    sourceRel: `languages/${state.effective.language}/core.md`,
-    target: path.join(outRoot, 'standards.md')
-  });
-
-  const localModules = state.localModules;
-  const localSet = new Set(localModules);
-  for (const mod of localModules) {
-    const sourceRel = `languages/${state.effective.language}/modules/${mod}.md`;
-    const source = path.join(packageRoot, sourceRel);
-    const target = path.join(outRoot, 'modules', `${mod}.md`);
-    if (await exists(source)) {
-      await copySourceFile({ packageRoot, sourceRel, target });
-      continue;
-    }
-
-    const existing = path.join(outRoot, 'modules', `${mod}.md`);
-    ensure(await exists(existing), `Missing module source: ${sourceRel}`);
-  }
-
-  const moduleDir = path.join(outRoot, 'modules');
-  if (await exists(moduleDir)) {
-    for (const entry of await fs.readdir(moduleDir)) {
-      if (!entry.endsWith('.md')) continue;
-      const id = entry.replace(/\.md$/u, '');
-      if (!localSet.has(id)) await rmIfExists(path.join(moduleDir, entry));
-    }
-  }
 }
 
 function ensure(condition: unknown, message: string): asserts condition {

--- a/src/cli/workspace-assets.test.ts
+++ b/src/cli/workspace-assets.test.ts
@@ -1,0 +1,79 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { ensureWorkspaceAssets } from './workspace-assets.ts';
+import type { WorkspaceState } from './types.ts';
+
+async function tempDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'ailib-workspace-assets-'));
+}
+
+function state(localModules: string[]): WorkspaceState {
+  return {
+    effective: {
+      $schema: 'https://ailib.dev/schema/config.schema.json',
+      registry_ref: 'test-registry',
+      on_conflict: 'merge',
+      language: 'typescript',
+      modules: localModules,
+      targets: ['cursor'],
+      docs_path: 'docs/',
+      inheritedModules: [],
+      localModules,
+      warnings: []
+    },
+    inheritedModules: [],
+    localModules,
+    requiredFiles: [],
+    warnings: []
+  };
+}
+
+async function seedPackage(packageRoot: string) {
+  await fs.mkdir(path.join(packageRoot, 'core'), { recursive: true });
+  await fs.mkdir(path.join(packageRoot, 'languages/typescript/modules'), { recursive: true });
+  await fs.writeFile(path.join(packageRoot, 'core/behavior.md'), 'behavior', 'utf8');
+  await fs.writeFile(path.join(packageRoot, 'core/development-standards.md'), 'dev', 'utf8');
+  await fs.writeFile(path.join(packageRoot, 'core/test-standards.md'), 'test', 'utf8');
+  await fs.writeFile(path.join(packageRoot, 'languages/typescript/core.md'), 'lang-core', 'utf8');
+  await fs.writeFile(path.join(packageRoot, 'languages/typescript/modules/eslint.md'), 'eslint', 'utf8');
+}
+
+test('ensureWorkspaceAssets copies core and module assets for root workspace', async () => {
+  const rootDir = await tempDir();
+  const packageRoot = path.join(rootDir, 'pkg');
+  await seedPackage(packageRoot);
+
+  await ensureWorkspaceAssets({
+    workspaceDir: rootDir,
+    packageRoot,
+    state: state(['eslint']),
+    rootDir
+  });
+
+  assert.equal(await fs.readFile(path.join(rootDir, '.ailib/behavior.md'), 'utf8'), 'behavior');
+  assert.equal(await fs.readFile(path.join(rootDir, '.ailib/standards.md'), 'utf8'), 'lang-core');
+  assert.equal(await fs.readFile(path.join(rootDir, '.ailib/modules/eslint.md'), 'utf8'), 'eslint');
+});
+
+test('ensureWorkspaceAssets keeps local-only modules and removes stale module files', async () => {
+  const rootDir = await tempDir();
+  const workspaceDir = path.join(rootDir, 'apps/api');
+  const packageRoot = path.join(rootDir, 'pkg');
+  await seedPackage(packageRoot);
+  await fs.mkdir(path.join(workspaceDir, '.ailib/modules'), { recursive: true });
+  await fs.writeFile(path.join(workspaceDir, '.ailib/modules/custom.md'), 'custom', 'utf8');
+  await fs.writeFile(path.join(workspaceDir, '.ailib/modules/stale.md'), 'stale', 'utf8');
+
+  await ensureWorkspaceAssets({
+    workspaceDir,
+    packageRoot,
+    state: state(['custom']),
+    rootDir
+  });
+
+  assert.equal(await fs.readFile(path.join(workspaceDir, '.ailib/modules/custom.md'), 'utf8'), 'custom');
+  await assert.rejects(fs.readFile(path.join(workspaceDir, '.ailib/modules/stale.md'), 'utf8'));
+});

--- a/src/cli/workspace-assets.ts
+++ b/src/cli/workspace-assets.ts
@@ -1,0 +1,70 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { copySourceFile } from './file-helpers.ts';
+import { exists, rmIfExists } from './utils.ts';
+import type { WorkspaceState } from './types.ts';
+
+export async function ensureWorkspaceAssets({
+  workspaceDir,
+  packageRoot,
+  state,
+  rootDir
+}: {
+  workspaceDir: string;
+  packageRoot: string;
+  state: WorkspaceState;
+  rootDir: string;
+}) {
+  const outRoot = path.join(workspaceDir, '.ailib');
+  await fs.mkdir(path.join(outRoot, 'modules'), { recursive: true });
+
+  if (path.resolve(workspaceDir) === path.resolve(rootDir)) {
+    await copySourceFile({ packageRoot, sourceRel: 'core/behavior.md', target: path.join(outRoot, 'behavior.md') });
+  }
+
+  await copySourceFile({
+    packageRoot,
+    sourceRel: 'core/development-standards.md',
+    target: path.join(outRoot, 'development-standards.md')
+  });
+
+  await copySourceFile({
+    packageRoot,
+    sourceRel: 'core/test-standards.md',
+    target: path.join(outRoot, 'test-standards.md')
+  });
+
+  await copySourceFile({
+    packageRoot,
+    sourceRel: `languages/${state.effective.language}/core.md`,
+    target: path.join(outRoot, 'standards.md')
+  });
+
+  const localModules = state.localModules;
+  const localSet = new Set(localModules);
+  for (const mod of localModules) {
+    const sourceRel = `languages/${state.effective.language}/modules/${mod}.md`;
+    const source = path.join(packageRoot, sourceRel);
+    const target = path.join(outRoot, 'modules', `${mod}.md`);
+    if (await exists(source)) {
+      await copySourceFile({ packageRoot, sourceRel, target });
+      continue;
+    }
+
+    const existing = path.join(outRoot, 'modules', `${mod}.md`);
+    ensure(await exists(existing), `Missing module source: ${sourceRel}`);
+  }
+
+  const moduleDir = path.join(outRoot, 'modules');
+  if (await exists(moduleDir)) {
+    for (const entry of await fs.readdir(moduleDir)) {
+      if (!entry.endsWith('.md')) continue;
+      const id = entry.replace(/\.md$/u, '');
+      if (!localSet.has(id)) await rmIfExists(path.join(moduleDir, entry));
+    }
+  }
+}
+
+function ensure(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}


### PR DESCRIPTION
## Summary
- extract workspace asset synchronization logic from `src/cli.ts` into `src/cli/workspace-assets.ts`
- keep behavior unchanged for copying core/module files and pruning stale module pointers
- add colocated tests in `src/cli/workspace-assets.test.ts` for root/service workspace asset handling

## TDD Evidence
- [ ] Behavior change: I added/updated a failing test first (Red), then implemented (Green), then refactored.
- [x] Refactor/docs/chore only: no behavior change, so Red step is not applicable.
- Red evidence:
  - Not applicable (behavior-preserving refactor)
- Green evidence:
  - `bun test src/cli/workspace-assets.test.ts src/cli.test.ts test/cli.test.ts`
  - `bun run check`

## Test plan
- [x] `bun test src/cli/workspace-assets.test.ts src/cli.test.ts test/cli.test.ts`
- [x] `bun run check`

Refs #85
Refs #84
Refs #87
Refs #83

Made with [Cursor](https://cursor.com)