### PR TITLE
refactor: extract cli introspection commands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import process from 'node:process';
 import { executeCommand } from './cli/dispatch.ts';
 import { getStringFlag, parseFlags } from './cli/flags.ts';
 import { printHelp } from './cli/help.ts';
+import { modulesCommand as runModulesCommand, slotsCommand as runSlotsCommand } from './cli/introspection.ts';
 import { detectProjectRoot, findNearestMonorepoRoot, resolveContext } from './cli/context-resolution.ts';
 import { doctorCommand as runDoctorCommand } from './cli/doctor.ts';
 import {
@@ -15,7 +16,7 @@ import { validateModuleSelection } from './cli/module-validation.ts';
 import { uninstallCommand as runUninstallCommand } from './cli/uninstall.ts';
 import { applyWorkspaceUpdate as applyWorkspaceUpdateCore } from './cli/workspace-update.ts';
 import { canonicalSlot, exists, readJson, splitCsv, toPosix, uniqueList } from './cli/utils.ts';
-import type { CommandContext, LanguageDefinition, Registry, RunOptions, WorkspaceConfig } from './cli/types.ts';
+import type { CommandContext, Registry, RunOptions, WorkspaceConfig } from './cli/types.ts';
 
 const CONFIG_FILE = 'ailib.config.json';
 const LOCAL_OVERRIDE_FILE = 'ailib.local.json';
@@ -56,73 +57,11 @@ function createCommandHandlers() {
 }
 
 async function slotsCommand({ packageRoot, flags }: Pick<CommandContext, 'packageRoot' | 'flags'>) {
-  const sub = flags._[0] || 'list';
-  ensure(sub === 'list', `Usage: ailib slots list`);
-
-  const registry = await readJson<Registry>(path.join(packageRoot, 'registry.json'));
-  const slotDefs = registry.slot_defs || {};
-
-  const lines = ['slots:'];
-  for (const slot of registry.slots || []) {
-    const def = slotDefs[slot] || {};
-    const kind = def.kind ? ` (${def.kind})` : '';
-    const description = def.description ? ` - ${def.description}` : '';
-    lines.push(`- ${slot}${kind}${description}`);
-  }
-  process.stdout.write(`${lines.join('\n')}\n`);
+  await runSlotsCommand({ packageRoot, flags });
 }
 
 async function modulesCommand({ packageRoot, flags }: Pick<CommandContext, 'packageRoot' | 'flags'>) {
-  const sub = flags._[0];
-  const registry = await readJson<Registry>(path.join(packageRoot, 'registry.json'));
-
-  if (sub === 'list') {
-    const language = getStringFlag(flags, 'language') || Object.keys(registry.languages)[0];
-    const lang = registry.languages[language];
-    ensure(lang, `Unsupported language: ${language}`);
-
-    const lines = [`modules (${language}):`];
-    const modules = Object.entries(lang.modules || {}).sort(([a], [b]) => a.localeCompare(b));
-    for (const [moduleId, moduleDef] of modules) {
-      lines.push(`- ${moduleId} (slot: ${moduleDef.slot})`);
-    }
-    process.stdout.write(`${lines.join('\n')}\n`);
-    return;
-  }
-
-  if (sub === 'explain') {
-    const moduleId = flags._[1];
-    ensure(moduleId, 'Usage: ailib modules explain <module> [--language=<lang>]');
-
-    const requestedLanguage = getStringFlag(flags, 'language');
-    const candidates: Array<[string, LanguageDefinition | undefined]> = requestedLanguage
-      ? [[requestedLanguage, registry.languages[requestedLanguage]]]
-      : Object.entries(registry.languages || {});
-
-    if (requestedLanguage) {
-      ensure(registry.languages[requestedLanguage], `Unsupported language: ${requestedLanguage}`);
-    }
-
-    for (const [language, lang] of candidates) {
-      const moduleDef = lang?.modules?.[moduleId];
-      if (!moduleDef) continue;
-      const lines = [
-        `module: ${moduleId}`,
-        `language: ${language}`,
-        `slot: ${moduleDef.slot}`,
-        `requires: ${(moduleDef.requires || []).join(', ') || '(none)'}`,
-        `conflicts_with: ${(moduleDef.conflicts_with || []).join(', ') || '(none)'}`,
-        `doc: languages/${language}/modules/${moduleId}.md`
-      ];
-      process.stdout.write(`${lines.join('\n')}\n`);
-      return;
-    }
-
-    const scope = requestedLanguage ? ` for ${requestedLanguage}` : '';
-    throw new Error(`Unknown module${scope}: ${moduleId}`);
-  }
-
-  throw new Error('Usage: ailib modules list [--language=<lang>] | ailib modules explain <module> [--language=<lang>]');
+  await runModulesCommand({ packageRoot, flags });
 }
 
 async function initCommand({ cwd, packageRoot, flags }: CommandContext) {

--- a/src/cli/introspection.test.ts
+++ b/src/cli/introspection.test.ts
@@ -1,0 +1,79 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { modulesCommand, slotsCommand } from './introspection.ts';
+import type { CliFlags, Registry } from './types.ts';
+
+async function tempDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'ailib-introspection-'));
+}
+
+async function withRegistry(registry: Registry) {
+  const root = await tempDir();
+  await fs.writeFile(path.join(root, 'registry.json'), `${JSON.stringify(registry, null, 2)}\n`, 'utf8');
+  return root;
+}
+
+async function captureStdout(fn: () => Promise<void>) {
+  const chunks: string[] = [];
+  const mutableStdout = process.stdout as unknown as { write: typeof process.stdout.write };
+  const originalWrite = mutableStdout.write.bind(process.stdout);
+  mutableStdout.write = ((chunk, encoding, callback) => {
+    chunks.push(typeof chunk === 'string' ? chunk : chunk.toString());
+    const done = typeof encoding === 'function' ? encoding : callback;
+    if (typeof done === 'function') done();
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    await fn();
+    return chunks.join('');
+  } finally {
+    mutableStdout.write = originalWrite;
+  }
+}
+
+const registry: Registry = {
+  version: 'test',
+  slots: ['linter'],
+  slot_defs: { linter: { kind: 'exclusive', description: 'Formatting and linting' } },
+  languages: {
+    typescript: {
+      modules: {
+        eslint: { slot: 'linter' }
+      }
+    }
+  },
+  targets: { cursor: { output: '.cursor/rules/ai.md' } }
+};
+
+test('slotsCommand prints slot definitions', async () => {
+  const packageRoot = await withRegistry(registry);
+  const output = await captureStdout(() => slotsCommand({ packageRoot, flags: { _: ['list'] } as CliFlags }));
+  assert.match(output, /slots:/);
+  assert.match(output, /linter \(exclusive\)/);
+});
+
+test('modulesCommand list and explain produce expected output', async () => {
+  const packageRoot = await withRegistry(registry);
+  const listOutput = await captureStdout(() =>
+    modulesCommand({ packageRoot, flags: { _: ['list'], language: 'typescript' } as CliFlags })
+  );
+  assert.match(listOutput, /modules \(typescript\):/);
+  assert.match(listOutput, /eslint \(slot: linter\)/);
+
+  const explainOutput = await captureStdout(() =>
+    modulesCommand({ packageRoot, flags: { _: ['explain', 'eslint'], language: 'typescript' } as CliFlags })
+  );
+  assert.match(explainOutput, /module: eslint/);
+  assert.match(explainOutput, /doc: languages\/typescript\/modules\/eslint\.md/);
+});
+
+test('modulesCommand explain throws for unknown module', async () => {
+  const packageRoot = await withRegistry(registry);
+  await assert.rejects(
+    modulesCommand({ packageRoot, flags: { _: ['explain', 'missing'], language: 'typescript' } as CliFlags }),
+    /Unknown module for typescript: missing/
+  );
+});

--- a/src/cli/introspection.ts
+++ b/src/cli/introspection.ts
@@ -1,0 +1,78 @@
+import path from 'node:path';
+import { getStringFlag } from './flags.ts';
+import { readJson } from './utils.ts';
+import type { CliFlags, LanguageDefinition, Registry } from './types.ts';
+
+export async function slotsCommand({ packageRoot, flags }: { packageRoot: string; flags: CliFlags }) {
+  const sub = flags._[0] || 'list';
+  ensure(sub === 'list', `Usage: ailib slots list`);
+
+  const registry = await readJson<Registry>(path.join(packageRoot, 'registry.json'));
+  const slotDefs = registry.slot_defs || {};
+
+  const lines = ['slots:'];
+  for (const slot of registry.slots || []) {
+    const def = slotDefs[slot] || {};
+    const kind = def.kind ? ` (${def.kind})` : '';
+    const description = def.description ? ` - ${def.description}` : '';
+    lines.push(`- ${slot}${kind}${description}`);
+  }
+  process.stdout.write(`${lines.join('\n')}\n`);
+}
+
+export async function modulesCommand({ packageRoot, flags }: { packageRoot: string; flags: CliFlags }) {
+  const sub = flags._[0];
+  const registry = await readJson<Registry>(path.join(packageRoot, 'registry.json'));
+
+  if (sub === 'list') {
+    const language = getStringFlag(flags, 'language') || Object.keys(registry.languages)[0];
+    const lang = registry.languages[language];
+    ensure(lang, `Unsupported language: ${language}`);
+
+    const lines = [`modules (${language}):`];
+    const modules = Object.entries(lang.modules || {}).sort(([a], [b]) => a.localeCompare(b));
+    for (const [moduleId, moduleDef] of modules) {
+      lines.push(`- ${moduleId} (slot: ${moduleDef.slot})`);
+    }
+    process.stdout.write(`${lines.join('\n')}\n`);
+    return;
+  }
+
+  if (sub === 'explain') {
+    const moduleId = flags._[1];
+    ensure(moduleId, 'Usage: ailib modules explain <module> [--language=<lang>]');
+
+    const requestedLanguage = getStringFlag(flags, 'language');
+    const candidates: Array<[string, LanguageDefinition | undefined]> = requestedLanguage
+      ? [[requestedLanguage, registry.languages[requestedLanguage]]]
+      : Object.entries(registry.languages || {});
+
+    if (requestedLanguage) {
+      ensure(registry.languages[requestedLanguage], `Unsupported language: ${requestedLanguage}`);
+    }
+
+    for (const [language, lang] of candidates) {
+      const moduleDef = lang?.modules?.[moduleId];
+      if (!moduleDef) continue;
+      const lines = [
+        `module: ${moduleId}`,
+        `language: ${language}`,
+        `slot: ${moduleDef.slot}`,
+        `requires: ${(moduleDef.requires || []).join(', ') || '(none)'}`,
+        `conflicts_with: ${(moduleDef.conflicts_with || []).join(', ') || '(none)'}`,
+        `doc: languages/${language}/modules/${moduleId}.md`
+      ];
+      process.stdout.write(`${lines.join('\n')}\n`);
+      return;
+    }
+
+    const scope = requestedLanguage ? ` for ${requestedLanguage}` : '';
+    throw new Error(`Unknown module${scope}: ${moduleId}`);
+  }
+
+  throw new Error('Usage: ailib modules list [--language=<lang>] | ailib modules explain <module> [--language=<lang>]');
+}
+
+function ensure(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}


### PR DESCRIPTION
## Summary
- extract `slots` and `modules` command logic from `src/cli.ts` into `src/cli/introspection.ts`
- keep `src/cli.ts` as thin wrappers delegating to the introspection module
- add colocated tests in `src/cli/introspection.test.ts` for slot listing and module list/explain flows

## TDD Evidence
- [ ] Behavior change: I added/updated a failing test first (Red), then implemented (Green), then refactored.
- [x] Refactor/docs/chore only: no behavior change, so Red step is not applicable.
- Red evidence:
  - Not applicable (behavior-preserving refactor)
- Green evidence:
  - `bun test src/cli/introspection.test.ts src/cli.test.ts test/cli.test.ts`
  - `bun run check`

## Test plan
- [x] `bun test src/cli/introspection.test.ts src/cli.test.ts test/cli.test.ts`
- [x] `bun run check`

Refs #85
Refs #84
Refs #87
Refs #83

Made with [Cursor](https://cursor.com)