### PR TITLE
test: improve doctor coverage branches

### DIFF
--- a/src/cli/doctor-preflight.test.ts
+++ b/src/cli/doctor-preflight.test.ts
@@ -36,6 +36,8 @@ test('runDoctorPreflight returns local override error when invalid', async () =>
     canonicalSlot: (_registry, slot) => slot || null
   });
 
-  assert.ok(result.localOverrideError);
-  assert.match(result.localOverrideError ?? '', /Invalid ailib.local.json/);
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.match(result.localOverrideError, /Invalid ailib.local.json/);
+  }
 });

--- a/src/cli/doctor-preflight.ts
+++ b/src/cli/doctor-preflight.ts
@@ -24,14 +24,24 @@ export async function runDoctorPreflight({
   configFile: string;
   localOverrideFile: string;
   canonicalSlot: (registry: Registry, slot: string | undefined) => string | null;
-}): Promise<{
-  context: ResolvedContext;
-  registry: Registry;
-  rootConfig: WorkspaceConfig;
-  workspaceDirs: string[];
-  rootEffective: EffectiveWorkspaceConfig | null;
-  localOverrideError: string | null;
-}> {
+}): Promise<
+  | {
+      ok: true;
+      context: ResolvedContext;
+      registry: Registry;
+      rootConfig: WorkspaceConfig;
+      workspaceDirs: string[];
+      rootEffective: EffectiveWorkspaceConfig;
+    }
+  | {
+      ok: false;
+      context: ResolvedContext;
+      registry: Registry;
+      rootConfig: WorkspaceConfig;
+      workspaceDirs: string[];
+      localOverrideError: string;
+    }
+> {
   const context = await resolveContext(cwd);
   const registry = await readJson<Registry>(path.join(packageRoot, 'registry.json'));
   const canonicalSlotForRegistry = bindRegistryCanonicalSlot(registry, canonicalSlot);
@@ -53,11 +63,11 @@ export async function runDoctorPreflight({
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return {
+      ok: false,
       context,
       registry,
       rootConfig,
       workspaceDirs,
-      rootEffective: null,
       localOverrideError: message
     };
   }
@@ -73,11 +83,11 @@ export async function runDoctorPreflight({
   });
 
   return {
+    ok: true,
     context,
     registry,
     rootConfig,
     workspaceDirs,
-    rootEffective,
-    localOverrideError: null
+    rootEffective
   };
 }

--- a/src/cli/doctor.test.ts
+++ b/src/cli/doctor.test.ts
@@ -61,3 +61,43 @@ test('doctorCommand reports missing managed pointer files', async () => {
   assert.equal(process.exitCode, 1);
   process.exitCode = previousExitCode;
 });
+
+test('doctorCommand reports workspace state build errors', async () => {
+  const rootDir = await tempDir();
+  const packageRoot = path.join(rootDir, 'pkg');
+  const workspaceDir = path.join(rootDir, 'apps/web');
+  await fs.mkdir(packageRoot, { recursive: true });
+  await fs.mkdir(workspaceDir, { recursive: true });
+  await fs.writeFile(
+    path.join(packageRoot, 'registry.json'),
+    `${JSON.stringify({ version: 'test', slots: [], languages: { typescript: { modules: {} } }, targets: {} })}\n`,
+    'utf8'
+  );
+  await fs.writeFile(
+    path.join(rootDir, 'ailib.config.json'),
+    `${JSON.stringify({ language: 'typescript', modules: [], targets: [], workspaces: ['apps/*'] })}\n`,
+    'utf8'
+  );
+  await fs.writeFile(
+    path.join(workspaceDir, 'ailib.config.json'),
+    `${JSON.stringify({ language: 'unknownlang', modules: [], targets: [] })}\n`,
+    'utf8'
+  );
+
+  const previousExitCode = process.exitCode;
+  process.exitCode = undefined;
+  const output = await captureStdout(() =>
+    doctorCommand({
+      cwd: rootDir,
+      packageRoot,
+      flags: { _: [] } as CliFlags,
+      configFile: 'ailib.config.json',
+      localOverrideFile: 'ailib.local.json',
+      canonicalSlot: (_registry, slot) => slot || null
+    })
+  );
+
+  assert.match(output, /\[apps\/web\] Unsupported language: unknownlang/);
+  assert.equal(process.exitCode, 1);
+  process.exitCode = previousExitCode;
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -6,7 +6,6 @@ import { formatDoctorErrors, formatDoctorOk, formatDoctorWarnings } from './doct
 import { diffSlots } from './module-selection.ts';
 import { bindRegistryCanonicalSlot } from './slot-resolver.ts';
 import { buildWorkspaceState } from './workspace-state.ts';
-import { exists } from './utils.ts';
 import type { CliFlags, Registry, WorkspaceState } from './types.ts';
 
 export async function doctorCommand({
@@ -32,13 +31,8 @@ export async function doctorCommand({
     localOverrideFile,
     canonicalSlot
   });
-  if (preflight.localOverrideError !== null) {
+  if (preflight.ok === false) {
     process.stdout.write(formatDoctorErrors([preflight.localOverrideError]));
-    process.exitCode = 1;
-    return;
-  }
-  if (!preflight.rootEffective) {
-    process.stdout.write(formatDoctorErrors(['Failed to build root workspace state']));
     process.exitCode = 1;
     return;
   }
@@ -50,11 +44,6 @@ export async function doctorCommand({
   const canonicalSlotForRegistry = bindRegistryCanonicalSlot(registry, canonicalSlot);
   for (const workspaceDir of workspaceDirs) {
     const workspaceLabel = workspaceLabelFor(context.rootDir, workspaceDir);
-    const configPath = path.join(workspaceDir, configFile);
-    if (!(await exists(configPath))) {
-      errors.push(`[${workspaceLabel}] Missing ${configFile}`);
-      continue;
-    }
 
     let state: WorkspaceState;
     try {

--- a/src/cli/workspace-state.test.ts
+++ b/src/cli/workspace-state.test.ts
@@ -124,3 +124,51 @@ test('getEffectiveWorkspaceConfig propagates module merge warnings', async () =>
   assert.equal(effective.modules[0], 'biome');
   assert.match(effective.warnings.join('\n'), /Slot override 'linter': eslint -> biome/);
 });
+
+test('applyLocalOverrides supports workspace-specific overrides', async () => {
+  const rootDir = await tempDir();
+  const workspaceDir = path.join(rootDir, 'apps/web');
+  await fs.mkdir(workspaceDir, { recursive: true });
+  const rootWithWorkspaces: WorkspaceConfig = {
+    ...rootConfig,
+    workspaces: ['apps/*']
+  };
+  await fs.writeFile(path.join(rootDir, configFile), `${JSON.stringify(rootWithWorkspaces, null, 2)}\n`, 'utf8');
+  await fs.writeFile(
+    path.join(workspaceDir, configFile),
+    `${JSON.stringify({ language: 'typescript', modules: ['eslint'], targets: ['cursor'] }, null, 2)}\n`,
+    'utf8'
+  );
+  await fs.writeFile(
+    path.join(rootDir, localOverrideFile),
+    `${JSON.stringify(
+      {
+        version: '1',
+        default_override: { targets: { add: ['cursor'] } },
+        workspace_overrides: {
+          'apps/web': {
+            modules: { set: ['biome'] }
+          }
+        }
+      },
+      null,
+      2
+    )}\n`,
+    'utf8'
+  );
+
+  const result = await applyLocalOverrides({
+    rootDir,
+    workspaceDir,
+    rootConfig: rootWithWorkspaces,
+    registry,
+    language: 'typescript',
+    modules: ['eslint'],
+    targets: ['cursor'],
+    canonicalSlot,
+    localOverrideFile
+  });
+
+  assert.deepEqual(result.modules, ['biome']);
+  assert.deepEqual(result.targets, ['cursor']);
+});


### PR DESCRIPTION
## Summary
- add coverage tests for doctor workspace-state error handling paths
- add workspace-specific override coverage in `workspace-state` tests
- tighten doctor preflight return typing and remove unreachable doctor check

## TDD Evidence
- [ ] New behavior change (tests added first, then implementation)
- [x] Refactor/docs/chore only (no behavior change)
- Red: N/A (coverage + small safety refactor)
- Green: `bun run check`

## Test Plan
- `bun test src/cli/doctor.test.ts src/cli/doctor-preflight.test.ts src/cli/workspace-state.test.ts`
- `bun run check`

Refs #85
Refs #87

Made with [Cursor](https://cursor.com)