### PR TITLE
refactor: split doctor and workspace state

### DIFF
--- a/src/cli/doctor-audit.test.ts
+++ b/src/cli/doctor-audit.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { auditWorkspaceRequiredFiles } from './doctor-audit.ts';
+
+async function tempDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'ailib-doctor-audit-'));
+}
+
+test('auditWorkspaceRequiredFiles reports pointer and frontmatter issues', async () => {
+  const workspaceDir = await tempDir();
+  const requiredFiles = ['.ailib/behavior.md', '.ailib/modules/eslint.md'];
+  await fs.mkdir(path.join(workspaceDir, '.ailib/modules'), { recursive: true });
+  await fs.writeFile(path.join(workspaceDir, '.ailib/behavior.md'), 'no frontmatter', 'utf8');
+  await fs.writeFile(
+    path.join(workspaceDir, '.ailib/modules/eslint.md'),
+    '---\nid: eslint\nversion: v1\nupdated: now\nlanguage: typescript\n---\nmodule',
+    'utf8'
+  );
+
+  const errors = await auditWorkspaceRequiredFiles({
+    workspaceDir,
+    workspaceLabel: '.',
+    requiredFiles
+  });
+
+  const joined = errors.join('\n');
+  assert.match(joined, /Missing frontmatter: \.ailib\/behavior\.md/);
+  assert.match(joined, /Frontmatter missing 'slot': \.ailib\/modules\/eslint\.md/);
+  assert.doesNotMatch(joined, /Missing pointer file/);
+});

--- a/src/cli/doctor-audit.ts
+++ b/src/cli/doctor-audit.ts
@@ -1,0 +1,46 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { parseFrontmatter } from './file-helpers.ts';
+import { exists } from './utils.ts';
+
+export async function auditWorkspaceRequiredFiles({
+  workspaceDir,
+  workspaceLabel,
+  requiredFiles
+}: {
+  workspaceDir: string;
+  workspaceLabel: string;
+  requiredFiles: string[];
+}) {
+  const errors: string[] = [];
+
+  for (const rel of requiredFiles) {
+    if (!(await exists(path.join(workspaceDir, rel)))) {
+      errors.push(`[${workspaceLabel}] Missing pointer file: ${rel}`);
+    }
+  }
+
+  for (const rel of requiredFiles) {
+    const full = path.join(workspaceDir, rel);
+    if (!(await exists(full))) continue;
+    const text = await fs.readFile(full, 'utf8');
+    const frontmatter = parseFrontmatter(text);
+    if (!frontmatter) {
+      errors.push(`[${workspaceLabel}] Missing frontmatter: ${rel}`);
+      continue;
+    }
+    for (const key of ['id', 'version', 'updated']) {
+      if (!(key in frontmatter)) {
+        errors.push(`[${workspaceLabel}] Frontmatter missing '${key}': ${rel}`);
+      }
+    }
+    if (!('language' in frontmatter) && !('core' in frontmatter)) {
+      errors.push(`[${workspaceLabel}] Frontmatter missing 'language' or 'core': ${rel}`);
+    }
+    if (rel.includes('/modules/') && !('slot' in frontmatter)) {
+      errors.push(`[${workspaceLabel}] Frontmatter missing 'slot': ${rel}`);
+    }
+  }
+
+  return errors;
+}

