### PR TITLE
feat: add typescript linting module metadata

### DIFF
--- a/docs/module-catalog.md
+++ b/docs/module-catalog.md
@@ -93,6 +93,8 @@ Core: `languages/typescript/core.md`
 
 - `biome` — requires: (none); conflicts: eslint, prettier
 - `eslint` — requires: (none); conflicts: biome
+- `eslint-js` — requires: eslint; conflicts: biome
+- `typescript-eslint` — requires: eslint; conflicts: biome
 
 #### formatter
 

--- a/docs/module-coverage-audit.md
+++ b/docs/module-coverage-audit.md
@@ -5,8 +5,8 @@ Run `bun tools/generate-coverage-audit.ts` after registry/module documentation c
 
 ## Summary
 
-- Registry modules: **37**
-- Module docs: **37**
+- Registry modules: **39**
+- Module docs: **39**
 - Canonical slots: **28**
 
 ## Coverage by Language
@@ -58,8 +58,8 @@ Run `bun tools/generate-coverage-audit.ts` after registry/module documentation c
 
 ### TypeScript (`typescript`)
 
-- Registry modules: 31
-- Module docs: 31
+- Registry modules: 33
+- Module docs: 33
 - Missing docs: 0
 - Orphan docs: 0
 - Frontmatter issues: 0
@@ -67,8 +67,8 @@ Run `bun tools/generate-coverage-audit.ts` after registry/module documentation c
 
 ## Slot Usage
 
-- `linter`: 3 module(s)
-  - `python:ruff`, `typescript:eslint`, `typescript:biome`
+- `linter`: 5 module(s)
+  - `python:ruff`, `typescript:eslint`, `typescript:typescript-eslint`, `typescript:eslint-js`, `typescript:biome`
 - `formatter`: 2 module(s)
   - `python:black`, `typescript:prettier`
 - `package_manager`: 4 module(s)

--- a/languages/typescript/modules/biome.md
+++ b/languages/typescript/modules/biome.md
@@ -2,7 +2,7 @@
 id: biome
 display: Biome
 version: 1.0.0
-updated: 2026-04-19
+updated: 2026-04-24
 language: typescript
 slot: linter
 requires: []
@@ -10,3 +10,8 @@ conflicts_with: [eslint, prettier]
 ---
 
 # Biome Conventions
+
+- Use Biome as an all-in-one lint+format tool only when it is the selected linter stack for the repo.
+- Do not mix Biome linting with ESLint in the same project unless a migration phase is explicitly documented.
+- Keep configuration centralized in `biome.json` and avoid per-package drift in monorepos.
+- Prefer Biome defaults first; add custom rules only for clear, repeated repository needs.

--- a/languages/typescript/modules/bun.md
+++ b/languages/typescript/modules/bun.md
@@ -2,7 +2,7 @@
 id: bun
 display: Bun
 version: 1.0.0
-updated: 2026-04-19
+updated: 2026-04-24
 language: typescript
 slot: package_manager
 requires: []
@@ -10,3 +10,8 @@ conflicts_with: [npm, pnpm, yarn]
 ---
 
 # Bun Conventions
+
+- Use Bun for script execution (`bun run`) and test workflows (`bun test`) when the repo declares Bun support.
+- Keep Bun version constraints explicit in `package.json` `engines` and align local/CI versions.
+- Prefer `bunx` for one-off tooling commands (for example TypeScript type checks) to avoid global tool drift.
+- Do not mix package managers in one workspace; treat Bun lockfiles and install semantics as authoritative when selected.

--- a/languages/typescript/modules/eslint-js.md
+++ b/languages/typescript/modules/eslint-js.md
@@ -1,0 +1,17 @@
+---
+id: eslint-js
+display: '@eslint/js'
+version: 1.0.0
+updated: 2026-04-24
+language: typescript
+slot: linter
+requires: [eslint]
+conflicts_with: [biome]
+---
+
+# @eslint/js Conventions
+
+- Use `@eslint/js` as the base ruleset for JavaScript defaults in flat config.
+- Import as `js` and apply `js.configs.recommended` before TypeScript-specific layers.
+- Treat this module as foundational ESLint config, not a standalone lint workflow.
+- Keep project overrides minimal; prefer upstream defaults unless the repo has a clear exception.

--- a/languages/typescript/modules/eslint.md
+++ b/languages/typescript/modules/eslint.md
@@ -2,7 +2,7 @@
 id: eslint
 display: ESLint
 version: 1.0.0
-updated: 2026-04-19
+updated: 2026-04-24
 language: typescript
 slot: linter
 requires: []
@@ -10,3 +10,9 @@ conflicts_with: [biome]
 ---
 
 # ESLint Conventions
+
+- Define lint rules in `eslint.config.js` (flat config) and keep it as the single source of truth.
+- Keep base linting in `js.configs.recommended`, then layer TypeScript-specific rules with `typescript-eslint`.
+- Favor autofixable rules and enforce `--max-warnings=0` in CI to prevent warning drift.
+- Scope rule exceptions with file globs instead of broad global disables.
+- Keep lint rules focused on correctness/readability; leave formatting concerns to `prettier` or `biome`.

--- a/languages/typescript/modules/prettier.md
+++ b/languages/typescript/modules/prettier.md
@@ -2,7 +2,7 @@
 id: prettier
 display: Prettier
 version: 1.0.0
