### PR TITLE
refactor: extract init command module

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,22 +1,21 @@
-import fs from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
 import { executeCommand } from './cli/dispatch.ts';
-import { getStringFlag, parseFlags } from './cli/flags.ts';
+import { parseFlags } from './cli/flags.ts';
 import { printHelp } from './cli/help.ts';
+import { initCommand as runInitCommand } from './cli/init.ts';
 import { modulesCommand as runModulesCommand, slotsCommand as runSlotsCommand } from './cli/introspection.ts';
-import { detectProjectRoot, findNearestMonorepoRoot, resolveContext } from './cli/context-resolution.ts';
+import { resolveContext } from './cli/context-resolution.ts';
 import { doctorCommand as runDoctorCommand } from './cli/doctor.ts';
 import {
   addCommand as runAddCommand,
   removeCommand as runRemoveCommand,
   updateCommand as runUpdateCommand
 } from './cli/module-mutations.ts';
-import { validateModuleSelection } from './cli/module-validation.ts';
 import { uninstallCommand as runUninstallCommand } from './cli/uninstall.ts';
 import { applyWorkspaceUpdate as applyWorkspaceUpdateCore } from './cli/workspace-update.ts';
-import { canonicalSlot, exists, readJson, splitCsv, toPosix, uniqueList } from './cli/utils.ts';
-import type { CommandContext, Registry, RunOptions, WorkspaceConfig } from './cli/types.ts';
+import { canonicalSlot } from './cli/utils.ts';
+import type { CommandContext, Registry, RunOptions } from './cli/types.ts';
 
 const CONFIG_FILE = 'ailib.config.json';
 const LOCAL_OVERRIDE_FILE = 'ailib.local.json';