--- a/src/cli/doctor-preflight.test.ts
+++ b/src/cli/doctor-preflight.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { runDoctorPreflight } from './doctor-preflight.ts';
+import type { CliFlags } from './types.ts';
+
+async function tempDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'ailib-doctor-preflight-'));
+}
+
+test('runDoctorPreflight returns local override error when invalid', async () => {
+  const rootDir = await tempDir();
+  const packageRoot = path.join(rootDir, 'pkg');
+  await fs.mkdir(packageRoot, { recursive: true });
+  await fs.writeFile(path.join(rootDir, 'package.json'), '{"name":"tmp"}\n', 'utf8');
+  await fs.writeFile(
+    path.join(packageRoot, 'registry.json'),
+    `${JSON.stringify({ version: 'test', slots: ['linter'], languages: { typescript: { modules: {} } }, targets: {} })}\n`,
+    'utf8'
+  );
+  await fs.writeFile(
+    path.join(rootDir, 'ailib.config.json'),
+    `${JSON.stringify({ language: 'typescript', modules: [], targets: [] })}\n`,
+    'utf8'
+  );
+  await fs.writeFile(path.join(rootDir, 'ailib.local.json'), '{"version":"1","workspace_overrides":[]}\n', 'utf8');
+
+  const result = await runDoctorPreflight({
+    cwd: rootDir,
+    packageRoot,
+    flags: { _: [] } as CliFlags,
+    configFile: 'ailib.config.json',
+    localOverrideFile: 'ailib.local.json',
+    canonicalSlot: (_registry, slot) => slot || null
+  });
+
+  assert.ok(result.localOverrideError);
+  assert.match(result.localOverrideError ?? '', /Invalid ailib.local.json/);
+});

