### PR TITLE
refactor: extract module mutation commands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,17 +4,15 @@ import process from 'node:process';
 import { executeCommand } from './cli/dispatch.ts';
 import { getStringFlag, parseFlags } from './cli/flags.ts';
 import { printHelp } from './cli/help.ts';
-import {
-  detectProjectRoot,
-  findNearestMonorepoRoot,
-  resolveDefaultWorkspaceForMutation,
-  resolveWorkspacePath,
-  resolveContext
-} from './cli/context-resolution.ts';
+import { detectProjectRoot, findNearestMonorepoRoot, resolveContext } from './cli/context-resolution.ts';
 import { doctorCommand as runDoctorCommand } from './cli/doctor.ts';
+import {
+  addCommand as runAddCommand,
+  removeCommand as runRemoveCommand,
+  updateCommand as runUpdateCommand
+} from './cli/module-mutations.ts';
 import { validateModuleSelection } from './cli/module-validation.ts';
 import { uninstallCommand as runUninstallCommand } from './cli/uninstall.ts';
-import { getEffectiveWorkspaceConfig } from './cli/workspace-state.ts';
 import { applyWorkspaceUpdate as applyWorkspaceUpdateCore } from './cli/workspace-update.ts';
 import { canonicalSlot, exists, readJson, splitCsv, toPosix, uniqueList } from './cli/utils.ts';
 import type { CommandContext, LanguageDefinition, Registry, RunOptions, WorkspaceConfig } from './cli/types.ts';
