### PR TITLE
refactor: extract cli command handlers

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,18 +1,9 @@
 import path from 'node:path';
 import process from 'node:process';
+import { createCommandHandlers } from './cli/command-handlers.ts';
 import { executeCommand } from './cli/dispatch.ts';
 import { parseFlags } from './cli/flags.ts';
 import { printHelp } from './cli/help.ts';
-import { initCommand as runInitCommand } from './cli/init.ts';
-import { modulesCommand as runModulesCommand, slotsCommand as runSlotsCommand } from './cli/introspection.ts';
-import { resolveContext } from './cli/context-resolution.ts';
-import { doctorCommand as runDoctorCommand } from './cli/doctor.ts';
-import {
-  addCommand as runAddCommand,
-  removeCommand as runRemoveCommand,
-  updateCommand as runUpdateCommand
-} from './cli/module-mutations.ts';
-import { uninstallCommand as runUninstallCommand } from './cli/uninstall.ts';
 import { applyWorkspaceUpdate as applyWorkspaceUpdateCore } from './cli/workspace-update.ts';
 import { canonicalSlot } from './cli/utils.ts';
 import type { CommandContext, Registry, RunOptions } from './cli/types.ts';
@@ -37,101 +28,15 @@ export async function run(argv: string[], options: RunOptions = {}) {
   await executeCommand({
     command,
     context,
-    handlers: createCommandHandlers(),
+    handlers: createCommandHandlers({
+      configFile: CONFIG_FILE,
+      localOverrideFile: LOCAL_OVERRIDE_FILE,
+      lockFile: LOCK_FILE,
+      resolveCanonicalSlot: (registry, slot) => resolveCanonicalSlot(registry, slot),
+      applyWorkspaceUpdate: async ({ packageRoot: rootPackage, rootDir, workspaceOverride, forceOnConflict }) =>
+        applyWorkspaceUpdate({ packageRoot: rootPackage, rootDir, workspaceOverride, forceOnConflict })
+    }),
     printHelp
-  });
-}
-
-function createCommandHandlers() {
-  return {
-    init: async (context: CommandContext) => initCommand(context),
-    update: async (context: CommandContext) => updateCommand(context),
-    add: async (context: CommandContext) => addCommand(context),
-    remove: async (context: CommandContext) => removeCommand(context),
-    doctor: async (context: CommandContext) => doctorCommand(context),
-    uninstall: async (context: CommandContext) => uninstallCommand(context),
-    slots: async (context: CommandContext) => slotsCommand(context),
-    modules: async (context: CommandContext) => modulesCommand(context)
-  };
-}
-
-async function slotsCommand({ packageRoot, flags }: Pick<CommandContext, 'packageRoot' | 'flags'>) {
-  await runSlotsCommand({ packageRoot, flags });
-}
-
-async function modulesCommand({ packageRoot, flags }: Pick<CommandContext, 'packageRoot' | 'flags'>) {
-  await runModulesCommand({ packageRoot, flags });
-}
-
-async function initCommand({ cwd, packageRoot, flags }: CommandContext) {
-  await runInitCommand({
-    cwd,
-    packageRoot,
-    flags,
-    configFile: CONFIG_FILE,
-    canonicalSlot: (registry, slot) => resolveCanonicalSlot(registry, slot),
-    applyWorkspaceUpdate: async ({ packageRoot: rootPackage, rootDir, workspaceOverride, forceOnConflict }) =>
-      applyWorkspaceUpdate({ packageRoot: rootPackage, rootDir, workspaceOverride, forceOnConflict })
-  });
-}
-
-async function updateCommand({ cwd, packageRoot, flags }: CommandContext) {
-  await runUpdateCommand({
-    cwd,
-    packageRoot,
-    flags,
-    configFile: CONFIG_FILE,
-    localOverrideFile: LOCAL_OVERRIDE_FILE,
-    canonicalSlot: (registry, slot) => resolveCanonicalSlot(registry, slot),
-    applyWorkspaceUpdate: async ({ packageRoot: rootPackage, rootDir, workspaceOverride, forceOnConflict }) =>
-      applyWorkspaceUpdate({ packageRoot: rootPackage, rootDir, workspaceOverride, forceOnConflict })
-  });
-}
-
-async function addCommand({ cwd, packageRoot, flags }: CommandContext) {
-  await runAddCommand({
-    cwd,
-    packageRoot,
-    flags,
-    configFile: CONFIG_FILE,
-    localOverrideFile: LOCAL_OVERRIDE_FILE,
-    canonicalSlot: (registry, slot) => resolveCanonicalSlot(registry, slot),
-    applyWorkspaceUpdate: async ({ packageRoot: rootPackage, rootDir, workspaceOverride, forceOnConflict }) =>
-      applyWorkspaceUpdate({ packageRoot: rootPackage, rootDir, workspaceOverride, forceOnConflict })
-  });
-}
-
-async function removeCommand({ cwd, packageRoot, flags }: CommandContext) {
-  await runRemoveCommand({
-    cwd,
-    packageRoot,
-    flags,
-    configFile: CONFIG_FILE,
-    applyWorkspaceUpdate: async ({ packageRoot: rootPackage, rootDir, workspaceOverride, forceOnConflict }) =>
-      applyWorkspaceUpdate({ packageRoot: rootPackage, rootDir, workspaceOverride, forceOnConflict })
-  });
-}
-
-async function doctorCommand({ cwd, packageRoot, flags }: CommandContext) {
-  await runDoctorCommand({
-    cwd,
-    packageRoot,
-    flags,
-    configFile: CONFIG_FILE,
-    localOverrideFile: LOCAL_OVERRIDE_FILE,
-    canonicalSlot: (registry, slot) => resolveCanonicalSlot(registry, slot)
-  });
-}
-
-async function uninstallCommand({ cwd, packageRoot, flags }: CommandContext) {
-  await runUninstallCommand({
-    cwd,
-    packageRoot,
-    flags,
-    configFile: CONFIG_FILE,
-    lockFile: LOCK_FILE,
-    applyWorkspaceUpdate: async ({ packageRoot: rootPackage, rootDir, forceOnConflict }) =>
-      applyWorkspaceUpdate({ packageRoot: rootPackage, rootDir, forceOnConflict })
   });
 }
 

