### PR TITLE
feat: add skills registry schema contract

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -258,6 +258,7 @@
       "template": "targets/gemini.md.tmpl"
     }
   },
+  "skills": {},
   "languages": {
     "go": {
       "display": "Go",

--- a/registry/core.json
+++ b/registry/core.json
@@ -129,5 +129,6 @@
       "output": "GEMINI.md",
       "template": "targets/gemini.md.tmpl"
     }
-  }
+  },
+  "skills": {}
 }

--- a/schema/registry.schema.json
+++ b/schema/registry.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ailib.dev/schema/registry.schema.json",
   "type": "object",
-  "required": ["version", "schema", "slots", "languages", "targets"],
+  "required": ["version", "schema", "slots", "languages", "targets", "skills"],
   "properties": {
     "version": { "type": "string" },
     "schema": { "type": "string" },
@@ -52,6 +52,29 @@
                 "requires": { "type": "array", "items": { "type": "string" } },
                 "conflicts_with": { "type": "array", "items": { "type": "string" } }
               }
+            }
+          }
+        }
+      }
+    },
+    "skills": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["display", "path"],
+        "properties": {
+          "display": { "type": "string" },
+          "description": { "type": "string" },
+          "path": { "type": "string" },
+          "requires": { "type": "array", "items": { "type": "string" } },
+          "conflicts_with": { "type": "array", "items": { "type": "string" } },
+          "compatible": {
+            "type": "object",
+            "properties": {
+              "languages": { "type": "array", "items": { "type": "string" } },
+              "modules": { "type": "array", "items": { "type": "string" } },
+              "targets": { "type": "array", "items": { "type": "string" } },
+              "llms": { "type": "array", "items": { "type": "string" } }
             }
           }
         }

--- a/test/registry-governance.test.ts
+++ b/test/registry-governance.test.ts
@@ -32,12 +32,29 @@ interface AliasMeta {
   remove_in: string;
 }
 
+interface SkillCompatibility {
+  languages?: string[];
+  modules?: string[];
+  targets?: string[];
+  llms?: string[];
+}
+
+interface SkillDef {
+  display: string;
+  description?: string;
+  path: string;
+  requires?: string[];
+  conflicts_with?: string[];
+  compatible?: SkillCompatibility;
+}
+
 interface Registry {
   slots?: string[];
   slot_defs?: Record<string, SlotDef>;
   slot_aliases?: Record<string, string>;
   slot_alias_meta?: Record<string, AliasMeta>;
   languages?: Record<string, LanguageDef>;
+  skills?: Record<string, SkillDef>;
 }
 
 async function loadRegistry(): Promise<Registry> {
@@ -209,4 +226,31 @@ test('split registry and generated catalog are in sync', () => {
 
   run('tools/sync-registry.ts', '--check');
   run('tools/generate-module-catalog.ts', '--check');
+});
+
+test('registry skills contract is well-formed', async () => {
+  const registry = await loadRegistry();
+  const skills = registry.skills || {};
+
+  for (const [skillId, skillDef] of Object.entries(skills)) {
+    assert.ok(skillDef.display.trim().length > 0, `skills.${skillId}.display must not be empty`);
+    assert.ok(skillDef.path.trim().length > 0, `skills.${skillId}.path must not be empty`);
+
+    const requires = skillDef.requires || [];
+    const conflicts = skillDef.conflicts_with || [];
+    const requiresSet = new Set(requires);
+    const conflictsSet = new Set(conflicts);
+
+    assert.equal(requires.length, requiresSet.size, `skills.${skillId}.requires must not contain duplicates`);
+    assert.equal(conflicts.length, conflictsSet.size, `skills.${skillId}.conflicts_with must not contain duplicates`);
+    assert.ok(!requiresSet.has(skillId), `skills.${skillId}.requires cannot contain itself`);
+    assert.ok(!conflictsSet.has(skillId), `skills.${skillId}.conflicts_with cannot contain itself`);
+
+    for (const dependency of requiresSet) {
+      assert.ok(
+        !conflictsSet.has(dependency),
+        `skills.${skillId} cannot both require and conflict with '${dependency}'`
+      );
+    }
+  }
 });


### PR DESCRIPTION
## Summary
- add a first-class `skills` contract to `schema/registry.schema.json`
- add the initial `skills` object to `registry/core.json` and regenerate `registry.json`
- add registry governance coverage for skills metadata consistency

## Test plan
- [x] Run `bun test test/registry-governance.test.ts`
- [x] Run `bun run check`

Refs #124

Made with [Cursor](https://cursor.com)