### PR TITLE
chore: implement phase 9 remediation

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -116,18 +116,5 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, typecheck, test, registry-validation, coverage]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Run full check command
-        run: bun run check
+      - name: Report aggregate status
+        run: echo "All quality gate jobs completed successfully."

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ bun run local:install
 - Development standards: [docs/development-standards.md](docs/development-standards.md)
 - Test standards: [docs/test-standards.md](docs/test-standards.md)
 - Coverage exceptions and rationale: [docs/coverage-exceptions.md](docs/coverage-exceptions.md)
+- Quality gates quickstart: [docs/quality-gates-quickstart.md](docs/quality-gates-quickstart.md)
 - Workflow hardening: [docs/workflow-security-hardening.md](docs/workflow-security-hardening.md)
 - Branch protection policy: [docs/branch-protection-policy.md](docs/branch-protection-policy.md)
 - Homebrew publishing: [docs/homebrew-publishing.md](docs/homebrew-publishing.md)

--- a/bun.lock
+++ b/bun.lock
@@ -4,19 +4,196 @@
     "": {
       "name": "@ailib/cli",
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@types/node": "^25.6.0",
+        "eslint": "^10.2.1",
         "prettier": "^3.8.3",
         "typescript": "^6.0.3",
+        "typescript-eslint": "^8.59.0",
       },
     },
   },
   "packages": {
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.23.5", "", { "dependencies": { "@eslint/object-schema": "^3.0.5", "debug": "^4.3.1", "minimatch": "^10.2.4" } }, "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.5.5", "", { "dependencies": { "@eslint/core": "^1.2.1" } }, "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w=="],
+
+    "@eslint/core": ["@eslint/core@1.2.1", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ=="],
+
+    "@eslint/js": ["@eslint/js@10.0.1", "", { "peerDependencies": { "eslint": "^10.0.0" }, "optionalPeers": ["eslint"] }, "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@3.0.5", "", {}, "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.1", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ=="],
+
+    "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.8", "", { "dependencies": { "@humanfs/core": "^0.19.2", "@humanfs/types": "^0.15.0", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ=="],
+
+    "@humanfs/types": ["@humanfs/types@0.15.0", "", {}, "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.59.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.59.0", "@typescript-eslint/type-utils": "8.59.0", "@typescript-eslint/utils": "8.59.0", "@typescript-eslint/visitor-keys": "8.59.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.59.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.59.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.59.0", "@typescript-eslint/types": "8.59.0", "@typescript-eslint/typescript-estree": "8.59.0", "@typescript-eslint/visitor-keys": "8.59.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg=="],
+
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.59.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.59.0", "@typescript-eslint/types": "^8.59.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.59.0", "", { "dependencies": { "@typescript-eslint/types": "8.59.0", "@typescript-eslint/visitor-keys": "8.59.0" } }, "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg=="],
+
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.59.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.59.0", "", { "dependencies": { "@typescript-eslint/types": "8.59.0", "@typescript-eslint/typescript-estree": "8.59.0", "@typescript-eslint/utils": "8.59.0", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.59.0", "", {}, "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.59.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.59.0", "@typescript-eslint/tsconfig-utils": "8.59.0", "@typescript-eslint/types": "8.59.0", "@typescript-eslint/visitor-keys": "8.59.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.59.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.59.0", "@typescript-eslint/types": "8.59.0", "@typescript-eslint/typescript-estree": "8.59.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.59.0", "", { "dependencies": { "@typescript-eslint/types": "8.59.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q=="],
+
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@10.2.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.5", "@eslint/config-helpers": "^0.5.5", "@eslint/core": "^1.2.1", "@eslint/plugin-kit": "^0.7.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.4", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q=="],
+
+    "eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "espree": ["espree@11.2.0", "", { "dependencies": { "acorn": "^8.16.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^5.0.1" } }, "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
 
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
+    "typescript-eslint": ["typescript-eslint@8.59.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.59.0", "@typescript-eslint/parser": "8.59.0", "@typescript-eslint/typescript-estree": "8.59.0", "@typescript-eslint/utils": "8.59.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw=="],
+
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
   }
 }

--- a/core/test-standards.md
+++ b/core/test-standards.md
@@ -19,9 +19,11 @@ These standards apply to generated consumer workspaces and `ailib` contributions
 
 ## 2) Coverage Targets
 
-- `src/` and `core/` changes: 85% line coverage minimum.
-- `tools/` changes: 80% line coverage minimum.
-- Critical command flows (`init/update/doctor/uninstall`): strong integration coverage.
+- `bun run coverage:check` is the canonical gate.
+- Repository line coverage: 80% minimum.
+- Repository function coverage: 80% minimum.
+- Repository branch coverage: 70% minimum.
+- Critical command flows (`init/update/doctor/uninstall`): strong integration coverage with edge-case assertions.
 
 ## 3) Quality Gates
 

--- a/docs/coverage-exceptions.md
+++ b/docs/coverage-exceptions.md
@@ -5,7 +5,10 @@ This document tracks why `src/cli.ts` is not yet at 100% line coverage and which
 Current baseline after Task #72 pass 2:
 
 - `src/cli.ts` line coverage: **91.25%**
-- Full-suite threshold gate: **80%** (enforced)
+- Full-suite threshold gate (enforced via `bun run coverage:check`):
+  - lines: **80%**
+  - functions: **80%**
+  - branches: **70%**
 
 ## High-value uncovered clusters
 

--- a/docs/development-standards.md
+++ b/docs/development-standards.md
@@ -41,7 +41,9 @@ Expected loop:
 
 ## 5) Quality Gates for PRs
 
-- `bun run lint` (includes standards + Prettier checks) must pass.
+- `bun run standards:check` must pass.
+- `bun run lint` (ESLint) must pass.
+- `bun run format:check` (Prettier) must pass.
 - `bun run typecheck` must pass.
 - `bun run check` must pass.
 - New behavior should include/adjust tests.

--- a/docs/quality-gates-quickstart.md
+++ b/docs/quality-gates-quickstart.md
@@ -1,0 +1,28 @@
+# Quality Gates Quickstart
+
+Use these commands before opening a PR:
+
+1. `bun run standards:check`
+2. `bun run lint`
+3. `bun run format:check`
+4. `bun run typecheck`
+5. `bun run test`
+6. `bun run coverage:check`
+
+Run the full gate in one command:
+
+```bash
+bun run check
+```
+
+If formatting issues are reported, apply fixes with:
+
+```bash
+bun run format:write
+```
+
+If lint issues are reported, auto-fix what is safe with:
+
+```bash
+bun run lint:fix
+```

--- a/docs/test-standards.md
+++ b/docs/test-standards.md
@@ -11,15 +11,16 @@ This guide defines minimum testing expectations for `ailib` changes.
 
 ## 2) Coverage Thresholds
 
-Coverage targets are minimums for changed code paths:
+Coverage targets are enforced by `bun run coverage:check` and are minimums for changed code paths:
 
-- **CLI/core logic (`src/`, `core/`):** 85% line coverage
-- **Tooling scripts (`tools/`):** 80% line coverage
-- **Critical command flows (`init/update/doctor/uninstall`):** 90% path coverage via integration tests
+- **Repository line coverage:** 80% minimum
+- **Repository function coverage:** 80% minimum
+- **Repository branch coverage:** 70% minimum
+- **Critical command flows (`init/update/doctor/uninstall`):** strong integration coverage with explicit edge-case assertions
 
 Notes:
 
-- Thresholds are quality gates, not a substitute for meaningful assertions.
+- These repository-wide thresholds are quality gates, not a substitute for meaningful assertions.
 - Do not inflate coverage with low-value tests.
 
 ## 3) Naming and Organization

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,37 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  {
+    ignores: [
+      'coverage/**',
+      'dist/**',
+      'node_modules/**',
+      '.cursor/**',
+      'docs/module-catalog.md',
+      'docs/module-coverage-audit.md'
+    ]
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      'no-undef': 'off',
+      'no-useless-assignment': 'off',
+      'preserve-caught-error': 'off'
+    }
+  },
+  {
+    files: ['**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }]
+    }
+  },
+  {
+    files: ['**/*.test.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off'
+    }
+  }
+);

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "security:audit": "bun audit --audit-level=high",
     "format:check": "prettier --check \"**/*.{ts,js,json,md,yml,yaml}\" --ignore-unknown",
     "format:write": "prettier --write \"**/*.{ts,js,json,md,yml,yaml}\" --ignore-unknown",
-    "lint": "bun tools/check-standards.ts && bun run format:check",
+    "lint": "eslint . --max-warnings=0",
+    "lint:fix": "eslint . --fix",
     "tools:build": "bunx tsc -p tsconfig.tools.json",
     "registry:build": "bun tools/sync-registry.ts",
     "registry:check": "bun tools/sync-registry.ts --check",
@@ -32,11 +33,11 @@
     "coverage-audit:build": "bun tools/generate-coverage-audit.ts",
     "coverage-audit:check": "bun tools/generate-coverage-audit.ts --check",
     "coverage:build": "bun test --coverage --coverage-reporter=text --coverage-reporter=lcov",
-    "coverage:check": "bun run coverage:build && bun tools/check-coverage-threshold.ts --file coverage/lcov.info --min-lines=80",
+    "coverage:check": "bun run coverage:build && bun tools/check-coverage-threshold.ts --file coverage/lcov.info --min-lines=80 --min-functions=80 --min-branches=70",
     "standards:check": "bun tools/check-standards.ts",
     "typecheck": "bunx tsc --noEmit",
     "test": "bun test",
-    "check": "bun run lint && bun run test && bun run typecheck && bun run coverage-audit:check && bun run registry:check && bun run catalog:check && bun run coverage:check"
+    "check": "bun run standards:check && bun run lint && bun run format:check && bun run test && bun run typecheck && bun run coverage-audit:check && bun run registry:check && bun run catalog:check && bun run coverage:check"
   },
   "keywords": [
     "ai",
@@ -51,8 +52,11 @@
     "bun": ">=1.3.0"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@types/node": "^25.6.0",
+    "eslint": "^10.2.1",
     "prettier": "^3.8.3",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.59.0"
   }
 }

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 
 import { run } from './cli.ts';
 
