### PR TITLE
refactor: extract doctor command module

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,35 +7,22 @@ import { printHelp } from './cli/help.ts';
 import {
   detectProjectRoot,
   findNearestMonorepoRoot,
-  resolveContext,
   resolveDefaultWorkspaceForMutation,
   resolveWorkspacePath,
-  workspaceLabelFor
+  resolveContext
 } from './cli/context-resolution.ts';
-import { parseFrontmatter } from './cli/file-helpers.ts';
-import { assertLocalOverridesValid } from './cli/local-override-config.ts';
-import { diffSlots } from './cli/module-selection.ts';
+import { doctorCommand as runDoctorCommand } from './cli/doctor.ts';
 import { validateModuleSelection } from './cli/module-validation.ts';
 import { uninstallCommand as runUninstallCommand } from './cli/uninstall.ts';
-import { buildWorkspaceState, getEffectiveWorkspaceConfig } from './cli/workspace-state.ts';
+import { getEffectiveWorkspaceConfig } from './cli/workspace-state.ts';
 import { applyWorkspaceUpdate as applyWorkspaceUpdateCore } from './cli/workspace-update.ts';
 import { canonicalSlot, exists, readJson, splitCsv, toPosix, uniqueList } from './cli/utils.ts';
-import { listWorkspaceDirs } from './cli/workspace-discovery.ts';
 import type {
-  CliFlags,
   CommandContext,
   LanguageDefinition,
-  ListOverrideScope,
-  ModuleDefinition,
   Registry,
   RunOptions,
-  SlotAliasMeta,
-  SlotDefinition,
-  SlotOverrideRule,
-  TargetDefinition,
-  WorkspaceConfig,
-  WorkspaceOverrideConfig,
-  WorkspaceState
+  WorkspaceConfig
 } from './cli/types.ts';
 
 const CONFIG_FILE = 'ailib.config.json';
