### PR TITLE
refactor: extract workspace update module

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,13 +14,11 @@ import {
   workspaceLabelFor
 } from './cli/context-resolution.ts';
 import { parseFrontmatter } from './cli/file-helpers.ts';
-import { writeRootLock } from './cli/lockfile.ts';
 import { assertLocalOverridesValid } from './cli/local-override-config.ts';
 import { diffSlots } from './cli/module-selection.ts';
 import { validateModuleSelection } from './cli/module-validation.ts';
-import { generateWorkspaceRouters } from './cli/router-generation.ts';
-import { ensureWorkspaceAssets } from './cli/workspace-assets.ts';
 import { buildWorkspaceState, getEffectiveWorkspaceConfig } from './cli/workspace-state.ts';
+import { applyWorkspaceUpdate as applyWorkspaceUpdateCore } from './cli/workspace-update.ts';
 import { canonicalSlot, exists, readJson, rmIfExists, splitCsv, toPosix, uniqueList } from './cli/utils.ts';
 import { listWorkspaceDirs } from './cli/workspace-discovery.ts';
 import type {
@@ -472,56 +470,14 @@ async function applyWorkspaceUpdate({
   workspaceOverride?: string;
   forceOnConflict?: string;
 }) {
-  const rootConfigPath = path.join(rootDir, CONFIG_FILE);
-  ensure(await exists(rootConfigPath), `Missing ${CONFIG_FILE} at root: ${rootDir}`);
-
-  const registry = await readJson<Registry>(path.join(packageRoot, 'registry.json'));
-  const packageJson = await readJson<{ version: string }>(path.join(packageRoot, 'package.json'));
-  const rootConfig = await readJson<WorkspaceConfig>(rootConfigPath);
-  await assertLocalOverridesValid({
-    rootDir,
-    rootConfig,
-    registry,
-    canonicalSlot: (slot) => resolveCanonicalSlot(registry, slot),
-    localOverrideFile: LOCAL_OVERRIDE_FILE
-  });
-
-  const workspaceDirs = await listWorkspaceDirs({ rootDir, rootConfig, workspaceOverride });
-  const allWorkspaceDirs = await listWorkspaceDirs({ rootDir, rootConfig });
-
-  const stateMap = new Map<string, WorkspaceState>();
-  for (const workspaceDir of allWorkspaceDirs) {
-    stateMap.set(
-      workspaceDir,
-      await buildWorkspaceState({
-        workspaceDir,
-        rootDir,
-        rootConfig,
-        registry,
-        canonicalSlot: (slot) => resolveCanonicalSlot(registry, slot),
-        configFile: CONFIG_FILE,
-        localOverrideFile: LOCAL_OVERRIDE_FILE
-      })
-    );
-  }
-
-  for (const workspaceDir of workspaceDirs) {
-    const state = stateMap.get(workspaceDir);
-    await ensureWorkspaceAssets({ workspaceDir, packageRoot, state, rootDir });
-  }
-
-  for (const workspaceDir of workspaceDirs) {
-    const state = stateMap.get(workspaceDir);
-    const onConflict = forceOnConflict || state.effective.on_conflict || 'merge';
-    await generateWorkspaceRouters({ workspaceDir, rootDir, state, onConflict, allStates: stateMap, registry });
-  }
-
-  await writeRootLock({
-    rootDir,
+  await applyWorkspaceUpdateCore({
     packageRoot,
-    packageVersion: packageJson.version,
-    registryRef: rootConfig.registry_ref || registry.version,
-    allStates: stateMap
+    rootDir,
+    workspaceOverride,
+    forceOnConflict,
+    configFile: CONFIG_FILE,
+    localOverrideFile: LOCAL_OVERRIDE_FILE,
+    canonicalSlot: (registry, slot) => resolveCanonicalSlot(registry, slot)
   });
 }
 

--- a/src/cli/workspace-update.test.ts
+++ b/src/cli/workspace-update.test.ts
@@ -1,0 +1,87 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { applyWorkspaceUpdate } from './workspace-update.ts';
+
+async function tempDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'ailib-workspace-update-'));
+}
+
+function canonicalSlot() {
+  return null;
+}
+
+test('applyWorkspaceUpdate fails when root config is missing', async () => {
+  const rootDir = await tempDir();
+  const packageRoot = path.join(rootDir, 'pkg');
+  await fs.mkdir(packageRoot, { recursive: true });
+  await fs.writeFile(path.join(packageRoot, 'registry.json'), '{"version":"test"}\n', 'utf8');
+  await fs.writeFile(path.join(packageRoot, 'package.json'), '{"version":"1.0.0"}\n', 'utf8');
+
+  await assert.rejects(
+    applyWorkspaceUpdate({
+      packageRoot,
+      rootDir,
+      configFile: 'ailib.config.json',
+      localOverrideFile: 'ailib.local.json',
+      canonicalSlot
+    }),
+    /Missing ailib\.config\.json at root/
+  );
+});
+
+test('applyWorkspaceUpdate generates workspace assets and lockfile', async () => {
+  const rootDir = await tempDir();
+  const packageRoot = path.join(rootDir, 'pkg');
+  await fs.mkdir(path.join(packageRoot, 'core'), { recursive: true });
+  await fs.mkdir(path.join(packageRoot, 'languages', 'typescript', 'modules'), { recursive: true });
+
+  await fs.writeFile(path.join(packageRoot, 'core', 'behavior.md'), '# behavior', 'utf8');
+  await fs.writeFile(path.join(packageRoot, 'core', 'development-standards.md'), '# dev', 'utf8');
+  await fs.writeFile(path.join(packageRoot, 'core', 'test-standards.md'), '# test', 'utf8');
+  await fs.writeFile(path.join(packageRoot, 'languages', 'typescript', 'core.md'), '# standards', 'utf8');
+  await fs.writeFile(
+    path.join(packageRoot, 'registry.json'),
+    `${JSON.stringify(
+      {
+        version: 'test-registry',
+        slots: [],
+        languages: { typescript: { modules: {} } },
+        targets: { cursor: { output: '.cursor/rules/ai.md', display: 'Cursor' } }
+      },
+      null,
+      2
+    )}\n`,
+    'utf8'
+  );
+  await fs.writeFile(path.join(packageRoot, 'package.json'), '{"version":"1.0.0"}\n', 'utf8');
+  await fs.writeFile(
+    path.join(rootDir, 'ailib.config.json'),
+    `${JSON.stringify(
+      {
+        $schema: 'https://ailib.dev/schema/config.schema.json',
+        language: 'typescript',
+        modules: [],
+        targets: ['cursor'],
+        docs_path: 'docs/'
+      },
+      null,
+      2
+    )}\n`,
+    'utf8'
+  );
+
+  await applyWorkspaceUpdate({
+    packageRoot,
+    rootDir,
+    configFile: 'ailib.config.json',
+    localOverrideFile: 'ailib.local.json',
+    canonicalSlot
+  });
+
+  assert.equal(await fs.readFile(path.join(rootDir, '.ailib', 'behavior.md'), 'utf8'), '# behavior');
+  assert.equal(await fs.readFile(path.join(rootDir, '.cursor/rules/ai.md'), 'utf8').then(Boolean), true);
+  assert.equal(await fs.readFile(path.join(rootDir, 'ailib.lock'), 'utf8').then(Boolean), true);
+});

