### PR TITLE
refactor: extract workspace update runner

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import { createCommandHandlers } from './cli/command-handlers.ts';
 import { executeCommand } from './cli/dispatch.ts';
 import { parseFlags } from './cli/flags.ts';
 import { printHelp } from './cli/help.ts';
-import { applyWorkspaceUpdate as applyWorkspaceUpdateCore } from './cli/workspace-update.ts';
+import { createWorkspaceUpdateRunner } from './cli/workspace-update-runner.ts';
 import { canonicalSlot } from './cli/utils.ts';
 import type { CommandContext, Registry, RunOptions } from './cli/types.ts';
 
@@ -12,6 +12,11 @@ const CONFIG_FILE = 'ailib.config.json';
 const LOCAL_OVERRIDE_FILE = 'ailib.local.json';
 const LOCK_FILE = 'ailib.lock';
 const WARNED_SLOT_ALIASES = new Set<string>();
+const APPLY_WORKSPACE_UPDATE = createWorkspaceUpdateRunner({
+  configFile: CONFIG_FILE,
+  localOverrideFile: LOCAL_OVERRIDE_FILE,
+  canonicalSlot: (registry, slot) => resolveCanonicalSlot(registry, slot)
+});
 
 function resolveCanonicalSlot(registry: Registry, slot: string | undefined) {
   return canonicalSlot({ registry, slot, warnedSlotAliases: WARNED_SLOT_ALIASES });
@@ -34,30 +39,8 @@ export async function run(argv: string[], options: RunOptions = {}) {
       lockFile: LOCK_FILE,
       resolveCanonicalSlot: (registry, slot) => resolveCanonicalSlot(registry, slot),
       applyWorkspaceUpdate: async ({ packageRoot: rootPackage, rootDir, workspaceOverride, forceOnConflict }) =>
-        applyWorkspaceUpdate({ packageRoot: rootPackage, rootDir, workspaceOverride, forceOnConflict })
+        APPLY_WORKSPACE_UPDATE({ packageRoot: rootPackage, rootDir, workspaceOverride, forceOnConflict })
     }),
     printHelp
-  });
-}
-
-async function applyWorkspaceUpdate({
-  packageRoot,
-  rootDir,
-  workspaceOverride,
-  forceOnConflict
-}: {
-  packageRoot: string;
-  rootDir: string;
-  workspaceOverride?: string;
-  forceOnConflict?: string;
-}) {
-  await applyWorkspaceUpdateCore({
-    packageRoot,
-    rootDir,
-    workspaceOverride,
-    forceOnConflict,
-    configFile: CONFIG_FILE,
-    localOverrideFile: LOCAL_OVERRIDE_FILE,
-    canonicalSlot: (registry, slot) => resolveCanonicalSlot(registry, slot)
   });
 }

--- a/src/cli/workspace-update-runner.test.ts
+++ b/src/cli/workspace-update-runner.test.ts
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createWorkspaceUpdateRunner } from './workspace-update-runner.ts';
+
+test('createWorkspaceUpdateRunner forwards args and config to core runner', async () => {
+  const calls: unknown[] = [];
+  const canonicalSlot = () => null;
+  const runner = createWorkspaceUpdateRunner({
+    configFile: 'ailib.config.json',
+    localOverrideFile: 'ailib.local.json',
+    canonicalSlot,
+    coreRunner: async (args) => {
+      calls.push(args);
+    }
+  });
+
+  await runner({
+    packageRoot: '/pkg',
+    rootDir: '/root',
+    workspaceOverride: 'apps/web',
+    forceOnConflict: 'overwrite'
+  });
+
+  assert.equal(calls.length, 1);
+  const first = calls[0] as {
+    packageRoot: string;
+    rootDir: string;
+    workspaceOverride?: string;
+    forceOnConflict?: string;
+    configFile: string;
+    localOverrideFile: string;
+    canonicalSlot: typeof canonicalSlot;
+  };
+  assert.equal(first.packageRoot, '/pkg');
+  assert.equal(first.rootDir, '/root');
+  assert.equal(first.workspaceOverride, 'apps/web');
+  assert.equal(first.forceOnConflict, 'overwrite');
+  assert.equal(first.configFile, 'ailib.config.json');
+  assert.equal(first.localOverrideFile, 'ailib.local.json');
+  assert.equal(first.canonicalSlot, canonicalSlot);
+  assert.deepEqual(
+    {
+      packageRoot: first.packageRoot,
+      rootDir: first.rootDir,
+      workspaceOverride: first.workspaceOverride,
+      forceOnConflict: first.forceOnConflict,
+      configFile: first.configFile,
+      localOverrideFile: first.localOverrideFile
+    },
+    {
+      packageRoot: '/pkg',
+      rootDir: '/root',
+      workspaceOverride: 'apps/web',
+      forceOnConflict: 'overwrite',
+      configFile: 'ailib.config.json',
+      localOverrideFile: 'ailib.local.json'
+    }
+  );
+});

--- a/src/cli/workspace-update-runner.ts
+++ b/src/cli/workspace-update-runner.ts
@@ -1,0 +1,34 @@
+import { applyWorkspaceUpdate as applyWorkspaceUpdateCore } from './workspace-update.ts';
+import type { Registry } from './types.ts';
+
+export type CanonicalSlotResolver = (registry: Registry, slot: string | undefined) => string | null;
+export type WorkspaceUpdateRunner = (args: {
+  packageRoot: string;
+  rootDir: string;
+  workspaceOverride?: string;
+  forceOnConflict?: string;
+}) => Promise<void>;
+
+export function createWorkspaceUpdateRunner({
+  configFile,
+  localOverrideFile,
+  canonicalSlot,
+  coreRunner = applyWorkspaceUpdateCore
+}: {
+  configFile: string;
+  localOverrideFile: string;
+  canonicalSlot: CanonicalSlotResolver;
+  coreRunner?: typeof applyWorkspaceUpdateCore;
+}): WorkspaceUpdateRunner {
+  return async ({ packageRoot, rootDir, workspaceOverride, forceOnConflict }) => {
+    await coreRunner({
+      packageRoot,
+      rootDir,
+      workspaceOverride,
+      forceOnConflict,
+      configFile,
+      localOverrideFile,
+      canonicalSlot
+    });
+  };
+}


### PR DESCRIPTION
## Summary
- extract workspace update adapter logic from `src/cli.ts` into `src/cli/workspace-update-runner.ts`
- keep `src/cli.ts` focused on entrypoint setup and command dispatch
- add colocated tests for runner argument forwarding in `src/cli/workspace-update-runner.test.ts`

## TDD Evidence
- [ ] New behavior change (tests added first, then implementation)
- [x] Refactor/docs/chore only (no behavior change)
- Red: N/A (refactor-only slice)
- Green: `bun test src/cli/workspace-update-runner.test.ts src/cli/command-handlers.test.ts src/cli.test.ts test/cli.test.ts`

## Test Plan
- `bun test src/cli/workspace-update-runner.test.ts src/cli/command-handlers.test.ts src/cli.test.ts test/cli.test.ts`
- `bun run check`

Refs #85
Refs #87

Made with [Cursor](https://cursor.com)