@@ -287,118 +274,14 @@ async function removeCommand({ cwd, packageRoot, flags }: CommandContext) {
 }
 
 async function doctorCommand({ cwd, packageRoot, flags }: CommandContext) {
-  const context = await resolveContext(cwd);
-  const registry = await readJson<Registry>(path.join(packageRoot, 'registry.json'));
-  const rootConfig = await readJson<WorkspaceConfig>(path.join(context.rootDir, CONFIG_FILE));
-  const workspaceDirs = await listWorkspaceDirs({
-    rootDir: context.rootDir,
-    rootConfig,
-    workspaceOverride: getStringFlag(flags, 'workspace')
-  });
-
-  const errors: string[] = [];
-  const warnings: string[] = [];
-  try {
-    await assertLocalOverridesValid({
-      rootDir: context.rootDir,
-      rootConfig,
-      registry,
-      canonicalSlot: (slot) => resolveCanonicalSlot(registry, slot),
-      localOverrideFile: LOCAL_OVERRIDE_FILE
-    });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    errors.push(message);
-  }
-  if (errors.length) {
-    process.stdout.write(`doctor failed:\n- ${errors.join('\n- ')}\n`);
-    process.exitCode = 1;
-    return;
-  }
-
-  const rootEffective = await getEffectiveWorkspaceConfig({
-    workspaceDir: context.rootDir,
-    rootDir: context.rootDir,
-    rootConfig,
-    registry,
-    canonicalSlot: (slot) => resolveCanonicalSlot(registry, slot),
+  await runDoctorCommand({
+    cwd,
+    packageRoot,
+    flags,
     configFile: CONFIG_FILE,
-    localOverrideFile: LOCAL_OVERRIDE_FILE
+    localOverrideFile: LOCAL_OVERRIDE_FILE,
+    canonicalSlot: (registry, slot) => resolveCanonicalSlot(registry, slot)
   });
-  for (const workspaceDir of workspaceDirs) {
-    const workspaceLabel = workspaceLabelFor(context.rootDir, workspaceDir);
-    const configPath = path.join(workspaceDir, CONFIG_FILE);
-    if (!(await exists(configPath))) {
-      errors.push(`[${workspaceLabel}] Missing ${CONFIG_FILE}`);
-      continue;
-    }
-
-    let state: WorkspaceState;
-    try {
-      state = await buildWorkspaceState({
-        workspaceDir,
-        rootDir: context.rootDir,
-        rootConfig,
-        registry,
-        canonicalSlot: (slot) => resolveCanonicalSlot(registry, slot),
-        configFile: CONFIG_FILE,
-        localOverrideFile: LOCAL_OVERRIDE_FILE
-      });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      errors.push(`[${workspaceLabel}] ${message}`);
-      continue;
-    }
-
-    for (const rel of state.requiredFiles) {
-      if (!(await exists(path.join(workspaceDir, rel)))) {
-        errors.push(`[${workspaceLabel}] Missing pointer file: ${rel}`);
-      }
-    }
-
-    for (const rel of state.requiredFiles) {
-      const full = path.join(workspaceDir, rel);
-      if (!(await exists(full))) continue;
-      const text = await fs.readFile(full, 'utf8');
-      const frontmatter = parseFrontmatter(text);
-      if (!frontmatter) {
-        errors.push(`[${workspaceLabel}] Missing frontmatter: ${rel}`);
-        continue;
-      }
-      for (const key of ['id', 'version', 'updated']) {
-        if (!(key in frontmatter)) {
-          errors.push(`[${workspaceLabel}] Frontmatter missing '${key}': ${rel}`);
-        }
-      }
-      if (!('language' in frontmatter) && !('core' in frontmatter)) {
-        errors.push(`[${workspaceLabel}] Frontmatter missing 'language' or 'core': ${rel}`);
-      }
-      if (rel.includes('/modules/') && !('slot' in frontmatter)) {
-        errors.push(`[${workspaceLabel}] Frontmatter missing 'slot': ${rel}`);
-      }
-    }
-
-    if (path.resolve(workspaceDir) !== path.resolve(context.rootDir)) {
-      const slotDiffs = diffSlots({
-        rootModules: rootEffective.modules,
-        workspaceModules: state.effective.modules,
-        registry,
-        language: state.effective.language,
-        canonicalSlot: (slot) => resolveCanonicalSlot(registry, slot)
-      });
-      for (const msg of slotDiffs) warnings.push(`[${workspaceLabel}] ${msg}`);
-    }
-  }
-
-  if (warnings.length) process.stdout.write(`doctor warnings:\n- ${warnings.join('\n- ')}\n`);
-
-  if (errors.length) {
-    process.stdout.write(`doctor failed:\n- ${errors.join('\n- ')}\n`);
-    process.exitCode = 1;
-    return;
-  }
-
-  process.stdout.write('doctor ok\n');
 }
 
 async function uninstallCommand({ cwd, packageRoot, flags }: CommandContext) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,13 +17,7 @@ import { uninstallCommand as runUninstallCommand } from './cli/uninstall.ts';
 import { getEffectiveWorkspaceConfig } from './cli/workspace-state.ts';
 import { applyWorkspaceUpdate as applyWorkspaceUpdateCore } from './cli/workspace-update.ts';
 import { canonicalSlot, exists, readJson, splitCsv, toPosix, uniqueList } from './cli/utils.ts';
-import type {
-  CommandContext,
-  LanguageDefinition,
-  Registry,
-  RunOptions,
-  WorkspaceConfig
-} from './cli/types.ts';
+import type { CommandContext, LanguageDefinition, Registry, RunOptions, WorkspaceConfig } from './cli/types.ts';
 
 const CONFIG_FILE = 'ailib.config.json';
 const LOCAL_OVERRIDE_FILE = 'ailib.local.json';

--- a/src/cli/doctor.test.ts
+++ b/src/cli/doctor.test.ts
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { doctorCommand } from './doctor.ts';
+import type { CliFlags } from './types.ts';
+
+async function tempDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'ailib-doctor-'));
+}
+
+async function captureStdout(fn: () => Promise<void>) {
+  const chunks: string[] = [];
+  const mutableStdout = process.stdout as unknown as { write: typeof process.stdout.write };
+  const originalWrite = mutableStdout.write.bind(process.stdout);
+  mutableStdout.write = ((chunk, encoding, callback) => {
+    chunks.push(typeof chunk === 'string' ? chunk : chunk.toString());
+    const done = typeof encoding === 'function' ? encoding : callback;
+    if (typeof done === 'function') done();
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    await fn();
+    return chunks.join('');
+  } finally {
+    mutableStdout.write = originalWrite;
+  }
+}
+
+test('doctorCommand reports missing managed pointer files', async () => {
+  const rootDir = await tempDir();
+  const packageRoot = path.join(rootDir, 'pkg');
+  await fs.mkdir(packageRoot, { recursive: true });
+  await fs.writeFile(
+    path.join(packageRoot, 'registry.json'),
+    `${JSON.stringify({ version: 'test', slots: [], languages: { typescript: { modules: {} } }, targets: {} })}\n`,
+    'utf8'
+  );
+  await fs.writeFile(
+    path.join(rootDir, 'ailib.config.json'),
+    `${JSON.stringify({ language: 'typescript', modules: [], targets: [] })}\n`,
+    'utf8'
+  );
+
+  const previousExitCode = process.exitCode;
+  process.exitCode = undefined;
+  const output = await captureStdout(() =>
+    doctorCommand({
+      cwd: rootDir,
+      packageRoot,
+      flags: { _: [] } as CliFlags,
+      configFile: 'ailib.config.json',
+      localOverrideFile: 'ailib.local.json',
+      canonicalSlot: (_registry, slot) => slot || null
+    })
+  );
+
+  assert.match(output, /doctor failed:/);
+  assert.match(output, /Missing pointer file: \.ailib\/behavior\.md/);
+  assert.equal(process.exitCode, 1);
+  process.exitCode = previousExitCode;
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,0 +1,145 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { resolveContext, workspaceLabelFor } from './context-resolution.ts';
+import { parseFrontmatter } from './file-helpers.ts';
+import { assertLocalOverridesValid } from './local-override-config.ts';
+import { diffSlots } from './module-selection.ts';
+import { buildWorkspaceState, getEffectiveWorkspaceConfig } from './workspace-state.ts';
+import { exists, readJson } from './utils.ts';
+import { listWorkspaceDirs } from './workspace-discovery.ts';
+import type { CliFlags, Registry, WorkspaceConfig, WorkspaceState } from './types.ts';
+
+export async function doctorCommand({
+  cwd,
+  packageRoot,
+  flags,
+  configFile,
+  localOverrideFile,
+  canonicalSlot
+}: {
+  cwd: string;
+  packageRoot: string;
+  flags: CliFlags;
+  configFile: string;
+  localOverrideFile: string;
+  canonicalSlot: (registry: Registry, slot: string | undefined) => string | null;
+}) {
+  const context = await resolveContext(cwd);
+  const registry = await readJson<Registry>(path.join(packageRoot, 'registry.json'));
+  const rootConfig = await readJson<WorkspaceConfig>(path.join(context.rootDir, configFile));
+  const workspaceDirs = await listWorkspaceDirs({
+    rootDir: context.rootDir,
+    rootConfig,
+    workspaceOverride: getStringFlag(flags, 'workspace')
+  });
+
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  try {
+    await assertLocalOverridesValid({
+      rootDir: context.rootDir,
+      rootConfig,
+      registry,
+      canonicalSlot: (slot) => canonicalSlot(registry, slot),
+      localOverrideFile
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    errors.push(message);
+  }
+  if (errors.length) {
+    process.stdout.write(`doctor failed:\n- ${errors.join('\n- ')}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const rootEffective = await getEffectiveWorkspaceConfig({
+    workspaceDir: context.rootDir,
+    rootDir: context.rootDir,
+    rootConfig,
+    registry,
+    canonicalSlot: (slot) => canonicalSlot(registry, slot),
+    configFile,
+    localOverrideFile
+  });
+  for (const workspaceDir of workspaceDirs) {
+    const workspaceLabel = workspaceLabelFor(context.rootDir, workspaceDir);
+    const configPath = path.join(workspaceDir, configFile);
+    if (!(await exists(configPath))) {
+      errors.push(`[${workspaceLabel}] Missing ${configFile}`);
+      continue;
+    }
+
+    let state: WorkspaceState;
+    try {
+      state = await buildWorkspaceState({
+        workspaceDir,
+        rootDir: context.rootDir,
+        rootConfig,
+        registry,
+        canonicalSlot: (slot) => canonicalSlot(registry, slot),
+        configFile,
+        localOverrideFile
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      errors.push(`[${workspaceLabel}] ${message}`);
+      continue;
+    }
+
+    for (const rel of state.requiredFiles) {
+      if (!(await exists(path.join(workspaceDir, rel)))) {
+        errors.push(`[${workspaceLabel}] Missing pointer file: ${rel}`);
+      }
+    }
+
+    for (const rel of state.requiredFiles) {
+      const full = path.join(workspaceDir, rel);
+      if (!(await exists(full))) continue;
+      const text = await fs.readFile(full, 'utf8');
+      const frontmatter = parseFrontmatter(text);
+      if (!frontmatter) {
+        errors.push(`[${workspaceLabel}] Missing frontmatter: ${rel}`);
+        continue;
+      }
+      for (const key of ['id', 'version', 'updated']) {
+        if (!(key in frontmatter)) {
+          errors.push(`[${workspaceLabel}] Frontmatter missing '${key}': ${rel}`);
+        }
+      }
+      if (!('language' in frontmatter) && !('core' in frontmatter)) {
+        errors.push(`[${workspaceLabel}] Frontmatter missing 'language' or 'core': ${rel}`);
+      }
+      if (rel.includes('/modules/') && !('slot' in frontmatter)) {
+        errors.push(`[${workspaceLabel}] Frontmatter missing 'slot': ${rel}`);
+      }
+    }
+
+    if (path.resolve(workspaceDir) !== path.resolve(context.rootDir)) {
+      const slotDiffs = diffSlots({
+        rootModules: rootEffective.modules,
+        workspaceModules: state.effective.modules,
+        registry,
+        language: state.effective.language,
+        canonicalSlot: (slot) => canonicalSlot(registry, slot)
+      });
+      for (const msg of slotDiffs) warnings.push(`[${workspaceLabel}] ${msg}`);
+    }
+  }
+
+  if (warnings.length) process.stdout.write(`doctor warnings:\n- ${warnings.join('\n- ')}\n`);
+
+  if (errors.length) {
+    process.stdout.write(`doctor failed:\n- ${errors.join('\n- ')}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  process.stdout.write('doctor ok\n');
+}
+
+function getStringFlag(flags: CliFlags, key: string): string | undefined {
+  const value = flags[key];
+  if (typeof value === 'string') return value;
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- extract doctor command orchestration from `src/cli.ts` into `src/cli/doctor.ts`
- keep `src/cli.ts` as a thin wrapper so behavior remains unchanged
- add colocated tests in `src/cli/doctor.test.ts` for failure reporting and exit code behavior

## TDD Evidence
- [ ] Behavior change: I added/updated a failing test first (Red), then implemented (Green), then refactored.
- [x] Refactor/docs/chore only: no behavior change, so Red step is not applicable.
- Red evidence:
  - Not applicable (behavior-preserving refactor)
- Green evidence:
  - `bun test src/cli/doctor.test.ts src/cli.test.ts test/cli.test.ts`
  - `bun run check`

## Test plan
- [x] `bun test src/cli/doctor.test.ts src/cli.test.ts test/cli.test.ts`
- [x] `bun run check`

Refs #85
Refs #84
Refs #87
Refs #83

Made with [Cursor](https://cursor.com)