--- a/src/cli/workspace-update.ts
+++ b/src/cli/workspace-update.ts
@@ -1,0 +1,83 @@
+import path from 'node:path';
+import { writeRootLock } from './lockfile.ts';
+import { assertLocalOverridesValid } from './local-override-config.ts';
+import { generateWorkspaceRouters } from './router-generation.ts';
+import { ensureWorkspaceAssets } from './workspace-assets.ts';
+import { buildWorkspaceState } from './workspace-state.ts';
+import { exists, readJson } from './utils.ts';
+import { listWorkspaceDirs } from './workspace-discovery.ts';
+import type { Registry, WorkspaceConfig, WorkspaceState } from './types.ts';
+
+export async function applyWorkspaceUpdate({
+  packageRoot,
+  rootDir,
+  workspaceOverride,
+  forceOnConflict,
+  configFile,
+  localOverrideFile,
+  canonicalSlot
+}: {
+  packageRoot: string;
+  rootDir: string;
+  workspaceOverride?: string;
+  forceOnConflict?: string;
+  configFile: string;
+  localOverrideFile: string;
+  canonicalSlot: (registry: Registry, slot: string | undefined) => string | null;
+}) {
+  const rootConfigPath = path.join(rootDir, configFile);
+  ensure(await exists(rootConfigPath), `Missing ${configFile} at root: ${rootDir}`);
+
+  const registry = await readJson<Registry>(path.join(packageRoot, 'registry.json'));
+  const packageJson = await readJson<{ version: string }>(path.join(packageRoot, 'package.json'));
+  const rootConfig = await readJson<WorkspaceConfig>(rootConfigPath);
+  await assertLocalOverridesValid({
+    rootDir,
+    rootConfig,
+    registry,
+    canonicalSlot: (slot) => canonicalSlot(registry, slot),
+    localOverrideFile
+  });
+
+  const workspaceDirs = await listWorkspaceDirs({ rootDir, rootConfig, workspaceOverride });
+  const allWorkspaceDirs = await listWorkspaceDirs({ rootDir, rootConfig });
+
+  const stateMap = new Map<string, WorkspaceState>();
+  for (const workspaceDir of allWorkspaceDirs) {
+    stateMap.set(
+      workspaceDir,
+      await buildWorkspaceState({
+        workspaceDir,
+        rootDir,
+        rootConfig,
+        registry,
+        canonicalSlot: (slot) => canonicalSlot(registry, slot),
+        configFile,
+        localOverrideFile
+      })
+    );
+  }
+
+  for (const workspaceDir of workspaceDirs) {
+    const state = stateMap.get(workspaceDir);
+    await ensureWorkspaceAssets({ workspaceDir, packageRoot, state, rootDir });
+  }
+
+  for (const workspaceDir of workspaceDirs) {
+    const state = stateMap.get(workspaceDir);
+    const onConflict = forceOnConflict || state.effective.on_conflict || 'merge';
+    await generateWorkspaceRouters({ workspaceDir, rootDir, state, onConflict, allStates: stateMap, registry });
+  }
+
+  await writeRootLock({
+    rootDir,
+    packageRoot,
+    packageVersion: packageJson.version,
+    registryRef: rootConfig.registry_ref || registry.version,
+    allStates: stateMap
+  });
+}
+
+function ensure(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}


### PR DESCRIPTION
## Summary
- extract workspace update orchestration from `src/cli.ts` into `src/cli/workspace-update.ts`
- keep existing CLI command behavior by using a thin wrapper in `src/cli.ts`
- add colocated tests in `src/cli/workspace-update.test.ts` for missing root config guard and successful update flow

## TDD Evidence
- [ ] Behavior change: I added/updated a failing test first (Red), then implemented (Green), then refactored.
- [x] Refactor/docs/chore only: no behavior change, so Red step is not applicable.
- Red evidence:
  - Not applicable (behavior-preserving refactor)
- Green evidence:
  - `bun test src/cli/workspace-update.test.ts src/cli.test.ts test/cli.test.ts`
  - `bun run check`

## Test plan
- [x] `bun test src/cli/workspace-update.test.ts src/cli.test.ts test/cli.test.ts`
- [x] `bun run check`

Refs #85
Refs #84
Refs #87
Refs #83

Made with [Cursor](https://cursor.com)