### PR TITLE
refactor: extract canonical slot resolver

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,23 +4,19 @@ import { createCommandHandlers } from './cli/command-handlers.ts';
 import { executeCommand } from './cli/dispatch.ts';
 import { parseFlags } from './cli/flags.ts';
 import { printHelp } from './cli/help.ts';
+import { createCanonicalSlotResolver } from './cli/slot-resolver.ts';
 import { createWorkspaceUpdateRunner } from './cli/workspace-update-runner.ts';
-import { canonicalSlot } from './cli/utils.ts';
-import type { CommandContext, Registry, RunOptions } from './cli/types.ts';
+import type { CommandContext, RunOptions } from './cli/types.ts';
 
 const CONFIG_FILE = 'ailib.config.json';
 const LOCAL_OVERRIDE_FILE = 'ailib.local.json';
 const LOCK_FILE = 'ailib.lock';
-const WARNED_SLOT_ALIASES = new Set<string>();
+const RESOLVE_CANONICAL_SLOT = createCanonicalSlotResolver();
 const APPLY_WORKSPACE_UPDATE = createWorkspaceUpdateRunner({
   configFile: CONFIG_FILE,
   localOverrideFile: LOCAL_OVERRIDE_FILE,
-  canonicalSlot: (registry, slot) => resolveCanonicalSlot(registry, slot)
+  canonicalSlot: (registry, slot) => RESOLVE_CANONICAL_SLOT(registry, slot)
 });
-
-function resolveCanonicalSlot(registry: Registry, slot: string | undefined) {
-  return canonicalSlot({ registry, slot, warnedSlotAliases: WARNED_SLOT_ALIASES });
-}
 
 export async function run(argv: string[], options: RunOptions = {}) {
   const cwd = options.cwd ?? process.cwd();
@@ -37,7 +33,7 @@ export async function run(argv: string[], options: RunOptions = {}) {
       configFile: CONFIG_FILE,
       localOverrideFile: LOCAL_OVERRIDE_FILE,
       lockFile: LOCK_FILE,
-      resolveCanonicalSlot: (registry, slot) => resolveCanonicalSlot(registry, slot),
+      resolveCanonicalSlot: (registry, slot) => RESOLVE_CANONICAL_SLOT(registry, slot),
       applyWorkspaceUpdate: async ({ packageRoot: rootPackage, rootDir, workspaceOverride, forceOnConflict }) =>
         APPLY_WORKSPACE_UPDATE({ packageRoot: rootPackage, rootDir, workspaceOverride, forceOnConflict })
     }),

--- a/src/cli/slot-resolver.test.ts
+++ b/src/cli/slot-resolver.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createCanonicalSlotResolver } from './slot-resolver.ts';
+import type { Registry } from './types.ts';
+
+function registryWithAlias(): Registry {
+  return {
+    version: '1',
+    slot_aliases: {
+      old_slot: 'new_slot'
+    },
+    languages: {
+      ts: {
+        modules: {}
+      }
+    },
+    targets: {}
+  };
+}
+
+test('createCanonicalSlotResolver resolves aliases', () => {
+  const resolveCanonicalSlot = createCanonicalSlotResolver({
+    writeWarning: () => {}
+  });
+  assert.equal(resolveCanonicalSlot(registryWithAlias(), 'old_slot'), 'new_slot');
+});
+
+test('createCanonicalSlotResolver warns once per alias', () => {
+  const warnings: string[] = [];
+  const resolveCanonicalSlot = createCanonicalSlotResolver({
+    writeWarning: (message) => warnings.push(message)
+  });
+  const registry = registryWithAlias();
+
+  assert.equal(resolveCanonicalSlot(registry, 'old_slot'), 'new_slot');
+  assert.equal(resolveCanonicalSlot(registry, 'old_slot'), 'new_slot');
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0] ?? '', /is deprecated; use/);
+});

--- a/src/cli/slot-resolver.ts
+++ b/src/cli/slot-resolver.ts
@@ -1,0 +1,19 @@
+import { canonicalSlot } from './utils.ts';
+import type { Registry } from './types.ts';
+
+type WriteWarning = (message: string) => void;
+
+export function createCanonicalSlotResolver({
+  writeWarning
+}: {
+  writeWarning?: WriteWarning;
+} = {}) {
+  const warnedSlotAliases = new Set<string>();
+  return (registry: Registry, slot: string | undefined) =>
+    canonicalSlot({
+      registry,
+      slot,
+      warnedSlotAliases,
+      writeWarning
+    });
+}


### PR DESCRIPTION
## Summary
- extract canonical slot resolution setup from `src/cli.ts` into `src/cli/slot-resolver.ts`
- encapsulate alias-warning state in a dedicated resolver factory
- add colocated tests in `src/cli/slot-resolver.test.ts` for alias mapping and warning behavior

## TDD Evidence
- [ ] New behavior change (tests added first, then implementation)
- [x] Refactor/docs/chore only (no behavior change)
- Red: N/A (refactor-only slice)
- Green: `bun test src/cli/slot-resolver.test.ts src/cli/workspace-update-runner.test.ts src/cli/command-handlers.test.ts src/cli.test.ts test/cli.test.ts`

## Test Plan
- `bun test src/cli/slot-resolver.test.ts src/cli/workspace-update-runner.test.ts src/cli/command-handlers.test.ts src/cli.test.ts test/cli.test.ts`
- `bun run check`

Refs #85
Refs #87

Made with [Cursor](https://cursor.com)