-updated: 2026-04-19
+updated: 2026-04-24
 language: typescript
 slot: formatter
 requires: []
@@ -10,3 +10,8 @@ conflicts_with: [biome]
 ---
 
 # Prettier Conventions
+
+- Use Prettier as the single formatting authority and run it through repo scripts (`format:check`, `format:write`).
+- Keep ignore patterns explicit via `.prettierignore` (or script-level ignores) for generated artifacts.
+- Avoid encoding stylistic formatting concerns as ESLint errors when Prettier already owns them.
+- Apply formatting consistently across code and docs to keep diffs reviewable and deterministic.

--- a/languages/typescript/modules/tailwind.md
+++ b/languages/typescript/modules/tailwind.md
@@ -2,7 +2,7 @@
 id: tailwind
 display: Tailwind CSS
 version: 1.3.0
-updated: 2026-04-15
+updated: 2026-04-24
 language: typescript
 slot: styling_system
 requires: []
@@ -14,3 +14,8 @@ tested_with:
 ---
 
 # Tailwind CSS Conventions
+
+- Keep design tokens centralized in Tailwind theme configuration and avoid ad-hoc values when token equivalents exist.
+- Prefer utility-first composition in components and extract repeated class sets into reusable primitives when duplication appears.
+- Keep `content` paths accurate so purge/tree-shaking can remove unused styles in production builds.
+- Resolve conditional classes with deterministic helpers (for example `clsx`/`cn`) rather than manual string concatenation.

--- a/languages/typescript/modules/typescript-eslint.md
+++ b/languages/typescript/modules/typescript-eslint.md
@@ -1,0 +1,18 @@
+---
+id: typescript-eslint
+display: typescript-eslint
+version: 1.0.0
+updated: 2026-04-24
+language: typescript
+slot: linter
+requires: [eslint]
+conflicts_with: [biome]
+---
+
+# typescript-eslint Conventions
+
+- Use `typescript-eslint` with ESLint flat config (`eslint.config.js`) and keep parser/plugin setup in a single shared config.
+- Start from `...tseslint.configs.recommended` and add only repo-specific rule overrides.
+- Prefer strict but actionable TS rules (`@typescript-eslint/no-unused-vars`, `@typescript-eslint/no-explicit-any`) over redundant JS-only lint checks.
+- Scope test-specific relaxations by glob (`**/*.test.ts`) instead of disabling rules globally.
+- Keep linting type-aware only when needed for signal quality to avoid unnecessary CI/runtime cost.

--- a/languages/typescript/modules/vitest.md
+++ b/languages/typescript/modules/vitest.md
@@ -2,7 +2,7 @@
 id: vitest
 display: Vitest
 version: 1.0.0
-updated: 2026-04-19
+updated: 2026-04-24
 language: typescript
 slot: test_runner
 requires: []
@@ -10,3 +10,9 @@ conflicts_with: [jest]
 ---
 
 # Vitest Conventions
+
+- Co-locate tests as `*.test.ts` near source modules unless a package-level `test/` structure is required.
+- Keep test suites deterministic: no hidden network/time dependencies and no cross-test shared mutable state.
+- Use table-driven tests for validation-heavy logic and prefer explicit assertions over snapshot-only coverage.
+- Keep mock boundaries at infrastructure edges; avoid mocking the unit under test's internal behavior.
+- Run the full suite with coverage in CI and treat regressions in branch/function coverage as review blockers.

--- a/registry.json
+++ b/registry.json
@@ -326,6 +326,24 @@
             "biome"
           ]
         },
+        "typescript-eslint": {
+          "slot": "linter",
+          "requires": [
+            "eslint"
+          ],
+          "conflicts_with": [
+            "biome"
+          ]
+        },
+        "eslint-js": {
+          "slot": "linter",
+          "requires": [
+            "eslint"
+          ],
+          "conflicts_with": [
+            "biome"
+          ]
+        },
         "biome": {
           "slot": "linter",
           "conflicts_with": [

--- a/registry/languages/typescript.json
+++ b/registry/languages/typescript.json
@@ -3,6 +3,8 @@
   "path": "languages/typescript/core.md",
   "modules": {
     "eslint": { "slot": "linter", "conflicts_with": ["biome"] },
+    "typescript-eslint": { "slot": "linter", "requires": ["eslint"], "conflicts_with": ["biome"] },
+    "eslint-js": { "slot": "linter", "requires": ["eslint"], "conflicts_with": ["biome"] },
     "biome": { "slot": "linter", "conflicts_with": ["eslint", "prettier"] },
     "prettier": { "slot": "formatter", "conflicts_with": ["biome"] },
     "bun": { "slot": "package_manager", "conflicts_with": ["npm", "pnpm", "yarn"] },


### PR DESCRIPTION
## Summary
- add `typescript-eslint` and `eslint-js` module entries to the TypeScript language registry
- add module docs for both new lint-related modules
- fill previously empty TypeScript module convention docs and sync generated registry/catalog outputs

## Test plan
- [x] Run `bun run registry:check`
- [x] Run `bun run catalog:check`
- [x] Review `git diff main...HEAD` for scoped changes only


Made with [Cursor](https://cursor.com)