@@ -65,66 +64,15 @@ async function modulesCommand({ packageRoot, flags }: Pick<CommandContext, 'pack
 }
 
 async function initCommand({ cwd, packageRoot, flags }: CommandContext) {
-  const registry = await readJson<Registry>(path.join(packageRoot, 'registry.json'));
-  const nearestRoot = await findNearestMonorepoRoot(path.resolve(cwd));
-  const inServiceContext = Boolean(nearestRoot && path.resolve(cwd) !== nearestRoot);
-
-  const language = getStringFlag(flags, 'language') || Object.keys(registry.languages)[0];
-  ensure(registry.languages[language], `Unsupported language: ${language}`);
-
-  const modules = uniqueList(splitCsv(flags.modules));
-  const targets = uniqueList(splitCsv(flags.targets).length ? splitCsv(flags.targets) : Object.keys(registry.targets));
-  const onConflict = getStringFlag(flags, 'on-conflict') || 'merge';
-
-  validateModuleSelection({
-    registry,
-    language,
-    modules,
-    canonicalSlot: (slot) => resolveCanonicalSlot(registry, slot)
+  await runInitCommand({
+    cwd,
+    packageRoot,
+    flags,
+    configFile: CONFIG_FILE,
+    canonicalSlot: (registry, slot) => resolveCanonicalSlot(registry, slot),
+    applyWorkspaceUpdate: async ({ packageRoot: rootPackage, rootDir, workspaceOverride, forceOnConflict }) =>
+      applyWorkspaceUpdate({ packageRoot: rootPackage, rootDir, workspaceOverride, forceOnConflict })
   });
-
-  if (inServiceContext && flags['no-inherit'] !== true) {
-    const projectRoot = path.resolve(cwd);
-    const rel = toPosix(path.relative(projectRoot, path.join(nearestRoot, CONFIG_FILE)));
-    const config: WorkspaceConfig = {
-      $schema: 'https://ailib.dev/schema/config.schema.json',
-      extends: rel,
-      language,
-      modules,
-      docs_path: './docs/'
-    };
-    if (targets.length) config.targets = targets;
-
-    await fs.writeFile(path.join(projectRoot, CONFIG_FILE), `${JSON.stringify(config, null, 2)}\n`, 'utf8');
-    await applyWorkspaceUpdate({
-      packageRoot,
-      rootDir: nearestRoot,
-      workspaceOverride: projectRoot,
-      forceOnConflict: onConflict
-    });
-    process.stdout.write('ailib initialized\n');
-    return;
-  }
-
-  const projectRoot = await detectProjectRoot(cwd);
-  const config: WorkspaceConfig = {
-    $schema: 'https://ailib.dev/schema/config.schema.json',
-    registry_ref: registry.version,
-    language,
-    modules,
-    targets,
-    docs_path: 'docs/',
-    on_conflict: onConflict
-  };
-
-  const workspacePatterns = splitCsv(flags.workspaces);
-  if (flags.bare !== true) {
-    config.workspaces = workspacePatterns.length ? workspacePatterns : ['apps/*', 'services/*'];
-  }
-
-  await fs.writeFile(path.join(projectRoot, CONFIG_FILE), `${JSON.stringify(config, null, 2)}\n`, 'utf8');
-  await applyWorkspaceUpdate({ packageRoot, rootDir: projectRoot, forceOnConflict: onConflict });
-  process.stdout.write('ailib initialized\n');
 }
 
 async function updateCommand({ cwd, packageRoot, flags }: CommandContext) {
@@ -207,8 +155,4 @@ async function applyWorkspaceUpdate({
     localOverrideFile: LOCAL_OVERRIDE_FILE,
     canonicalSlot: (registry, slot) => resolveCanonicalSlot(registry, slot)
   });
-}
-
-function ensure(condition: unknown, message: string): asserts condition {
-  if (!condition) throw new Error(message);
 }

--- a/src/cli/init.test.ts
+++ b/src/cli/init.test.ts
@@ -1,0 +1,71 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { initCommand } from './init.ts';
+import type { CliFlags, Registry, WorkspaceConfig } from './types.ts';
+
+async function tempDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'ailib-init-'));
+}
+
+const registry: Registry = {
+  version: 'test-registry',
+  slots: ['linter'],
+  languages: { typescript: { modules: { eslint: { slot: 'linter' } } } },
+  targets: { cursor: { output: '.cursor/rules/ai.md' } }
+};
+
+test('initCommand writes root config and calls update', async () => {
+  const rootDir = await tempDir();
+  await fs.writeFile(path.join(rootDir, 'package.json'), '{"name":"root"}\n', 'utf8');
+  const packageRoot = path.join(rootDir, 'pkg');
+  await fs.mkdir(packageRoot, { recursive: true });
+  await fs.writeFile(path.join(packageRoot, 'registry.json'), `${JSON.stringify(registry)}\n`, 'utf8');
+
+  let called = false;
+  await initCommand({
+    cwd: rootDir,
+    packageRoot,
+    flags: { _: [], language: 'typescript', modules: 'eslint', targets: 'cursor' } as CliFlags,
+    configFile: 'ailib.config.json',
+    canonicalSlot: (_registry, slot) => slot || null,
+    applyWorkspaceUpdate: async ({ rootDir: updateRoot }) => {
+      called = true;
+      assert.equal(updateRoot, rootDir);
+    }
+  });
+
+  const config = JSON.parse(await fs.readFile(path.join(rootDir, 'ailib.config.json'), 'utf8')) as WorkspaceConfig;
+  assert.equal(config.language, 'typescript');
+  assert.deepEqual(config.modules, ['eslint']);
+  assert.ok(Array.isArray(config.workspaces));
+  assert.equal(called, true);
+});
+
+test('initCommand in service context writes extends config', async () => {
+  const rootDir = await tempDir();
+  await fs.writeFile(path.join(rootDir, 'ailib.config.json'), '{"workspaces":["apps/*"]}\n', 'utf8');
+  const serviceDir = path.join(rootDir, 'apps', 'api');
+  await fs.mkdir(serviceDir, { recursive: true });
+  const packageRoot = path.join(rootDir, 'pkg');
+  await fs.mkdir(packageRoot, { recursive: true });
+  await fs.writeFile(path.join(packageRoot, 'registry.json'), `${JSON.stringify(registry)}\n`, 'utf8');
+
+  let calledOverride = '';
+  await initCommand({
+    cwd: serviceDir,
+    packageRoot,
+    flags: { _: [], language: 'typescript', 'no-inherit': false } as CliFlags,
+    configFile: 'ailib.config.json',
+    canonicalSlot: (_registry, slot) => slot || null,
+    applyWorkspaceUpdate: async ({ workspaceOverride }) => {
+      calledOverride = workspaceOverride || '';
+    }
+  });
+
+  const config = JSON.parse(await fs.readFile(path.join(serviceDir, 'ailib.config.json'), 'utf8')) as WorkspaceConfig;
+  assert.ok(config.extends);
+  assert.equal(calledOverride, serviceDir);
+});

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,0 +1,93 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { detectProjectRoot, findNearestMonorepoRoot } from './context-resolution.ts';
+import { getStringFlag } from './flags.ts';
+import { validateModuleSelection } from './module-validation.ts';
+import { readJson, splitCsv, toPosix, uniqueList } from './utils.ts';
+import type { CliFlags, Registry, WorkspaceConfig } from './types.ts';
+
+export async function initCommand({
+  cwd,
+  packageRoot,
+  flags,
+  configFile,
+  canonicalSlot,
+  applyWorkspaceUpdate
+}: {
+  cwd: string;
+  packageRoot: string;
+  flags: CliFlags;
+  configFile: string;
+  canonicalSlot: (registry: Registry, slot: string | undefined) => string | null;
+  applyWorkspaceUpdate: (args: {
+    packageRoot: string;
+    rootDir: string;
+    workspaceOverride?: string;
+    forceOnConflict?: string;
+  }) => Promise<void>;
+}) {
+  const registry = await readJson<Registry>(path.join(packageRoot, 'registry.json'));
+  const nearestRoot = await findNearestMonorepoRoot(path.resolve(cwd));
+  const inServiceContext = Boolean(nearestRoot && path.resolve(cwd) !== nearestRoot);
+
+  const language = getStringFlag(flags, 'language') || Object.keys(registry.languages)[0];
+  ensure(registry.languages[language], `Unsupported language: ${language}`);
+
+  const modules = uniqueList(splitCsv(flags.modules));
+  const targets = uniqueList(splitCsv(flags.targets).length ? splitCsv(flags.targets) : Object.keys(registry.targets));
+  const onConflict = getStringFlag(flags, 'on-conflict') || 'merge';
+
+  validateModuleSelection({
+    registry,
+    language,
+    modules,
+    canonicalSlot: (slot) => canonicalSlot(registry, slot)
+  });
+
+  if (inServiceContext && flags['no-inherit'] !== true) {
+    const projectRoot = path.resolve(cwd);
+    const rel = toPosix(path.relative(projectRoot, path.join(nearestRoot, configFile)));
+    const config: WorkspaceConfig = {
+      $schema: 'https://ailib.dev/schema/config.schema.json',
+      extends: rel,
+      language,
+      modules,
+      docs_path: './docs/'
+    };
+    if (targets.length) config.targets = targets;
+
+    await fs.writeFile(path.join(projectRoot, configFile), `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+    await applyWorkspaceUpdate({
+      packageRoot,
+      rootDir: nearestRoot,
+      workspaceOverride: projectRoot,
+      forceOnConflict: onConflict
+    });
+    process.stdout.write('ailib initialized\n');
+    return;
+  }
+
+  const projectRoot = await detectProjectRoot(cwd);
+  const config: WorkspaceConfig = {
+    $schema: 'https://ailib.dev/schema/config.schema.json',
+    registry_ref: registry.version,
+    language,
+    modules,
+    targets,
+    docs_path: 'docs/',
+    on_conflict: onConflict
+  };
+
+  const workspacePatterns = splitCsv(flags.workspaces);
+  if (flags.bare !== true) {
+    config.workspaces = workspacePatterns.length ? workspacePatterns : ['apps/*', 'services/*'];
+  }
+
+  await fs.writeFile(path.join(projectRoot, configFile), `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+  await applyWorkspaceUpdate({ packageRoot, rootDir: projectRoot, forceOnConflict: onConflict });
+  process.stdout.write('ailib initialized\n');
+}
+
+function ensure(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}


### PR DESCRIPTION
## Summary
- extract init command orchestration from `src/cli.ts` into `src/cli/init.ts`
- keep `src/cli.ts` as a thin wrapper that delegates to the init module
- add colocated tests in `src/cli/init.test.ts` for root and service-context init flows

## TDD Evidence
- [ ] Behavior change: I added/updated a failing test first (Red), then implemented (Green), then refactored.
- [x] Refactor/docs/chore only: no behavior change, so Red step is not applicable.
- Red evidence:
  - Not applicable (behavior-preserving refactor)
- Green evidence:
  - `bun test src/cli/init.test.ts src/cli.test.ts test/cli.test.ts`
  - `bun run check`

## Test plan
- [x] `bun test src/cli/init.test.ts src/cli.test.ts test/cli.test.ts`
- [x] `bun run check`

Refs #85
Refs #84
Refs #87
Refs #83

Made with [Cursor](https://cursor.com)