--- a/src/cli/command-handlers.test.ts
+++ b/src/cli/command-handlers.test.ts
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createCommandHandlers } from './command-handlers.ts';
+import type { CommandContext, Registry } from './types.ts';
+
+function noopUpdate() {
+  return Promise.resolve();
+}
+
+const registryResolver = (_registry: Registry, slot: string | undefined) => slot || null;
+
+test('createCommandHandlers wires calls to provided runners', async () => {
+  const calls: string[] = [];
+  const context: CommandContext = { cwd: '/tmp', packageRoot: '/tmp/pkg', flags: { _: [] } };
+  const runners = {
+    initCommand: async () => void calls.push('init'),
+    updateCommand: async () => void calls.push('update'),
+    addCommand: async () => void calls.push('add'),
+    removeCommand: async () => void calls.push('remove'),
+    doctorCommand: async () => void calls.push('doctor'),
+    uninstallCommand: async () => void calls.push('uninstall'),
+    slotsCommand: async () => void calls.push('slots'),
+    modulesCommand: async () => void calls.push('modules')
+  };
+
+  const handlers = createCommandHandlers({
+    configFile: 'ailib.config.json',
+    localOverrideFile: 'ailib.local.json',
+    lockFile: 'ailib.lock',
+    resolveCanonicalSlot: registryResolver,
+    applyWorkspaceUpdate: noopUpdate,
+    runners
+  });
+
+  await handlers.init(context);
+  await handlers.update(context);
+  await handlers.add(context);
+  await handlers.remove(context);
+  await handlers.doctor(context);
+  await handlers.uninstall(context);
+  await handlers.slots(context);
+  await handlers.modules(context);
+
+  assert.deepEqual(calls, ['init', 'update', 'add', 'remove', 'doctor', 'uninstall', 'slots', 'modules']);
+});