-function captureStdoutSync(fn: () => void): string {
+async function captureStdout(fn: () => Promise<void>): Promise<string> {
   const chunks: string[] = [];
   const mutableStdout = process.stdout as unknown as { write: typeof process.stdout.write };
   const originalWrite = mutableStdout.write.bind(process.stdout);
@@ -14,7 +14,7 @@ function captureStdoutSync(fn: () => void): string {
     return true;
   }) as typeof process.stdout.write;
   try {
-    fn();
+    await fn();
     return chunks.join('');
   } finally {
     mutableStdout.write = originalWrite;
@@ -22,8 +22,8 @@ function captureStdoutSync(fn: () => void): string {
 }
 
 test('run prints help for --help flag', async () => {
-  const output = captureStdoutSync(() => {
-    run(['--help'], { cwd: process.cwd(), packageRoot: process.cwd() });
+  const output = await captureStdout(async () => {
+    await run(['--help'], { cwd: process.cwd(), packageRoot: process.cwd() });
   });
   assert.match(output, /ailib commands:/);
 });

--- a/src/cli/assertions.ts
+++ b/src/cli/assertions.ts
@@ -1,0 +1,3 @@
+export function ensure(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}

--- a/src/cli/context-resolution.ts
+++ b/src/cli/context-resolution.ts
@@ -1,6 +1,5 @@
-import fs from 'node:fs/promises';
-import { constants as fsConstants } from 'node:fs';
 import path from 'node:path';
+import { exists, readJson, toPosix } from './utils.ts';
 import type { WorkspaceConfig } from './types.ts';
 
 const CONFIG_FILE = 'ailib.config.json';
@@ -87,21 +86,4 @@ async function findNearestWorkspace(startDir: string): Promise<string | null> {
     if (parent === current) return null;
     current = parent;
   }
-}
-
-function toPosix(value: string) {
-  return value.split(path.sep).join('/');
-}
-
-async function exists(filePath: string) {
-  try {
-    await fs.access(filePath, fsConstants.F_OK);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function readJson<T = unknown>(filePath: string): Promise<T> {
-  return JSON.parse(await fs.readFile(filePath, 'utf8')) as T;
 }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -8,7 +8,58 @@ import { bindRegistryCanonicalSlot } from './slot-resolver.ts';
 import { buildWorkspaceState } from './workspace-state.ts';
 import type { CliFlags, Registry, WorkspaceState } from './types.ts';
 
+export interface DoctorCommandIo {
+  write: (line: string) => void;
+  setExitCode: (code: number) => void;
+}
+
+export interface DoctorEvaluation {
+  ok: boolean;
+  warningOutput: string;
+  errorOutput: string;
+}
+
 export async function doctorCommand({
+  cwd,
+  packageRoot,
+  flags,
+  configFile,
+  localOverrideFile,
+  canonicalSlot,
+  io
+}: {
+  cwd: string;
+  packageRoot: string;
+  flags: CliFlags;
+  configFile: string;
+  localOverrideFile: string;
+  canonicalSlot: (registry: Registry, slot: string | undefined) => string | null;
+  io?: DoctorCommandIo;
+}) {
+  const output = io || {
+    write: (line: string) => process.stdout.write(line),
+    setExitCode: (code: number) => {
+      process.exitCode = code;
+    }
+  };
+  const evaluation = await evaluateDoctor({
+    cwd,
+    packageRoot,
+    flags,
+    configFile,
+    localOverrideFile,
+    canonicalSlot
+  });
+  if (evaluation.warningOutput) output.write(evaluation.warningOutput);
+  if (evaluation.errorOutput) {
+    output.write(evaluation.errorOutput);
+    output.setExitCode(1);
+    return;
+  }
+  output.write(formatDoctorOk());
+}
+
+export async function evaluateDoctor({
   cwd,
   packageRoot,
   flags,
@@ -22,7 +73,7 @@ export async function doctorCommand({
   configFile: string;
   localOverrideFile: string;
   canonicalSlot: (registry: Registry, slot: string | undefined) => string | null;
-}) {
+}): Promise<DoctorEvaluation> {
   const preflight = await runDoctorPreflight({
     cwd,
     packageRoot,
@@ -32,9 +83,11 @@ export async function doctorCommand({
     canonicalSlot
   });
   if (preflight.ok === false) {
-    process.stdout.write(formatDoctorErrors([preflight.localOverrideError]));
-    process.exitCode = 1;
-    return;
+    return {
+      ok: false,
+      warningOutput: '',
+      errorOutput: formatDoctorErrors([preflight.localOverrideError])
+    };
   }
 
   const errors: string[] = [];
@@ -82,13 +135,17 @@ export async function doctorCommand({
   }
 
   const warningOutput = formatDoctorWarnings(warnings);
-  if (warningOutput) process.stdout.write(warningOutput);
-
   if (errors.length) {
-    process.stdout.write(formatDoctorErrors(errors));
-    process.exitCode = 1;
-    return;
+    return {
+      ok: false,
+      warningOutput,
+      errorOutput: formatDoctorErrors(errors)
+    };
   }
 
-  process.stdout.write(formatDoctorOk());
+  return {
+    ok: true,
+    warningOutput,
+    errorOutput: ''
+  };
 }

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { ensure } from './assertions.ts';
 import { detectProjectRoot, findNearestMonorepoRoot } from './context-resolution.ts';
 import { getStringFlag } from './flags.ts';
 import { validateModuleSelection } from './module-validation.ts';
@@ -35,7 +36,8 @@ export async function initCommand({
   ensure(registry.languages[language], `Unsupported language: ${language}`);
 
   const modules = uniqueList(splitCsv(flags.modules));
-  const targets = uniqueList(splitCsv(flags.targets).length ? splitCsv(flags.targets) : Object.keys(registry.targets));
+  const requestedTargets = splitCsv(flags.targets);
+  const targets = uniqueList(requestedTargets.length ? requestedTargets : Object.keys(registry.targets));
   const onConflict = getStringFlag(flags, 'on-conflict') || 'merge';
   const canonicalSlotForRegistry = bindRegistryCanonicalSlot(registry, canonicalSlot);
 
@@ -47,6 +49,7 @@ export async function initCommand({
   });
 
   if (inServiceContext && flags['no-inherit'] !== true) {
+    ensure(nearestRoot, 'Could not resolve monorepo root for service initialization');
     const projectRoot = path.resolve(cwd);
     const rel = toPosix(path.relative(projectRoot, path.join(nearestRoot, configFile)));
     const config: WorkspaceConfig = {
@@ -88,8 +91,4 @@ export async function initCommand({
   await fs.writeFile(path.join(projectRoot, configFile), `${JSON.stringify(config, null, 2)}\n`, 'utf8');
   await applyWorkspaceUpdate({ packageRoot, rootDir: projectRoot, forceOnConflict: onConflict });
   process.stdout.write('ailib initialized\n');
-}
-
-function ensure(condition: unknown, message: string): asserts condition {
-  if (!condition) throw new Error(message);
 }

--- a/src/cli/module-mutations.test.ts
+++ b/src/cli/module-mutations.test.ts
@@ -29,7 +29,8 @@ const registry: Registry = {
 test('updateCommand forwards workspace override and prints updated message', async () => {
   const rootDir = await tempDir();
   await fs.writeFile(path.join(rootDir, 'package.json'), '{"name":"tmp"}\n', 'utf8');
-  let calledWith: { workspaceOverride?: string } | null = null;
+  const calledWith: { workspaceOverride?: string } = {};
+  let called = false;
   const stdout: string[] = [];
   const originalWrite = process.stdout.write.bind(process.stdout);
   (process.stdout as unknown as { write: typeof process.stdout.write }).write = ((chunk) => {
@@ -45,13 +46,15 @@ test('updateCommand forwards workspace override and prints updated message', asy
       localOverrideFile: 'ailib.local.json',
       canonicalSlot: (_r, slot) => slot || null,
       applyWorkspaceUpdate: async (args) => {
-        calledWith = { workspaceOverride: args.workspaceOverride };
+        called = true;
+        calledWith.workspaceOverride = args.workspaceOverride;
       }
     });
   } finally {
     (process.stdout as unknown as { write: typeof process.stdout.write }).write = originalWrite;
   }
-  assert.ok(calledWith?.workspaceOverride?.endsWith('apps/api'));
+  assert.equal(called, true);
+  assert.ok(calledWith.workspaceOverride?.endsWith('apps/api'));
   assert.match(stdout.join(''), /ailib updated/);
 });
 

--- a/src/cli/module-mutations.ts
+++ b/src/cli/module-mutations.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { ensure } from './assertions.ts';
 import { resolveContext, resolveDefaultWorkspaceForMutation, resolveWorkspacePath } from './context-resolution.ts';
 import { getStringFlag } from './flags.ts';
 import { validateModuleSelection } from './module-validation.ts';
@@ -12,9 +13,9 @@ export async function updateCommand({
   cwd,
   packageRoot,
   flags,
-  configFile,
-  localOverrideFile,
-  canonicalSlot,
+  configFile: _configFile,
+  localOverrideFile: _localOverrideFile,
+  canonicalSlot: _canonicalSlot,
   applyWorkspaceUpdate
 }: {
   cwd: string;
@@ -143,8 +144,4 @@ export async function removeCommand({
   });
 
   process.stdout.write(`module removed: ${moduleId}\n`);
-}
-
-function ensure(condition: unknown, message: string): asserts condition {
-  if (!condition) throw new Error(message);
 }

--- a/src/cli/router-generation.ts
+++ b/src/cli/router-generation.ts
@@ -22,6 +22,29 @@ export async function generateWorkspaceRouters({
   const targetSet = new Set<string>(state.effective.targets || []);
   const atRoot = path.resolve(workspaceDir) === path.resolve(rootDir);
 
+  await writeStandardTargetRouters({ workspaceDir, rootDir, state, onConflict, atRoot, targetSet, registry });
+
+  if (!atRoot || !targetSet.has('copilot')) return;
+  await writeCopilotRouters({ rootDir, allStates, registry, onConflict });
+}
+
+async function writeStandardTargetRouters({
+  workspaceDir,
+  rootDir,
+  state,
+  onConflict,
+  atRoot,
+  targetSet,
+  registry
+}: {
+  workspaceDir: string;
+  rootDir: string;
+  state: WorkspaceState;
+  onConflict: string;
+  atRoot: boolean;
+  targetSet: Set<string>;
+  registry: Registry;
+}) {
   for (const targetId of targetSet) {
     const targetDef = registry.targets[targetId];
     if (!targetDef || targetDef.mode === 'copilot') continue;
@@ -34,39 +57,71 @@ export async function generateWorkspaceRouters({
       : '';
     const rendered = `${frontmatter || ''}${renderRouterDoc({ label, workspaceDir, rootDir, state })}`;
     await writeManagedFile({ outPath: path.join(workspaceDir, targetDef.output), rendered, onConflict });
-
     if (atRoot && targetDef.root_output) {
       await writeManagedFile({ outPath: path.join(workspaceDir, targetDef.root_output), rendered, onConflict });
     }
   }
+}
 
-  if (atRoot && targetSet.has('copilot')) {
-    const scopedStates = [...allStates.entries()].filter(([, s]) => (s.effective.targets || []).includes('copilot'));
-    const sections = scopedStates
-      .map(([dir, s]) => {
-        const label = workspaceLabelFor(rootDir, dir);
-        return `## Workspace: ${label}\n\n${renderRouterDoc({ label: registry.targets.copilot?.display || 'GitHub Copilot', workspaceDir: dir, rootDir, state: s }).trim()}\n`;
-      })
-      .join('\n');
+async function writeCopilotRouters({
+  rootDir,
+  allStates,
+  registry,
+  onConflict
+}: {
+  rootDir: string;
+  allStates: Map<string, WorkspaceState>;
+  registry: Registry;
+  onConflict: string;
+}) {
+  const scopedStates = [...allStates.entries()].filter(([, s]) => (s.effective.targets || []).includes('copilot'));
+  const copilotLabel = registry.targets.copilot?.display || 'GitHub Copilot';
+  const sections = scopedStates
+    .map(([dir, state]) => {
+      const label = workspaceLabelFor(rootDir, dir);
+      return `## Workspace: ${label}\n\n${renderRouterDoc({ label: copilotLabel, workspaceDir: dir, rootDir, state }).trim()}\n`;
+    })
+    .join('\n');
 
-    await writeManagedFile({
-      outPath: path.join(rootDir, registry.targets.copilot?.output || '.github/copilot-instructions.md'),
-      rendered: `# ailib Router (${registry.targets.copilot?.display || 'GitHub Copilot'})\n\n${sections}`,
+  await writeManagedFile({
+    outPath: path.join(rootDir, registry.targets.copilot?.output || '.github/copilot-instructions.md'),
+    rendered: `# ailib Router (${copilotLabel})\n\n${sections}`,
+    onConflict
+  });
+
+  for (const [workspaceDir, state] of scopedStates) {
+    await writeCopilotWorkspaceInstruction({
+      rootDir,
+      workspaceDir,
+      state,
+      copilotLabel,
       onConflict
     });
-
-    for (const [dir, s] of scopedStates) {
-      const rel = workspaceLabelFor(rootDir, dir);
-      const applyTo = rel === '.' ? '**' : `${toPosix(rel)}/**`;
-      const fileName = rel === '.' ? 'root.instructions.md' : `${sanitizeForFilename(rel)}.instructions.md`;
-      const content = `---\napplyTo: "${applyTo}"\n---\n\n${renderRouterDoc({ label: registry.targets.copilot?.display || 'GitHub Copilot', workspaceDir: dir, rootDir, state: s })}`;
-      await writeManagedFile({
-        outPath: path.join(rootDir, '.github/instructions', fileName),
-        rendered: content,
-        onConflict
-      });
-    }
   }
+}
+
+async function writeCopilotWorkspaceInstruction({
+  rootDir,
+  workspaceDir,
+  state,
+  copilotLabel,
+  onConflict
+}: {
+  rootDir: string;
+  workspaceDir: string;
+  state: WorkspaceState;
+  copilotLabel: string;
+  onConflict: string;
+}) {
+  const rel = workspaceLabelFor(rootDir, workspaceDir);
+  const applyTo = rel === '.' ? '**' : `${toPosix(rel)}/**`;
+  const fileName = rel === '.' ? 'root.instructions.md' : `${sanitizeForFilename(rel)}.instructions.md`;
+  const content = `---\napplyTo: "${applyTo}"\n---\n\n${renderRouterDoc({ label: copilotLabel, workspaceDir, rootDir, state })}`;
+  await writeManagedFile({
+    outPath: path.join(rootDir, '.github/instructions', fileName),
+    rendered: content,
+    onConflict
+  });
 }
 
 export function renderRouterDoc({

--- a/src/cli/slot-resolver.ts
+++ b/src/cli/slot-resolver.ts
@@ -1,4 +1,4 @@
-import { canonicalSlot } from './utils.ts';
+import { resolveCanonicalSlotAlias } from './utils.ts';
 import type { Registry } from './types.ts';
 
 type WriteWarning = (message: string) => void;
@@ -12,7 +12,7 @@ export function createCanonicalSlotResolver({
 } = {}) {
   const warnedSlotAliases = new Set<string>();
   return (registry: Registry, slot: string | undefined) =>
-    canonicalSlot({
+    resolveCanonicalSlotAlias({
       registry,
       slot,
       warnedSlotAliases,

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -24,16 +24,22 @@ export async function uninstallCommand({
 
   const rootConfigPath = path.join(context.rootDir, configFile);
   const rootConfig = (await exists(rootConfigPath)) ? await readJson<WorkspaceConfig>(rootConfigPath) : null;
-  const atRoot = path.resolve(context.workspaceDir) === path.resolve(context.rootDir);
-  const monorepo = Boolean(rootConfig?.workspaces);
+  const scope = resolveUninstallScope({
+    atRoot: path.resolve(context.workspaceDir) === path.resolve(context.rootDir),
+    isMonorepo: Boolean(rootConfig?.workspaces),
+    removeAll: flags.all === true
+  });
 
-  if (atRoot && monorepo && flags.all !== true) {
+  if (scope === 'root-only') {
     await uninstallWorkspace(context.rootDir, rootConfig, registry, configFile);
     process.stdout.write('ailib uninstalled\n');
     return;
   }
 
-  if (atRoot && monorepo && flags.all === true) {
+  if (scope === 'all-workspaces') {
+    if (!rootConfig) {
+      throw new Error(`Missing ${configFile} at root: ${context.rootDir}`);
+    }
     const workspaceDirs = await listWorkspaceDirs({ rootDir: context.rootDir, rootConfig });
     for (const workspaceDir of workspaceDirs) {
       const cfgPath = path.join(workspaceDir, configFile);
@@ -75,9 +81,27 @@ export async function uninstallWorkspace(
       if (targetDef.root_output && isRootWorkspaceConfig(config)) {
         await rmIfExists(path.join(workspaceDir, targetDef.root_output));
       }
-      if (target === 'copilot' && isRootWorkspaceConfig(config)) {
+      if (shouldRemoveRootInstructions({ target, config })) {
         await rmIfExists(path.join(workspaceDir, '.github/instructions'));
       }
     }
   }
+}
+
+function resolveUninstallScope({
+  atRoot,
+  isMonorepo,
+  removeAll
+}: {
+  atRoot: boolean;
+  isMonorepo: boolean;
+  removeAll: boolean;
+}): 'root-only' | 'all-workspaces' | 'current-workspace' {
+  if (atRoot && isMonorepo && !removeAll) return 'root-only';
+  if (atRoot && isMonorepo && removeAll) return 'all-workspaces';
+  return 'current-workspace';
+}
+
+function shouldRemoveRootInstructions({ target, config }: { target: string; config: WorkspaceConfig }) {
+  return target === 'copilot' && isRootWorkspaceConfig(config);
 }

--- a/src/cli/utils.test.ts
+++ b/src/cli/utils.test.ts
@@ -4,9 +4,9 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import {
-  canonicalSlot,
   exists,
   readJson,
+  resolveCanonicalSlotAlias,
   rmIfExists,
   sanitizeForFilename,
   splitCsv,
@@ -43,7 +43,7 @@ test('file utilities support existence checks, reads, and safe removals', async 
   await rmIfExists(path.join(root, 'missing'));
 });
 
-test('canonicalSlot resolves aliases and warns only once', () => {
+test('resolveCanonicalSlotAlias resolves aliases and warns once', () => {
   const registry: Registry = {
     version: 'test',
     slots: ['runtime'],
@@ -59,10 +59,10 @@ test('canonicalSlot resolves aliases and warns only once', () => {
     warnings.push(line);
   };
 
-  assert.equal(canonicalSlot({ registry, slot: 'platform', warnedSlotAliases, writeWarning }), 'runtime');
-  assert.equal(canonicalSlot({ registry, slot: 'platform', warnedSlotAliases, writeWarning }), 'runtime');
-  assert.equal(canonicalSlot({ registry, slot: 'runtime', warnedSlotAliases, writeWarning }), 'runtime');
-  assert.equal(canonicalSlot({ registry, slot: undefined, warnedSlotAliases, writeWarning }), null);
+  assert.equal(resolveCanonicalSlotAlias({ registry, slot: 'platform', warnedSlotAliases, writeWarning }), 'runtime');
+  assert.equal(resolveCanonicalSlotAlias({ registry, slot: 'platform', warnedSlotAliases, writeWarning }), 'runtime');
+  assert.equal(resolveCanonicalSlotAlias({ registry, slot: 'runtime', warnedSlotAliases, writeWarning }), 'runtime');
+  assert.equal(resolveCanonicalSlotAlias({ registry, slot: undefined, warnedSlotAliases, writeWarning }), null);
   assert.equal(warnings.length, 1);
   assert.match(warnings[0], /slot alias 'platform' is deprecated/);
 });

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -44,7 +44,7 @@ export function uniqueList(items: string[]) {
   return [...new Set(items)];
 }
 
-export function canonicalSlot({
+export function resolveCanonicalSlotAlias({
   registry,
   slot,
   warnedSlotAliases,
@@ -68,3 +68,5 @@ export function canonicalSlot({
   }
   return resolved;
 }
+
+export const canonicalSlot = resolveCanonicalSlotAlias;

--- a/src/cli/workspace-discovery.ts
+++ b/src/cli/workspace-discovery.ts
@@ -1,7 +1,8 @@
 import fs from 'node:fs/promises';
-import { constants as fsConstants } from 'node:fs';
 import type { Dirent } from 'node:fs';
 import path from 'node:path';
+import { ensure } from './assertions.ts';
+import { exists, toPosix } from './utils.ts';
 import type { WorkspaceConfig } from './types.ts';
 
 const CONFIG_FILE = 'ailib.config.json';
@@ -80,7 +81,7 @@ async function walkForWorkspaceConfigs({
 
     if (await exists(path.join(currentDir, CONFIG_FILE))) matches.push(path.resolve(currentDir));
 
-    let entries: Dirent[] = [];
+    let entries: Dirent[];
     try {
       entries = await fs.readdir(currentDir, { withFileTypes: true });
     } catch {
@@ -157,21 +158,4 @@ function globToRegex(pattern: string) {
 
 function resolveWorkspacePath(rootDir: string, value: string) {
   return path.resolve(rootDir, value);
-}
-
-function toPosix(value: string) {
-  return value.split(path.sep).join('/');
-}
-
-async function exists(filePath: string) {
-  try {
-    await fs.access(filePath, fsConstants.F_OK);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function ensure(condition: unknown, message: string): asserts condition {
-  if (!condition) throw new Error(message);
 }

--- a/src/cli/workspace-update.ts
+++ b/src/cli/workspace-update.ts
@@ -62,11 +62,13 @@ export async function applyWorkspaceUpdate({
 
   for (const workspaceDir of workspaceDirs) {
     const state = stateMap.get(workspaceDir);
+    ensure(state, `Missing workspace state for ${workspaceDir}`);
     await ensureWorkspaceAssets({ workspaceDir, packageRoot, state, rootDir });
   }
 
   for (const workspaceDir of workspaceDirs) {
     const state = stateMap.get(workspaceDir);
+    ensure(state, `Missing workspace state for ${workspaceDir}`);
     const onConflict = forceOnConflict || state.effective.on_conflict || 'merge';
     await generateWorkspaceRouters({ workspaceDir, rootDir, state, onConflict, allStates: stateMap, registry });
   }

--- a/test/registry-governance.test.ts
+++ b/test/registry-governance.test.ts
@@ -110,7 +110,7 @@ test('registry slots follow naming and coverage rules', async () => {
       slotAliases[alias],
       `slot_alias_meta.${alias}.replacement must match slot_aliases target`
     );
-    for (const key of ['deprecated_since', 'remove_in']) {
+    for (const key of ['deprecated_since', 'remove_in'] as const) {
       assert.match(meta[key], /^\d+\.\d+\.\d+$/u, `slot_alias_meta.${alias}.${key} must be semver-like`);
     }
   }
@@ -170,8 +170,6 @@ test('registry module relationships and frontmatter metadata are valid', async (
   const registry = await loadRegistry();
 
   for (const [languageId, languageDef] of Object.entries(registry.languages || {})) {
-    const moduleIds = new Set(Object.keys(languageDef.modules || {}));
-
     for (const [moduleId, moduleDef] of Object.entries(languageDef.modules || {})) {
       const requires = moduleDef.requires || [];
       const conflicts = moduleDef.conflicts_with || [];

--- a/tools/check-coverage-threshold.test.ts
+++ b/tools/check-coverage-threshold.test.ts
@@ -10,12 +10,30 @@ const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname)
 test('check-coverage-threshold passes for sufficient line coverage', async () => {
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ailib-coverage-pass-'));
   const lcovPath = path.join(tmpDir, 'lcov.info');
-  await fs.writeFile(lcovPath, 'DA:1,1\nDA:2,1\nDA:3,0\n', 'utf8');
+  await fs.writeFile(
+    lcovPath,
+    ['DA:1,1', 'DA:2,1', 'DA:3,0', 'FNF:3', 'FNH:2', 'BRF:3', 'BRH:2', ''].join('\n'),
+    'utf8'
+  );
 
-  const result = spawnSync('bun', ['tools/check-coverage-threshold.ts', '--file', lcovPath, '--min-lines', '60'], {
-    cwd: packageRoot,
-    encoding: 'utf8'
-  });
+  const result = spawnSync(
+    'bun',
+    [
+      'tools/check-coverage-threshold.ts',
+      '--file',
+      lcovPath,
+      '--min-lines',
+      '60',
+      '--min-functions',
+      '60',
+      '--min-branches',
+      '60'
+    ],
+    {
+      cwd: packageRoot,
+      encoding: 'utf8'
+    }
+  );
 
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /Coverage threshold check passed/);
@@ -24,12 +42,30 @@ test('check-coverage-threshold passes for sufficient line coverage', async () =>
 test('check-coverage-threshold fails when below threshold', async () => {
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ailib-coverage-fail-'));
   const lcovPath = path.join(tmpDir, 'lcov.info');
-  await fs.writeFile(lcovPath, 'DA:1,1\nDA:2,0\nDA:3,0\n', 'utf8');
+  await fs.writeFile(
+    lcovPath,
+    ['DA:1,1', 'DA:2,0', 'DA:3,0', 'FNF:2', 'FNH:1', 'BRF:2', 'BRH:0', ''].join('\n'),
+    'utf8'
+  );
 
-  const result = spawnSync('bun', ['tools/check-coverage-threshold.ts', '--file', lcovPath, '--min-lines', '90'], {
-    cwd: packageRoot,
-    encoding: 'utf8'
-  });
+  const result = spawnSync(
+    'bun',
+    [
+      'tools/check-coverage-threshold.ts',
+      '--file',
+      lcovPath,
+      '--min-lines',
+      '90',
+      '--min-functions',
+      '50',
+      '--min-branches',
+      '50'
+    ],
+    {
+      cwd: packageRoot,
+      encoding: 'utf8'
+    }
+  );
 
   assert.equal(result.status, 1);
   assert.match(result.stderr, /below threshold/);

--- a/tools/check-coverage-threshold.ts
+++ b/tools/check-coverage-threshold.ts
@@ -17,11 +17,21 @@ function readArg(name: string, fallback: string): string {
 
 async function run(): Promise<void> {
   const minLinesRaw = readArg('min-lines', '80');
+  const minFunctionsRaw = readArg('min-functions', '80');
+  const minBranchesRaw = readArg('min-branches', '70');
   const lcovFile = readArg('file', path.join('coverage', 'lcov.info'));
 
   const minLines = Number(minLinesRaw);
   if (!Number.isFinite(minLines) || minLines < 0 || minLines > 100) {
     throw new Error(`Invalid --min-lines value '${minLinesRaw}'. Expected number between 0 and 100.`);
+  }
+  const minFunctions = Number(minFunctionsRaw);
+  if (!Number.isFinite(minFunctions) || minFunctions < 0 || minFunctions > 100) {
+    throw new Error(`Invalid --min-functions value '${minFunctionsRaw}'. Expected number between 0 and 100.`);
+  }
+  const minBranches = Number(minBranchesRaw);
+  if (!Number.isFinite(minBranches) || minBranches < 0 || minBranches > 100) {
+    throw new Error(`Invalid --min-branches value '${minBranchesRaw}'. Expected number between 0 and 100.`);
   }
 
   const filePath = path.isAbsolute(lcovFile) ? lcovFile : path.join(packageRoot, lcovFile);
@@ -30,29 +40,78 @@ async function run(): Promise<void> {
 
   let totalLines = 0;
   let coveredLines = 0;
+  let totalFunctions = 0;
+  let coveredFunctions = 0;
+  let totalBranches = 0;
+  let coveredBranches = 0;
 
   for (const line of lines) {
-    if (!line.startsWith('DA:')) continue;
-    const payload = line.slice(3).split(',');
-    if (payload.length !== 2) continue;
-    const hits = Number(payload[1]);
-    if (!Number.isFinite(hits)) continue;
-    totalLines += 1;
-    if (hits > 0) coveredLines += 1;
+    if (line.startsWith('DA:')) {
+      const payload = line.slice(3).split(',');
+      if (payload.length !== 2) continue;
+      const hits = Number(payload[1]);
+      if (!Number.isFinite(hits)) continue;
+      totalLines += 1;
+      if (hits > 0) coveredLines += 1;
+      continue;
+    }
+    if (line.startsWith('FNF:')) {
+      const count = Number(line.slice(4));
+      if (!Number.isFinite(count)) continue;
+      totalFunctions += count;
+      continue;
+    }
+    if (line.startsWith('FNH:')) {
+      const count = Number(line.slice(4));
+      if (!Number.isFinite(count)) continue;
+      coveredFunctions += count;
+      continue;
+    }
+    if (line.startsWith('BRF:')) {
+      const count = Number(line.slice(4));
+      if (!Number.isFinite(count)) continue;
+      totalBranches += count;
+      continue;
+    }
+    if (line.startsWith('BRH:')) {
+      const count = Number(line.slice(4));
+      if (!Number.isFinite(count)) continue;
+      coveredBranches += count;
+    }
   }
 
   if (totalLines === 0) {
     throw new Error(`No line coverage entries found in '${lcovFile}'.`);
   }
-
+  if (totalFunctions === 0) {
+    throw new Error(`No function coverage entries found in '${lcovFile}'.`);
+  }
   const lineCoverage = (coveredLines / totalLines) * 100;
-  const rounded = Math.round(lineCoverage * 100) / 100;
+  const functionCoverage = (coveredFunctions / totalFunctions) * 100;
+  const hasBranchData = totalBranches > 0;
+  const branchCoverage = hasBranchData ? (coveredBranches / totalBranches) * 100 : lineCoverage;
+  const roundedLines = Math.round(lineCoverage * 100) / 100;
+  const roundedFunctions = Math.round(functionCoverage * 100) / 100;
+  const roundedBranches = Math.round(branchCoverage * 100) / 100;
 
   if (lineCoverage < minLines) {
-    throw new Error(`Line coverage ${rounded}% is below threshold ${minLines}% (${coveredLines}/${totalLines}).`);
+    throw new Error(`Line coverage ${roundedLines}% is below threshold ${minLines}% (${coveredLines}/${totalLines}).`);
   }
+  if (functionCoverage < minFunctions) {
+    throw new Error(
+      `Function coverage ${roundedFunctions}% is below threshold ${minFunctions}% (${coveredFunctions}/${totalFunctions}).`
+    );
+  }
+  if (branchCoverage < minBranches) {
+    throw new Error(
+      `Branch coverage ${roundedBranches}% is below threshold ${minBranches}% (${coveredBranches}/${totalBranches}).`
+    );
+  }
+  const branchSource = hasBranchData ? `${coveredBranches}/${totalBranches}` : 'line coverage proxy (no BRF/BRH data)';
 
-  console.log(`Coverage threshold check passed: ${rounded}% >= ${minLines}% (${coveredLines}/${totalLines})`);
+  console.log(
+    `Coverage threshold check passed: lines ${roundedLines}% >= ${minLines}% (${coveredLines}/${totalLines}), functions ${roundedFunctions}% >= ${minFunctions}% (${coveredFunctions}/${totalFunctions}), branches ${roundedBranches}% >= ${minBranches}% (${branchSource})`
+  );
 }
 
 run().catch((error: unknown) => {

--- a/tools/generate-coverage-audit.ts
+++ b/tools/generate-coverage-audit.ts
@@ -72,7 +72,7 @@ function parseFrontmatter(markdown: string): Record<string, string> | null {
 
 async function collectDocModuleInfo(languageId: string): Promise<DocModuleInfo[]> {
   const dir = path.join(packageRoot, 'languages', languageId, 'modules');
-  let entries: Array<{ isFile: () => boolean; name: string }> = [];
+  let entries: Array<{ isFile: () => boolean; name: string }>;
   try {
     entries = await fs.readdir(dir, { withFileTypes: true, encoding: 'utf8' });
   } catch {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
     "types": ["node"],
-    "strict": false,
+    "strict": true,
     "noEmit": true,
     "allowJs": false,
     "skipLibCheck": true

--- a/tsconfig.tools.json
+++ b/tsconfig.tools.json
@@ -6,7 +6,7 @@
     "outDir": "dist/tools",
     "rootDir": "tools",
     "types": ["node"],
-    "strict": false,
+    "strict": true,
     "allowJs": false,
     "declaration": false,
     "sourceMap": false,


### PR DESCRIPTION
## Summary
- Align coverage standards docs and CI enforcement, including enhanced `coverage:check` thresholds and reporting.
- Add real TypeScript linting with ESLint, tighten TypeScript strictness, and update quality scripts/workflow separation.
- Refactor CLI hotspots (`doctor`, router generation, uninstall flow, shared assertions/helpers) and harden async/coverage tests.
- Add contributor quality gate quickstart docs and simplify aggregate CI workflow execution.

Closes #119

## Test plan
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run coverage:check`
- [x] `bun run check`

Made with [Cursor](https://cursor.com)