### PR TITLE
refactor: extract uninstall module

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,6 @@ import { printHelp } from './cli/help.ts';
 import {
   detectProjectRoot,
   findNearestMonorepoRoot,
-  isRootWorkspaceConfig,
   resolveContext,
   resolveDefaultWorkspaceForMutation,
   resolveWorkspacePath,
@@ -17,9 +16,10 @@ import { parseFrontmatter } from './cli/file-helpers.ts';
 import { assertLocalOverridesValid } from './cli/local-override-config.ts';
 import { diffSlots } from './cli/module-selection.ts';
 import { validateModuleSelection } from './cli/module-validation.ts';
+import { uninstallCommand as runUninstallCommand } from './cli/uninstall.ts';
 import { buildWorkspaceState, getEffectiveWorkspaceConfig } from './cli/workspace-state.ts';
 import { applyWorkspaceUpdate as applyWorkspaceUpdateCore } from './cli/workspace-update.ts';
-import { canonicalSlot, exists, readJson, rmIfExists, splitCsv, toPosix, uniqueList } from './cli/utils.ts';
+import { canonicalSlot, exists, readJson, splitCsv, toPosix, uniqueList } from './cli/utils.ts';
 import { listWorkspaceDirs } from './cli/workspace-discovery.ts';
 import type {
   CliFlags,
@@ -402,61 +402,15 @@ async function doctorCommand({ cwd, packageRoot, flags }: CommandContext) {
 }
 
 async function uninstallCommand({ cwd, packageRoot, flags }: CommandContext) {
-  const context = await resolveContext(cwd);
-  const registry = await readJson<Registry>(path.join(packageRoot, 'registry.json'));
-
-  const rootConfigPath = path.join(context.rootDir, CONFIG_FILE);
-  const rootConfig = (await exists(rootConfigPath)) ? await readJson<WorkspaceConfig>(rootConfigPath) : null;
-  const atRoot = path.resolve(context.workspaceDir) === path.resolve(context.rootDir);
-  const monorepo = Boolean(rootConfig?.workspaces);
-
-  if (atRoot && monorepo && flags.all !== true) {
-    await uninstallWorkspace(context.rootDir, rootConfig, registry);
-    process.stdout.write('ailib uninstalled\n');
-    return;
-  }
-
-  if (atRoot && monorepo && flags.all === true) {
-    const workspaceDirs = await listWorkspaceDirs({ rootDir: context.rootDir, rootConfig });
-    for (const workspaceDir of workspaceDirs) {
-      const cfgPath = path.join(workspaceDir, CONFIG_FILE);
-      const cfg = (await exists(cfgPath)) ? await readJson<WorkspaceConfig>(cfgPath) : rootConfig;
-      await uninstallWorkspace(workspaceDir, cfg, registry);
-    }
-    await rmIfExists(path.join(context.rootDir, LOCK_FILE));
-    process.stdout.write('ailib uninstalled\n');
-    return;
-  }
-
-  const targetDir = context.workspaceDir;
-  const cfgPath = path.join(targetDir, CONFIG_FILE);
-  const cfg = (await exists(cfgPath)) ? await readJson<WorkspaceConfig>(cfgPath) : null;
-  await uninstallWorkspace(targetDir, cfg, registry);
-
-  if (path.resolve(targetDir) === path.resolve(context.rootDir)) {
-    await rmIfExists(path.join(context.rootDir, LOCK_FILE));
-  } else if (await exists(rootConfigPath)) {
-    await applyWorkspaceUpdate({ packageRoot, rootDir: context.rootDir, forceOnConflict: 'overwrite' });
-  }
-
-  process.stdout.write('ailib uninstalled\n');
-}
-
-async function uninstallWorkspace(workspaceDir: string, config: WorkspaceConfig | null, registry: Registry) {
-  await rmIfExists(path.join(workspaceDir, '.ailib'));
-  await rmIfExists(path.join(workspaceDir, CONFIG_FILE));
-  if (config?.targets) {
-    for (const target of config.targets) {
-      const targetDef = registry.targets[target];
-      if (!targetDef) continue;
-      await rmIfExists(path.join(workspaceDir, targetDef.output));
-      if (targetDef.root_output && isRootWorkspaceConfig(config))
-        await rmIfExists(path.join(workspaceDir, targetDef.root_output));
-      if (target === 'copilot' && isRootWorkspaceConfig(config)) {
-        await rmIfExists(path.join(workspaceDir, '.github/instructions'));
-      }
-    }
-  }
+  await runUninstallCommand({
+    cwd,
+    packageRoot,
+    flags,
+    configFile: CONFIG_FILE,
+    lockFile: LOCK_FILE,
+    applyWorkspaceUpdate: async ({ packageRoot: rootPackage, rootDir, forceOnConflict }) =>
+      applyWorkspaceUpdate({ packageRoot: rootPackage, rootDir, forceOnConflict })
+  });
 }
 
 async function applyWorkspaceUpdate({

--- a/src/cli/uninstall.test.ts
+++ b/src/cli/uninstall.test.ts
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { uninstallCommand, uninstallWorkspace } from './uninstall.ts';
+import type { Registry, WorkspaceConfig } from './types.ts';
+
+async function tempDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'ailib-uninstall-'));
+}
+
+const registry: Registry = {
+  version: 'test',
+  languages: { typescript: { modules: {} } },
+  targets: {
+    cursor: { output: '.cursor/rules/ai.md', root_output: '.cursor/rules/root.md' },
+    copilot: { output: '.github/copilot-instructions.md' }
+  }
+};
+
+test('uninstallWorkspace removes managed outputs and root extras', async () => {
+  const rootDir = await tempDir();
+  const config: WorkspaceConfig = { workspaces: ['apps/*'], targets: ['cursor', 'copilot'] };
+  await fs.mkdir(path.join(rootDir, '.ailib'), { recursive: true });
+  await fs.mkdir(path.join(rootDir, '.cursor/rules'), { recursive: true });
+  await fs.mkdir(path.join(rootDir, '.github/instructions'), { recursive: true });
+  await fs.writeFile(path.join(rootDir, 'ailib.config.json'), '{}', 'utf8');
+  await fs.writeFile(path.join(rootDir, '.cursor/rules/ai.md'), 'x', 'utf8');
+  await fs.writeFile(path.join(rootDir, '.cursor/rules/root.md'), 'x', 'utf8');
+
+  await uninstallWorkspace(rootDir, config, registry, 'ailib.config.json');
+
+  await assert.rejects(fs.readFile(path.join(rootDir, 'ailib.config.json'), 'utf8'));
+  await assert.rejects(fs.readFile(path.join(rootDir, '.cursor/rules/ai.md'), 'utf8'));
+  await assert.rejects(fs.readFile(path.join(rootDir, '.cursor/rules/root.md'), 'utf8'));
+  await assert.rejects(fs.readdir(path.join(rootDir, '.github/instructions')));
+});
+
+test('uninstallCommand uninstalls root workspace in monorepo without --all', async () => {
+  const rootDir = await tempDir();
+  const packageRoot = path.join(rootDir, 'pkg');
+  await fs.mkdir(path.join(packageRoot), { recursive: true });
+  await fs.writeFile(path.join(packageRoot, 'registry.json'), `${JSON.stringify(registry)}\n`, 'utf8');
+  await fs.mkdir(path.join(rootDir, '.ailib'), { recursive: true });
+  await fs.writeFile(
+    path.join(rootDir, 'ailib.config.json'),
+    `${JSON.stringify({ workspaces: ['apps/*'], targets: ['cursor'] })}\n`,
+    'utf8'
+  );
+
+  let applyCalled = false;
+  await uninstallCommand({
+    cwd: rootDir,
+    packageRoot,
+    flags: {},
+    configFile: 'ailib.config.json',
+    lockFile: 'ailib.lock',
+    applyWorkspaceUpdate: async () => {
+      applyCalled = true;
+    }
+  });
+  assert.equal(applyCalled, false);
+  await assert.rejects(fs.readFile(path.join(rootDir, 'ailib.config.json'), 'utf8'));
+});

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -1,0 +1,83 @@
+import path from 'node:path';
+import { resolveContext, isRootWorkspaceConfig } from './context-resolution.ts';
+import { listWorkspaceDirs } from './workspace-discovery.ts';
+import { exists, readJson, rmIfExists } from './utils.ts';
+import type { Registry, WorkspaceConfig } from './types.ts';
+
+export async function uninstallCommand({
+  cwd,
+  packageRoot,
+  flags,
+  configFile,
+  lockFile,
+  applyWorkspaceUpdate
+}: {
+  cwd: string;
+  packageRoot: string;
+  flags: Record<string, unknown>;
+  configFile: string;
+  lockFile: string;
+  applyWorkspaceUpdate: (args: { packageRoot: string; rootDir: string; forceOnConflict?: string }) => Promise<void>;
+}) {
+  const context = await resolveContext(cwd);
+  const registry = await readJson<Registry>(path.join(packageRoot, 'registry.json'));
+
+  const rootConfigPath = path.join(context.rootDir, configFile);
+  const rootConfig = (await exists(rootConfigPath)) ? await readJson<WorkspaceConfig>(rootConfigPath) : null;
+  const atRoot = path.resolve(context.workspaceDir) === path.resolve(context.rootDir);
+  const monorepo = Boolean(rootConfig?.workspaces);
+
+  if (atRoot && monorepo && flags.all !== true) {
+    await uninstallWorkspace(context.rootDir, rootConfig, registry, configFile);
+    process.stdout.write('ailib uninstalled\n');
+    return;
+  }
+
+  if (atRoot && monorepo && flags.all === true) {
+    const workspaceDirs = await listWorkspaceDirs({ rootDir: context.rootDir, rootConfig });
+    for (const workspaceDir of workspaceDirs) {
+      const cfgPath = path.join(workspaceDir, configFile);
+      const cfg = (await exists(cfgPath)) ? await readJson<WorkspaceConfig>(cfgPath) : rootConfig;
+      await uninstallWorkspace(workspaceDir, cfg, registry, configFile);
+    }
+    await rmIfExists(path.join(context.rootDir, lockFile));
+    process.stdout.write('ailib uninstalled\n');
+    return;
+  }
+
+  const targetDir = context.workspaceDir;
+  const cfgPath = path.join(targetDir, configFile);
+  const cfg = (await exists(cfgPath)) ? await readJson<WorkspaceConfig>(cfgPath) : null;
+  await uninstallWorkspace(targetDir, cfg, registry, configFile);
+
+  if (path.resolve(targetDir) === path.resolve(context.rootDir)) {
+    await rmIfExists(path.join(context.rootDir, lockFile));
+  } else if (await exists(rootConfigPath)) {
+    await applyWorkspaceUpdate({ packageRoot, rootDir: context.rootDir, forceOnConflict: 'overwrite' });
+  }
+
+  process.stdout.write('ailib uninstalled\n');
+}
+
+export async function uninstallWorkspace(
+  workspaceDir: string,
+  config: WorkspaceConfig | null,
+  registry: Registry,
+  configFile: string
+) {
+  await rmIfExists(path.join(workspaceDir, '.ailib'));
+  await rmIfExists(path.join(workspaceDir, configFile));
+  if (config?.targets) {
+    for (const target of config.targets) {
+      const targetDef = registry.targets[target];
+      if (!targetDef) continue;
+      await rmIfExists(path.join(workspaceDir, targetDef.output));
+      if (targetDef.root_output && isRootWorkspaceConfig(config)) {
+        await rmIfExists(path.join(workspaceDir, targetDef.root_output));
+      }
+      if (target === 'copilot' && isRootWorkspaceConfig(config)) {
+        await rmIfExists(path.join(workspaceDir, '.github/instructions'));
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- extract uninstall command orchestration from `src/cli.ts` into `src/cli/uninstall.ts`
- keep CLI behavior unchanged with a thin wrapper in `src/cli.ts`
- add colocated tests in `src/cli/uninstall.test.ts` for workspace cleanup and root monorepo uninstall flow

## TDD Evidence
- [ ] Behavior change: I added/updated a failing test first (Red), then implemented (Green), then refactored.
- [x] Refactor/docs/chore only: no behavior change, so Red step is not applicable.
- Red evidence:
  - Not applicable (behavior-preserving refactor)
- Green evidence:
  - `bun test src/cli/uninstall.test.ts src/cli.test.ts test/cli.test.ts`
  - `bun run check`

## Test plan
- [x] `bun test src/cli/uninstall.test.ts src/cli.test.ts test/cli.test.ts`
- [x] `bun run check`

Refs #85
Refs #84
Refs #87
Refs #83

Made with [Cursor](https://cursor.com)