--- a/src/cli/command-handlers.ts
+++ b/src/cli/command-handlers.ts
@@ -1,0 +1,117 @@
+import type { CommandContext, Registry } from './types.ts';
+import { doctorCommand as runDoctorCommand } from './doctor.ts';
+import { initCommand as runInitCommand } from './init.ts';
+import { modulesCommand as runModulesCommand, slotsCommand as runSlotsCommand } from './introspection.ts';
+import {
+  addCommand as runAddCommand,
+  removeCommand as runRemoveCommand,
+  updateCommand as runUpdateCommand
+} from './module-mutations.ts';
+import { uninstallCommand as runUninstallCommand } from './uninstall.ts';
+
+export type CanonicalSlotResolver = (registry: Registry, slot: string | undefined) => string | null;
+export type WorkspaceUpdateRunner = (args: {
+  packageRoot: string;
+  rootDir: string;
+  workspaceOverride?: string;
+  forceOnConflict?: string;
+}) => Promise<void>;
+
+type Runners = {
+  initCommand: typeof runInitCommand;
+  updateCommand: typeof runUpdateCommand;
+  addCommand: typeof runAddCommand;
+  removeCommand: typeof runRemoveCommand;
+  doctorCommand: typeof runDoctorCommand;
+  uninstallCommand: typeof runUninstallCommand;
+  slotsCommand: typeof runSlotsCommand;
+  modulesCommand: typeof runModulesCommand;
+};
+
+const DEFAULT_RUNNERS: Runners = {
+  initCommand: runInitCommand,
+  updateCommand: runUpdateCommand,
+  addCommand: runAddCommand,
+  removeCommand: runRemoveCommand,
+  doctorCommand: runDoctorCommand,
+  uninstallCommand: runUninstallCommand,
+  slotsCommand: runSlotsCommand,
+  modulesCommand: runModulesCommand
+};
+
+export function createCommandHandlers({
+  configFile,
+  localOverrideFile,
+  lockFile,
+  resolveCanonicalSlot,
+  applyWorkspaceUpdate,
+  runners = DEFAULT_RUNNERS
+}: {
+  configFile: string;
+  localOverrideFile: string;
+  lockFile: string;
+  resolveCanonicalSlot: CanonicalSlotResolver;
+  applyWorkspaceUpdate: WorkspaceUpdateRunner;
+  runners?: Runners;
+}) {
+  return {
+    init: async ({ cwd, packageRoot, flags }: CommandContext) =>
+      runners.initCommand({
+        cwd,
+        packageRoot,
+        flags,
+        configFile,
+        canonicalSlot: resolveCanonicalSlot,
+        applyWorkspaceUpdate
+      }),
+    update: async ({ cwd, packageRoot, flags }: CommandContext) =>
+      runners.updateCommand({
+        cwd,
+        packageRoot,
+        flags,
+        configFile,
+        localOverrideFile,
+        canonicalSlot: resolveCanonicalSlot,
+        applyWorkspaceUpdate
+      }),
+    add: async ({ cwd, packageRoot, flags }: CommandContext) =>
+      runners.addCommand({
+        cwd,
+        packageRoot,
+        flags,
+        configFile,
+        localOverrideFile,
+        canonicalSlot: resolveCanonicalSlot,
+        applyWorkspaceUpdate
+      }),
+    remove: async ({ cwd, packageRoot, flags }: CommandContext) =>
+      runners.removeCommand({
+        cwd,
+        packageRoot,
+        flags,
+        configFile,
+        applyWorkspaceUpdate
+      }),
+    doctor: async ({ cwd, packageRoot, flags }: CommandContext) =>
+      runners.doctorCommand({
+        cwd,
+        packageRoot,
+        flags,
+        configFile,
+        localOverrideFile,
+        canonicalSlot: resolveCanonicalSlot
+      }),
+    uninstall: async ({ cwd, packageRoot, flags }: CommandContext) =>
+      runners.uninstallCommand({
+        cwd,
+        packageRoot,
+        flags,
+        configFile,
+        lockFile,
+        applyWorkspaceUpdate: async ({ packageRoot: rootPackage, rootDir, forceOnConflict }) =>
+          applyWorkspaceUpdate({ packageRoot: rootPackage, rootDir, forceOnConflict })
+      }),
+    slots: async ({ packageRoot, flags }: CommandContext) => runners.slotsCommand({ packageRoot, flags }),
+    modules: async ({ packageRoot, flags }: CommandContext) => runners.modulesCommand({ packageRoot, flags })
+  };
+}


### PR DESCRIPTION
## Summary
- extract command wrapper wiring from `src/cli.ts` into `src/cli/command-handlers.ts`
- keep `src/cli.ts` focused on entrypoint parsing and dispatch orchestration
- add colocated tests for handler routing in `src/cli/command-handlers.test.ts`

## TDD Evidence
- [ ] New behavior change (tests added first, then implementation)
- [x] Refactor/docs/chore only (no behavior change)
- Red: N/A (refactor-only slice)
- Green: `bun test src/cli/command-handlers.test.ts src/cli.test.ts test/cli.test.ts`

## Test Plan
- `bun test src/cli/command-handlers.test.ts src/cli.test.ts test/cli.test.ts`
- `bun run check`

Refs #85
Refs #87

Made with [Cursor](https://cursor.com)