@@ -191,80 +189,40 @@ async function initCommand({ cwd, packageRoot, flags }: CommandContext) {
 }
 
 async function updateCommand({ cwd, packageRoot, flags }: CommandContext) {
-  const context = await resolveContext(cwd);
-  const workspaceFlag = getStringFlag(flags, 'workspace');
-  const workspaceOverride = workspaceFlag ? resolveWorkspacePath(context.rootDir, workspaceFlag) : undefined;
-  await applyWorkspaceUpdate({
+  await runUpdateCommand({
+    cwd,
     packageRoot,
-    rootDir: context.rootDir,
-    workspaceOverride,
-    forceOnConflict: 'overwrite'
+    flags,
+    configFile: CONFIG_FILE,
+    localOverrideFile: LOCAL_OVERRIDE_FILE,
+    canonicalSlot: (registry, slot) => resolveCanonicalSlot(registry, slot),
+    applyWorkspaceUpdate: async ({ packageRoot: rootPackage, rootDir, workspaceOverride, forceOnConflict }) =>
+      applyWorkspaceUpdate({ packageRoot: rootPackage, rootDir, workspaceOverride, forceOnConflict })
   });
-  process.stdout.write('ailib updated\n');
 }
 
 async function addCommand({ cwd, packageRoot, flags }: CommandContext) {
-  const moduleId = flags._[0];
-  ensure(moduleId, 'Usage: ailib add <module>');
-  const context = await resolveContext(cwd);
-  const registry = await readJson<Registry>(path.join(packageRoot, 'registry.json'));
-
-  const targetWorkspace = resolveDefaultWorkspaceForMutation(context, getStringFlag(flags, 'workspace'));
-  const configPath = path.join(targetWorkspace, CONFIG_FILE);
-  ensure(await exists(configPath), `Missing ${CONFIG_FILE} in workspace: ${targetWorkspace}`);
-
-  const config = await readJson<WorkspaceConfig>(configPath);
-  const effective = await getEffectiveWorkspaceConfig({
-    workspaceDir: targetWorkspace,
-    rootDir: context.rootDir,
-    rootConfig: await readJson<WorkspaceConfig>(path.join(context.rootDir, CONFIG_FILE)),
-    registry,
-    canonicalSlot: (slot) => resolveCanonicalSlot(registry, slot),
-    configFile: CONFIG_FILE,
-    localOverrideFile: LOCAL_OVERRIDE_FILE
-  });
-  validateModuleSelection({
-    registry,
-    language: effective.language,
-    modules: uniqueList([...(config.modules || []), moduleId]),
-    canonicalSlot: (slot) => resolveCanonicalSlot(registry, slot)
-  });
-
-  config.modules = uniqueList([...(config.modules || []), moduleId]);
-  await fs.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
-
-  const isRootMutation = path.resolve(targetWorkspace) === path.resolve(context.rootDir);
-  await applyWorkspaceUpdate({
+  await runAddCommand({
+    cwd,
     packageRoot,
-    rootDir: context.rootDir,
-    workspaceOverride: isRootMutation ? undefined : targetWorkspace,
-    forceOnConflict: 'overwrite'
+    flags,
+    configFile: CONFIG_FILE,
+    localOverrideFile: LOCAL_OVERRIDE_FILE,
+    canonicalSlot: (registry, slot) => resolveCanonicalSlot(registry, slot),
+    applyWorkspaceUpdate: async ({ packageRoot: rootPackage, rootDir, workspaceOverride, forceOnConflict }) =>
+      applyWorkspaceUpdate({ packageRoot: rootPackage, rootDir, workspaceOverride, forceOnConflict })
   });
-
-  process.stdout.write(`module added: ${moduleId}\n`);
 }
 
 async function removeCommand({ cwd, packageRoot, flags }: CommandContext) {
-  const moduleId = flags._[0];
-  ensure(moduleId, 'Usage: ailib remove <module>');
-  const context = await resolveContext(cwd);
-  const targetWorkspace = resolveDefaultWorkspaceForMutation(context, getStringFlag(flags, 'workspace'));
-
-  const configPath = path.join(targetWorkspace, CONFIG_FILE);
-  ensure(await exists(configPath), `Missing ${CONFIG_FILE} in workspace: ${targetWorkspace}`);
-  const config = await readJson<WorkspaceConfig>(configPath);
-  config.modules = (config.modules || []).filter((m) => m !== moduleId);
-  await fs.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
-
-  const isRootMutation = path.resolve(targetWorkspace) === path.resolve(context.rootDir);
-  await applyWorkspaceUpdate({
+  await runRemoveCommand({
+    cwd,
     packageRoot,
-    rootDir: context.rootDir,
-    workspaceOverride: isRootMutation ? undefined : targetWorkspace,
-    forceOnConflict: 'overwrite'
+    flags,
+    configFile: CONFIG_FILE,
+    applyWorkspaceUpdate: async ({ packageRoot: rootPackage, rootDir, workspaceOverride, forceOnConflict }) =>
+      applyWorkspaceUpdate({ packageRoot: rootPackage, rootDir, workspaceOverride, forceOnConflict })
   });
-
-  process.stdout.write(`module removed: ${moduleId}\n`);
 }
 
 async function doctorCommand({ cwd, packageRoot, flags }: CommandContext) {

--- a/src/cli/module-mutations.test.ts
+++ b/src/cli/module-mutations.test.ts
@@ -1,0 +1,107 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { addCommand, removeCommand, updateCommand } from './module-mutations.ts';
+import type { CliFlags, Registry, WorkspaceConfig } from './types.ts';
+
+async function tempDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'ailib-module-mutations-'));
+}
+
+const registry: Registry = {
+  version: 'test',
+  slots: ['linter'],
+  languages: {
+    typescript: {
+      modules: {
+        eslint: { slot: 'linter' },
+        biome: { slot: 'linter' }
+      }
+    }
+  },
+  targets: {
+    cursor: { output: '.cursor/rules/ai.md' }
+  }
+};
+
+test('updateCommand forwards workspace override and prints updated message', async () => {
+  const rootDir = await tempDir();
+  await fs.writeFile(path.join(rootDir, 'package.json'), '{"name":"tmp"}\n', 'utf8');
+  let calledWith: { workspaceOverride?: string } | null = null;
+  const stdout: string[] = [];
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  (process.stdout as unknown as { write: typeof process.stdout.write }).write = ((chunk) => {
+    stdout.push(typeof chunk === 'string' ? chunk : chunk.toString());
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    await updateCommand({
+      cwd: rootDir,
+      packageRoot: rootDir,
+      flags: { _: [], workspace: 'apps/api' } as CliFlags,
+      configFile: 'ailib.config.json',
+      localOverrideFile: 'ailib.local.json',
+      canonicalSlot: (_r, slot) => slot || null,
+      applyWorkspaceUpdate: async (args) => {
+        calledWith = { workspaceOverride: args.workspaceOverride };
+      }
+    });
+  } finally {
+    (process.stdout as unknown as { write: typeof process.stdout.write }).write = originalWrite;
+  }
+  assert.ok(calledWith?.workspaceOverride?.endsWith('apps/api'));
+  assert.match(stdout.join(''), /ailib updated/);
+});
+
+test('addCommand writes module into config and triggers update', async () => {
+  const rootDir = await tempDir();
+  const packageRoot = path.join(rootDir, 'pkg');
+  await fs.mkdir(packageRoot, { recursive: true });
+  await fs.writeFile(path.join(packageRoot, 'registry.json'), `${JSON.stringify(registry)}\n`, 'utf8');
+  const rootConfig: WorkspaceConfig = { language: 'typescript', modules: [], targets: ['cursor'] };
+  await fs.writeFile(path.join(rootDir, 'ailib.config.json'), `${JSON.stringify(rootConfig)}\n`, 'utf8');
+
+  let called = false;
+  await addCommand({
+    cwd: rootDir,
+    packageRoot,
+    flags: { _: ['eslint'] } as CliFlags,
+    configFile: 'ailib.config.json',
+    localOverrideFile: 'ailib.local.json',
+    canonicalSlot: (_r, slot) => slot || null,
+    applyWorkspaceUpdate: async () => {
+      called = true;
+    }
+  });
+
+  const updated = JSON.parse(await fs.readFile(path.join(rootDir, 'ailib.config.json'), 'utf8')) as WorkspaceConfig;
+  assert.deepEqual(updated.modules, ['eslint']);
+  assert.equal(called, true);
+});
+
+test('removeCommand removes module from config and triggers update', async () => {
+  const rootDir = await tempDir();
+  const packageRoot = await tempDir();
+  await fs.writeFile(
+    path.join(rootDir, 'ailib.config.json'),
+    `${JSON.stringify({ language: 'typescript', modules: ['eslint', 'biome'], targets: [] })}\n`,
+    'utf8'
+  );
+
+  let called = false;
+  await removeCommand({
+    cwd: rootDir,
+    packageRoot,
+    flags: { _: ['eslint'] } as CliFlags,
+    configFile: 'ailib.config.json',
+    applyWorkspaceUpdate: async () => {
+      called = true;
+    }
+  });
+
+  const updated = JSON.parse(await fs.readFile(path.join(rootDir, 'ailib.config.json'), 'utf8')) as WorkspaceConfig;
+  assert.deepEqual(updated.modules, ['biome']);
+  assert.equal(called, true);
+});

--- a/src/cli/module-mutations.ts
+++ b/src/cli/module-mutations.ts
@@ -1,0 +1,153 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { resolveContext, resolveDefaultWorkspaceForMutation, resolveWorkspacePath } from './context-resolution.ts';
+import { validateModuleSelection } from './module-validation.ts';
+import { getEffectiveWorkspaceConfig } from './workspace-state.ts';
+import { exists, readJson, uniqueList } from './utils.ts';
+import type { CliFlags, Registry, WorkspaceConfig } from './types.ts';
+
+export async function updateCommand({
+  cwd,
+  packageRoot,
+  flags,
+  configFile,
+  localOverrideFile,
+  canonicalSlot,
+  applyWorkspaceUpdate
+}: {
+  cwd: string;
+  packageRoot: string;
+  flags: CliFlags;
+  configFile: string;
+  localOverrideFile: string;
+  canonicalSlot: (registry: Registry, slot: string | undefined) => string | null;
+  applyWorkspaceUpdate: (args: {
+    packageRoot: string;
+    rootDir: string;
+    workspaceOverride?: string;
+    forceOnConflict?: string;
+  }) => Promise<void>;
+}) {
+  const context = await resolveContext(cwd);
+  const workspaceFlag = getStringFlag(flags, 'workspace');
+  const workspaceOverride = workspaceFlag ? resolveWorkspacePath(context.rootDir, workspaceFlag) : undefined;
+  await applyWorkspaceUpdate({
+    packageRoot,
+    rootDir: context.rootDir,
+    workspaceOverride,
+    forceOnConflict: 'overwrite'
+  });
+  process.stdout.write('ailib updated\n');
+}
+
+export async function addCommand({
+  cwd,
+  packageRoot,
+  flags,
+  configFile,
+  localOverrideFile,
+  canonicalSlot,
+  applyWorkspaceUpdate
+}: {
+  cwd: string;
+  packageRoot: string;
+  flags: CliFlags;
+  configFile: string;
+  localOverrideFile: string;
+  canonicalSlot: (registry: Registry, slot: string | undefined) => string | null;
+  applyWorkspaceUpdate: (args: {
+    packageRoot: string;
+    rootDir: string;
+    workspaceOverride?: string;
+    forceOnConflict?: string;
+  }) => Promise<void>;
+}) {
+  const moduleId = flags._[0];
+  ensure(moduleId, 'Usage: ailib add <module>');
+  const context = await resolveContext(cwd);
+  const registry = await readJson<Registry>(path.join(packageRoot, 'registry.json'));
+
+  const targetWorkspace = resolveDefaultWorkspaceForMutation(context, getStringFlag(flags, 'workspace'));
+  const configPath = path.join(targetWorkspace, configFile);
+  ensure(await exists(configPath), `Missing ${configFile} in workspace: ${targetWorkspace}`);
+
+  const config = await readJson<WorkspaceConfig>(configPath);
+  const effective = await getEffectiveWorkspaceConfig({
+    workspaceDir: targetWorkspace,
+    rootDir: context.rootDir,
+    rootConfig: await readJson<WorkspaceConfig>(path.join(context.rootDir, configFile)),
+    registry,
+    canonicalSlot: (slot) => canonicalSlot(registry, slot),
+    configFile,
+    localOverrideFile
+  });
+  validateModuleSelection({
+    registry,
+    language: effective.language,
+    modules: uniqueList([...(config.modules || []), moduleId]),
+    canonicalSlot: (slot) => canonicalSlot(registry, slot)
+  });
+
+  config.modules = uniqueList([...(config.modules || []), moduleId]);
+  await fs.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+
+  const isRootMutation = path.resolve(targetWorkspace) === path.resolve(context.rootDir);
+  await applyWorkspaceUpdate({
+    packageRoot,
+    rootDir: context.rootDir,
+    workspaceOverride: isRootMutation ? undefined : targetWorkspace,
+    forceOnConflict: 'overwrite'
+  });
+
+  process.stdout.write(`module added: ${moduleId}\n`);
+}
+
+export async function removeCommand({
+  cwd,
+  packageRoot,
+  flags,
+  configFile,
+  applyWorkspaceUpdate
+}: {
+  cwd: string;
+  packageRoot: string;
+  flags: CliFlags;
+  configFile: string;
+  applyWorkspaceUpdate: (args: {
+    packageRoot: string;
+    rootDir: string;
+    workspaceOverride?: string;
+    forceOnConflict?: string;
+  }) => Promise<void>;
+}) {
+  const moduleId = flags._[0];
+  ensure(moduleId, 'Usage: ailib remove <module>');
+  const context = await resolveContext(cwd);
+  const targetWorkspace = resolveDefaultWorkspaceForMutation(context, getStringFlag(flags, 'workspace'));
+
+  const configPath = path.join(targetWorkspace, configFile);
+  ensure(await exists(configPath), `Missing ${configFile} in workspace: ${targetWorkspace}`);
+  const config = await readJson<WorkspaceConfig>(configPath);
+  config.modules = (config.modules || []).filter((m) => m !== moduleId);
+  await fs.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+
+  const isRootMutation = path.resolve(targetWorkspace) === path.resolve(context.rootDir);
+  await applyWorkspaceUpdate({
+    packageRoot,
+    rootDir: context.rootDir,
+    workspaceOverride: isRootMutation ? undefined : targetWorkspace,
+    forceOnConflict: 'overwrite'
+  });
+
+  process.stdout.write(`module removed: ${moduleId}\n`);
+}
+
+function getStringFlag(flags: CliFlags, key: string): string | undefined {
+  const value = flags[key];
+  if (typeof value === 'string') return value;
+  return undefined;
+}
+
+function ensure(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}


### PR DESCRIPTION
## Summary
- extract module mutation command logic from `src/cli.ts` into `src/cli/module-mutations.ts`
- keep `src/cli.ts` as thin wrappers for `update`, `add`, and `remove`
- add colocated tests in `src/cli/module-mutations.test.ts` for update/add/remove command flows

## TDD Evidence
- [ ] Behavior change: I added/updated a failing test first (Red), then implemented (Green), then refactored.
- [x] Refactor/docs/chore only: no behavior change, so Red step is not applicable.
- Red evidence:
  - Not applicable (behavior-preserving refactor)
- Green evidence:
  - `bun test src/cli/module-mutations.test.ts src/cli.test.ts test/cli.test.ts`
  - `bun run check`

## Test plan
- [x] `bun test src/cli/module-mutations.test.ts src/cli.test.ts test/cli.test.ts`
- [x] `bun run check`

Refs #85
Refs #84
Refs #87
Refs #83

Made with [Cursor](https://cursor.com)