--- a/src/cli/doctor-preflight.ts
+++ b/src/cli/doctor-preflight.ts
@@ -1,0 +1,83 @@
+import path from 'node:path';
+import { resolveContext } from './context-resolution.ts';
+import { assertLocalOverridesValid } from './local-override-config.ts';
+import { bindRegistryCanonicalSlot } from './slot-resolver.ts';
+import { getEffectiveWorkspaceConfig } from './workspace-state.ts';
+import { readJson } from './utils.ts';
+import { listWorkspaceDirs } from './workspace-discovery.ts';
+import { getStringFlag } from './flags.ts';
+import type { CliFlags, Registry, WorkspaceConfig } from './types.ts';
+import type { ResolvedContext } from './context-resolution.ts';
+import type { EffectiveWorkspaceConfig } from './types.ts';
+
+export async function runDoctorPreflight({
+  cwd,
+  packageRoot,
+  flags,
+  configFile,
+  localOverrideFile,
+  canonicalSlot
+}: {
+  cwd: string;
+  packageRoot: string;
+  flags: CliFlags;
+  configFile: string;
+  localOverrideFile: string;
+  canonicalSlot: (registry: Registry, slot: string | undefined) => string | null;
+}): Promise<{
+  context: ResolvedContext;
+  registry: Registry;
+  rootConfig: WorkspaceConfig;
+  workspaceDirs: string[];
+  rootEffective: EffectiveWorkspaceConfig | null;
+  localOverrideError: string | null;
+}> {
+  const context = await resolveContext(cwd);
+  const registry = await readJson<Registry>(path.join(packageRoot, 'registry.json'));
+  const canonicalSlotForRegistry = bindRegistryCanonicalSlot(registry, canonicalSlot);
+  const rootConfig = await readJson<WorkspaceConfig>(path.join(context.rootDir, configFile));
+  const workspaceDirs = await listWorkspaceDirs({
+    rootDir: context.rootDir,
+    rootConfig,
+    workspaceOverride: getStringFlag(flags, 'workspace')
+  });
+
+  try {
+    await assertLocalOverridesValid({
+      rootDir: context.rootDir,
+      rootConfig,
+      registry,
+      canonicalSlot: canonicalSlotForRegistry,
+      localOverrideFile
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      context,
+      registry,
+      rootConfig,
+      workspaceDirs,
+      rootEffective: null,
+      localOverrideError: message
+    };
+  }
+
+  const rootEffective = await getEffectiveWorkspaceConfig({
+    workspaceDir: context.rootDir,
+    rootDir: context.rootDir,
+    rootConfig,
+    registry,
+    canonicalSlot: canonicalSlotForRegistry,
+    configFile,
+    localOverrideFile
+  });
+
+  return {
+    context,
+    registry,
+    rootConfig,
+    workspaceDirs,
+    rootEffective,
+    localOverrideError: null
+  };
+}

--- a/src/cli/doctor-reporting.test.ts
+++ b/src/cli/doctor-reporting.test.ts
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { formatDoctorErrors, formatDoctorOk, formatDoctorWarnings } from './doctor-reporting.ts';
+
+test('doctor reporting formatters build expected output', () => {
+  assert.equal(formatDoctorWarnings([]), '');
+  assert.equal(formatDoctorWarnings(['a', 'b']), 'doctor warnings:\n- a\n- b\n');
+  assert.equal(formatDoctorErrors(['x']), 'doctor failed:\n- x\n');
+  assert.equal(formatDoctorOk(), 'doctor ok\n');
+});

--- a/src/cli/doctor-reporting.ts
+++ b/src/cli/doctor-reporting.ts
@@ -1,0 +1,12 @@
+export function formatDoctorWarnings(warnings: string[]) {
+  if (!warnings.length) return '';
+  return `doctor warnings:\n- ${warnings.join('\n- ')}\n`;
+}
+
+export function formatDoctorErrors(errors: string[]) {
+  return `doctor failed:\n- ${errors.join('\n- ')}\n`;
+}
+
+export function formatDoctorOk() {
+  return 'doctor ok\n';
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,13 +1,13 @@
-import fs from 'node:fs/promises';
 import path from 'node:path';
-import { resolveContext, workspaceLabelFor } from './context-resolution.ts';
-import { parseFrontmatter } from './file-helpers.ts';
-import { assertLocalOverridesValid } from './local-override-config.ts';
+import { workspaceLabelFor } from './context-resolution.ts';
+import { auditWorkspaceRequiredFiles } from './doctor-audit.ts';
+import { runDoctorPreflight } from './doctor-preflight.ts';
+import { formatDoctorErrors, formatDoctorOk, formatDoctorWarnings } from './doctor-reporting.ts';
 import { diffSlots } from './module-selection.ts';
-import { buildWorkspaceState, getEffectiveWorkspaceConfig } from './workspace-state.ts';
-import { exists, readJson } from './utils.ts';
-import { listWorkspaceDirs } from './workspace-discovery.ts';
-import type { CliFlags, Registry, WorkspaceConfig, WorkspaceState } from './types.ts';
+import { bindRegistryCanonicalSlot } from './slot-resolver.ts';
+import { buildWorkspaceState } from './workspace-state.ts';
+import { exists } from './utils.ts';
+import type { CliFlags, Registry, WorkspaceState } from './types.ts';
 
 export async function doctorCommand({
   cwd,
@@ -24,44 +24,30 @@ export async function doctorCommand({
   localOverrideFile: string;
   canonicalSlot: (registry: Registry, slot: string | undefined) => string | null;
 }) {
-  const context = await resolveContext(cwd);
-  const registry = await readJson<Registry>(path.join(packageRoot, 'registry.json'));
-  const rootConfig = await readJson<WorkspaceConfig>(path.join(context.rootDir, configFile));
-  const workspaceDirs = await listWorkspaceDirs({
-    rootDir: context.rootDir,
-    rootConfig,
-    workspaceOverride: getStringFlag(flags, 'workspace')
+  const preflight = await runDoctorPreflight({
+    cwd,
+    packageRoot,
+    flags,
+    configFile,
+    localOverrideFile,
+    canonicalSlot
   });
-
-  const errors: string[] = [];
-  const warnings: string[] = [];
-  try {
-    await assertLocalOverridesValid({
-      rootDir: context.rootDir,
-      rootConfig,
-      registry,
-      canonicalSlot: (slot) => canonicalSlot(registry, slot),
-      localOverrideFile
-    });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    errors.push(message);
+  if (preflight.localOverrideError !== null) {
+    process.stdout.write(formatDoctorErrors([preflight.localOverrideError]));
+    process.exitCode = 1;
+    return;
   }
-  if (errors.length) {
-    process.stdout.write(`doctor failed:\n- ${errors.join('\n- ')}\n`);
+  if (!preflight.rootEffective) {
+    process.stdout.write(formatDoctorErrors(['Failed to build root workspace state']));
     process.exitCode = 1;
     return;
   }
 
-  const rootEffective = await getEffectiveWorkspaceConfig({
-    workspaceDir: context.rootDir,
-    rootDir: context.rootDir,
-    rootConfig,
-    registry,
-    canonicalSlot: (slot) => canonicalSlot(registry, slot),
-    configFile,
-    localOverrideFile
-  });
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  const { context, registry, rootConfig, workspaceDirs, rootEffective } = preflight;
+  const canonicalSlotForRegistry = bindRegistryCanonicalSlot(registry, canonicalSlot);
   for (const workspaceDir of workspaceDirs) {
     const workspaceLabel = workspaceLabelFor(context.rootDir, workspaceDir);
     const configPath = path.join(workspaceDir, configFile);
@@ -77,7 +63,7 @@ export async function doctorCommand({
         rootDir: context.rootDir,
         rootConfig,
         registry,
-        canonicalSlot: (slot) => canonicalSlot(registry, slot),
+        canonicalSlot: canonicalSlotForRegistry,
         configFile,
         localOverrideFile
       });
@@ -86,34 +72,13 @@ export async function doctorCommand({
       errors.push(`[${workspaceLabel}] ${message}`);
       continue;
     }
-
-    for (const rel of state.requiredFiles) {
-      if (!(await exists(path.join(workspaceDir, rel)))) {
-        errors.push(`[${workspaceLabel}] Missing pointer file: ${rel}`);
-      }
-    }
-
-    for (const rel of state.requiredFiles) {
-      const full = path.join(workspaceDir, rel);
-      if (!(await exists(full))) continue;
-      const text = await fs.readFile(full, 'utf8');
-      const frontmatter = parseFrontmatter(text);
-      if (!frontmatter) {
-        errors.push(`[${workspaceLabel}] Missing frontmatter: ${rel}`);
-        continue;
-      }
-      for (const key of ['id', 'version', 'updated']) {
-        if (!(key in frontmatter)) {
-          errors.push(`[${workspaceLabel}] Frontmatter missing '${key}': ${rel}`);
-        }
-      }
-      if (!('language' in frontmatter) && !('core' in frontmatter)) {
-        errors.push(`[${workspaceLabel}] Frontmatter missing 'language' or 'core': ${rel}`);
-      }
-      if (rel.includes('/modules/') && !('slot' in frontmatter)) {
-        errors.push(`[${workspaceLabel}] Frontmatter missing 'slot': ${rel}`);
-      }
-    }
+    errors.push(
+      ...(await auditWorkspaceRequiredFiles({
+        workspaceDir,
+        workspaceLabel,
+        requiredFiles: state.requiredFiles
+      }))
+    );
 
     if (path.resolve(workspaceDir) !== path.resolve(context.rootDir)) {
       const slotDiffs = diffSlots({
@@ -121,25 +86,20 @@ export async function doctorCommand({
         workspaceModules: state.effective.modules,
         registry,
         language: state.effective.language,
-        canonicalSlot: (slot) => canonicalSlot(registry, slot)
+        canonicalSlot: canonicalSlotForRegistry
       });
       for (const msg of slotDiffs) warnings.push(`[${workspaceLabel}] ${msg}`);
     }
   }
 
-  if (warnings.length) process.stdout.write(`doctor warnings:\n- ${warnings.join('\n- ')}\n`);
+  const warningOutput = formatDoctorWarnings(warnings);
+  if (warningOutput) process.stdout.write(warningOutput);
 
   if (errors.length) {
-    process.stdout.write(`doctor failed:\n- ${errors.join('\n- ')}\n`);
+    process.stdout.write(formatDoctorErrors(errors));
     process.exitCode = 1;
     return;
   }
 
-  process.stdout.write('doctor ok\n');
-}
-
-function getStringFlag(flags: CliFlags, key: string): string | undefined {
-  const value = flags[key];
-  if (typeof value === 'string') return value;
-  return undefined;
+  process.stdout.write(formatDoctorOk());
 }

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { detectProjectRoot, findNearestMonorepoRoot } from './context-resolution.ts';
 import { getStringFlag } from './flags.ts';
 import { validateModuleSelection } from './module-validation.ts';
+import { bindRegistryCanonicalSlot } from './slot-resolver.ts';
 import { readJson, splitCsv, toPosix, uniqueList } from './utils.ts';
 import type { CliFlags, Registry, WorkspaceConfig } from './types.ts';
 
@@ -36,12 +37,13 @@ export async function initCommand({
   const modules = uniqueList(splitCsv(flags.modules));
   const targets = uniqueList(splitCsv(flags.targets).length ? splitCsv(flags.targets) : Object.keys(registry.targets));
   const onConflict = getStringFlag(flags, 'on-conflict') || 'merge';
+  const canonicalSlotForRegistry = bindRegistryCanonicalSlot(registry, canonicalSlot);
 
   validateModuleSelection({
     registry,
     language,
     modules,
-    canonicalSlot: (slot) => canonicalSlot(registry, slot)
+    canonicalSlot: canonicalSlotForRegistry
   });
 
   if (inServiceContext && flags['no-inherit'] !== true) {

--- a/src/cli/module-mutations.ts
+++ b/src/cli/module-mutations.ts
@@ -1,7 +1,9 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { resolveContext, resolveDefaultWorkspaceForMutation, resolveWorkspacePath } from './context-resolution.ts';
+import { getStringFlag } from './flags.ts';
 import { validateModuleSelection } from './module-validation.ts';
+import { bindRegistryCanonicalSlot } from './slot-resolver.ts';
 import { getEffectiveWorkspaceConfig } from './workspace-state.ts';
 import { exists, readJson, uniqueList } from './utils.ts';
 import type { CliFlags, Registry, WorkspaceConfig } from './types.ts';
@@ -66,6 +68,7 @@ export async function addCommand({
   ensure(moduleId, 'Usage: ailib add <module>');
   const context = await resolveContext(cwd);
   const registry = await readJson<Registry>(path.join(packageRoot, 'registry.json'));
+  const canonicalSlotForRegistry = bindRegistryCanonicalSlot(registry, canonicalSlot);
 
   const targetWorkspace = resolveDefaultWorkspaceForMutation(context, getStringFlag(flags, 'workspace'));
   const configPath = path.join(targetWorkspace, configFile);
@@ -77,7 +80,7 @@ export async function addCommand({
     rootDir: context.rootDir,
     rootConfig: await readJson<WorkspaceConfig>(path.join(context.rootDir, configFile)),
     registry,
-    canonicalSlot: (slot) => canonicalSlot(registry, slot),
+    canonicalSlot: canonicalSlotForRegistry,
     configFile,
     localOverrideFile
   });
@@ -85,7 +88,7 @@ export async function addCommand({
     registry,
     language: effective.language,
     modules: uniqueList([...(config.modules || []), moduleId]),
-    canonicalSlot: (slot) => canonicalSlot(registry, slot)
+    canonicalSlot: canonicalSlotForRegistry
   });
 
   config.modules = uniqueList([...(config.modules || []), moduleId]);
@@ -140,12 +143,6 @@ export async function removeCommand({
   });
 
   process.stdout.write(`module removed: ${moduleId}\n`);
-}
-
-function getStringFlag(flags: CliFlags, key: string): string | undefined {
-  const value = flags[key];
-  if (typeof value === 'string') return value;
-  return undefined;
 }
 
 function ensure(condition: unknown, message: string): asserts condition {

--- a/src/cli/slot-resolver.test.ts
+++ b/src/cli/slot-resolver.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { createCanonicalSlotResolver } from './slot-resolver.ts';
+import { bindRegistryCanonicalSlot, createCanonicalSlotResolver } from './slot-resolver.ts';
 import type { Registry } from './types.ts';
 
 function registryWithAlias(): Registry {
@@ -36,4 +36,10 @@ test('createCanonicalSlotResolver warns once per alias', () => {
   assert.equal(resolveCanonicalSlot(registry, 'old_slot'), 'new_slot');
   assert.equal(warnings.length, 1);
   assert.match(warnings[0] ?? '', /is deprecated; use/);
+});
+
+test('bindRegistryCanonicalSlot binds resolver to registry', () => {
+  const resolver = createCanonicalSlotResolver({ writeWarning: () => {} });
+  const bound = bindRegistryCanonicalSlot(registryWithAlias(), resolver);
+  assert.equal(bound('old_slot'), 'new_slot');
 });

--- a/src/cli/slot-resolver.ts
+++ b/src/cli/slot-resolver.ts
@@ -2,6 +2,8 @@ import { canonicalSlot } from './utils.ts';
 import type { Registry } from './types.ts';
 
 type WriteWarning = (message: string) => void;
+export type CanonicalSlotResolver = (registry: Registry, slot: string | undefined) => string | null;
+export type RegistryCanonicalSlotResolver = (slot: string | undefined) => string | null;
 
 export function createCanonicalSlotResolver({
   writeWarning
@@ -16,4 +18,11 @@ export function createCanonicalSlotResolver({
       warnedSlotAliases,
       writeWarning
     });
+}
+
+export function bindRegistryCanonicalSlot(
+  registry: Registry,
+  canonicalSlotResolver: CanonicalSlotResolver
+): RegistryCanonicalSlotResolver {
+  return (slot) => canonicalSlotResolver(registry, slot);
 }

--- a/src/cli/workspace-state-pipeline.test.ts
+++ b/src/cli/workspace-state-pipeline.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  buildEffectiveWorkspaceConfig,
+  resolveWorkspaceLanguage,
+  splitModuleOwnership
+} from './workspace-state-pipeline.ts';
+import type { Registry, WorkspaceConfig } from './types.ts';
+
+const registry: Registry = {
+  version: '1',
+  languages: { typescript: { modules: {} } },
+  targets: {}
+};
+
+test('resolveWorkspaceLanguage picks workspace then base language', () => {
+  const base: WorkspaceConfig = { language: 'typescript' };
+  const workspaceRaw: WorkspaceConfig = {};
+  assert.equal(
+    resolveWorkspaceLanguage({
+      workspaceRaw,
+      base,
+      registry,
+      configFile: 'ailib.config.json',
+      workspaceDir: '/tmp'
+    }),
+    'typescript'
+  );
+});
+
+test('splitModuleOwnership separates inherited and local', () => {
+  const ownership = splitModuleOwnership({
+    modules: ['eslint', 'biome'],
+    inheritedModules: ['eslint']
+  });
+  assert.deepEqual(ownership.inherited, ['eslint']);
+  assert.deepEqual(ownership.local, ['biome']);
+});
+
+test('buildEffectiveWorkspaceConfig builds expected shape', () => {
+  const workspaceRaw: WorkspaceConfig = {};
+  const base: WorkspaceConfig = {};
+  const result = buildEffectiveWorkspaceConfig({
+    workspaceRaw,
+    base,
+    isRootWorkspace: true,
+    language: 'typescript',
+    modules: ['eslint'],
+    targets: ['cursor'],
+    inheritedModules: [],
+    localModules: ['eslint'],
+    warnings: ['warn']
+  });
+  assert.equal(result.docs_path, 'docs/');
+  assert.deepEqual(result.warnings, ['warn']);
+});

--- a/src/cli/workspace-state-pipeline.ts
+++ b/src/cli/workspace-state-pipeline.ts
@@ -1,0 +1,66 @@
+import type { EffectiveWorkspaceConfig, Registry, WorkspaceConfig } from './types.ts';
+
+export function resolveWorkspaceLanguage({
+  workspaceRaw,
+  base,
+  registry,
+  configFile,
+  workspaceDir
+}: {
+  workspaceRaw: WorkspaceConfig;
+  base: WorkspaceConfig;
+  registry: Registry;
+  configFile: string;
+  workspaceDir: string;
+}) {
+  const language = workspaceRaw.language || base.language;
+  ensure(language, `Missing language in ${configFile}: ${workspaceDir}`);
+  ensure(registry.languages[language], `Unsupported language: ${language}`);
+  return language;
+}
+
+export function splitModuleOwnership({ modules, inheritedModules }: { modules: string[]; inheritedModules: string[] }) {
+  const inheritedModuleSet = new Set(inheritedModules);
+  const inherited = modules.filter((mod) => inheritedModuleSet.has(mod));
+  const local = modules.filter((mod) => !inheritedModuleSet.has(mod));
+  return { inherited, local };
+}
+
+export function buildEffectiveWorkspaceConfig({
+  workspaceRaw,
+  base,
+  isRootWorkspace,
+  language,
+  modules,
+  targets,
+  inheritedModules,
+  localModules,
+  warnings
+}: {
+  workspaceRaw: WorkspaceConfig;
+  base: WorkspaceConfig;
+  isRootWorkspace: boolean;
+  language: string;
+  modules: string[];
+  targets: string[];
+  inheritedModules: string[];
+  localModules: string[];
+  warnings: string[];
+}): EffectiveWorkspaceConfig {
+  return {
+    $schema: workspaceRaw.$schema || base.$schema || 'https://ailib.dev/schema/config.schema.json',
+    registry_ref: workspaceRaw.registry_ref || base.registry_ref,
+    on_conflict: workspaceRaw.on_conflict || base.on_conflict || 'merge',
+    language,
+    modules,
+    targets,
+    docs_path: workspaceRaw.docs_path || (isRootWorkspace ? 'docs/' : './docs/'),
+    inheritedModules,
+    localModules,
+    warnings
+  };
+}
+
+function ensure(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}

--- a/src/cli/workspace-state.test.ts
+++ b/src/cli/workspace-state.test.ts
@@ -99,3 +99,28 @@ test('buildWorkspaceState includes root behavior file for root workspace', async
   assert.ok(state.requiredFiles.includes('.ailib/behavior.md'));
   assert.ok(state.requiredFiles.includes('.ailib/standards.md'));
 });
+
+test('getEffectiveWorkspaceConfig propagates module merge warnings', async () => {
+  const rootDir = await tempDir();
+  const workspaceDir = path.join(rootDir, 'apps/web');
+  await fs.mkdir(workspaceDir, { recursive: true });
+  await fs.writeFile(path.join(rootDir, configFile), `${JSON.stringify(rootConfig, null, 2)}\n`, 'utf8');
+  await fs.writeFile(
+    path.join(workspaceDir, configFile),
+    `${JSON.stringify({ language: 'typescript', modules: ['biome'], targets: ['cursor'] }, null, 2)}\n`,
+    'utf8'
+  );
+
+  const effective = await getEffectiveWorkspaceConfig({
+    workspaceDir,
+    rootDir,
+    rootConfig,
+    registry,
+    canonicalSlot,
+    configFile,
+    localOverrideFile
+  });
+
+  assert.equal(effective.modules[0], 'biome');
+  assert.match(effective.warnings.join('\n'), /Slot override 'linter': eslint -> biome/);
+});

--- a/src/cli/workspace-state.ts
+++ b/src/cli/workspace-state.ts
@@ -5,6 +5,11 @@ import { mergeModules, mergeTargets } from './module-selection.ts';
 import { validateModuleSelection } from './module-validation.ts';
 import { readJson, toPosix } from './utils.ts';
 import { resolveExtendsBase } from './workspace-config.ts';
+import {
+  buildEffectiveWorkspaceConfig,
+  resolveWorkspaceLanguage,
+  splitModuleOwnership
+} from './workspace-state-pipeline.ts';
 import type { EffectiveWorkspaceConfig, Registry, WorkspaceConfig, WorkspaceState } from './types.ts';
 
 export async function buildWorkspaceState({
@@ -78,9 +83,13 @@ export async function getEffectiveWorkspaceConfig({
   const isRootWorkspace = path.resolve(workspaceDir) === path.resolve(rootDir);
 
   const base = await resolveExtendsBase({ workspaceDir, rootDir, rootConfig, registry });
-  const language = workspaceRaw.language || base.language;
-  ensure(language, `Missing language in ${configFile}: ${workspaceDir}`);
-  ensure(registry.languages[language], `Unsupported language: ${language}`);
+  const language = resolveWorkspaceLanguage({
+    workspaceRaw,
+    base,
+    registry,
+    configFile,
+    workspaceDir
+  });
 
   const mergedModules = mergeModules({
     registry,
@@ -107,22 +116,22 @@ export async function getEffectiveWorkspaceConfig({
     canonicalSlot,
     localOverrideFile
   });
-  const inheritedModuleSet = new Set(mergedModules.inheritedModules || []);
-  const inheritedModules = overrideResult.modules.filter((mod) => inheritedModuleSet.has(mod));
-  const localModules = overrideResult.modules.filter((mod) => !inheritedModuleSet.has(mod));
+  const ownership = splitModuleOwnership({
+    modules: overrideResult.modules,
+    inheritedModules: mergedModules.inheritedModules || []
+  });
 
-  return {
-    $schema: workspaceRaw.$schema || base.$schema || 'https://ailib.dev/schema/config.schema.json',
-    registry_ref: workspaceRaw.registry_ref || base.registry_ref,
-    on_conflict: workspaceRaw.on_conflict || base.on_conflict || 'merge',
+  return buildEffectiveWorkspaceConfig({
+    workspaceRaw,
+    base,
+    isRootWorkspace,
     language,
     modules: overrideResult.modules,
     targets: overrideResult.targets,
-    docs_path: workspaceRaw.docs_path || (isRootWorkspace ? 'docs/' : './docs/'),
-    inheritedModules,
-    localModules,
+    inheritedModules: ownership.inherited,
+    localModules: ownership.local,
     warnings: [...mergedModules.warnings, ...overrideResult.warnings]
-  };
+  });
 }
 
 export async function applyLocalOverrides({
@@ -194,8 +203,4 @@ export async function applyLocalOverrides({
     targets: targetResult.values,
     warnings
   };
-}
-
-function ensure(condition: unknown, message: string): asserts condition {
-  if (!condition) throw new Error(message);
 }

--- a/src/cli/workspace-update.ts
+++ b/src/cli/workspace-update.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { writeRootLock } from './lockfile.ts';
 import { assertLocalOverridesValid } from './local-override-config.ts';
 import { generateWorkspaceRouters } from './router-generation.ts';
+import { bindRegistryCanonicalSlot } from './slot-resolver.ts';
 import { ensureWorkspaceAssets } from './workspace-assets.ts';
 import { buildWorkspaceState } from './workspace-state.ts';
 import { exists, readJson } from './utils.ts';
@@ -29,13 +30,14 @@ export async function applyWorkspaceUpdate({
   ensure(await exists(rootConfigPath), `Missing ${configFile} at root: ${rootDir}`);
 
   const registry = await readJson<Registry>(path.join(packageRoot, 'registry.json'));
+  const canonicalSlotForRegistry = bindRegistryCanonicalSlot(registry, canonicalSlot);
   const packageJson = await readJson<{ version: string }>(path.join(packageRoot, 'package.json'));
   const rootConfig = await readJson<WorkspaceConfig>(rootConfigPath);
   await assertLocalOverridesValid({
     rootDir,
     rootConfig,
     registry,
-    canonicalSlot: (slot) => canonicalSlot(registry, slot),
+    canonicalSlot: canonicalSlotForRegistry,
     localOverrideFile
   });
 
@@ -51,7 +53,7 @@ export async function applyWorkspaceUpdate({
         rootDir,
         rootConfig,
         registry,
-        canonicalSlot: (slot) => canonicalSlot(registry, slot),
+        canonicalSlot: canonicalSlotForRegistry,
         configFile,
         localOverrideFile
       })


### PR DESCRIPTION
## Summary
- extract doctor flow into dedicated modules for preflight, required-file/frontmatter auditing, and output reporting
- split workspace-state config assembly into explicit pipeline helpers to reduce function complexity
- standardize canonical-slot binding via helper and remove repeated inline registry closures
- add focused tests for new modules plus warning propagation coverage in workspace-state

## TDD Evidence
- [ ] New behavior change (tests added first, then implementation)
- [x] Refactor/docs/chore only (no behavior change)
- Red: N/A (refactor-only batch)
- Green: `bun run check`

## Test Plan
- `bun test src/cli/doctor-preflight.test.ts src/cli/doctor-audit.test.ts src/cli/doctor-reporting.test.ts src/cli/workspace-state-pipeline.test.ts src/cli/workspace-state.test.ts src/cli/slot-resolver.test.ts src/cli/doctor.test.ts src/cli/module-mutations.test.ts src/cli/init.test.ts src/cli/workspace-update.test.ts`
- `bun run check`

Refs #85
Refs #87

Made with [Cursor](https://cursor.com)