### PR TITLE
feat: add skills fields to workspace types

### DIFF
--- a/src/cli/lockfile.test.ts
+++ b/src/cli/lockfile.test.ts
@@ -31,6 +31,7 @@ function state(language: string, localModules: string[]): WorkspaceState {
       language,
       modules: localModules,
       targets: ['cursor'],
+      skills: [],
       docs_path: 'docs/',
       inheritedModules: [],
       localModules,

--- a/src/cli/router-generation.test.ts
+++ b/src/cli/router-generation.test.ts
@@ -19,6 +19,7 @@ function state(targets: string[], inheritedModules: string[] = [], localModules:
       language: 'typescript',
       modules: [...inheritedModules, ...localModules],
       targets,
+      skills: [],
       docs_path: 'docs/',
       inheritedModules,
       localModules,

--- a/src/cli/types.test.ts
+++ b/src/cli/types.test.ts
@@ -6,10 +6,16 @@ import type { CliFlags, CommandContext, RunOptions, WorkspaceConfig } from './ty
 test('types module supports expected shape usage', () => {
   const runOptions: RunOptions = { cwd: '/tmp/project', packageRoot: '/tmp/pkg' };
   const flags: CliFlags = { _: ['init'], language: 'typescript', dryRun: true };
-  const config: WorkspaceConfig = { language: 'typescript', modules: ['eslint'], targets: ['claude-code'] };
+  const config: WorkspaceConfig = {
+    language: 'typescript',
+    modules: ['eslint'],
+    targets: ['claude-code'],
+    skills: ['task-driven-gh-flow']
+  };
   const context: CommandContext = { cwd: '/tmp/project', packageRoot: '/tmp/pkg', flags };
 
   assert.equal(runOptions.cwd, '/tmp/project');
   assert.equal(context.flags._[0], 'init');
   assert.equal(config.modules?.[0], 'eslint');
+  assert.equal(config.skills?.[0], 'task-driven-gh-flow');
 });

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -26,6 +26,22 @@ export interface TargetDefinition {
   };
 }
 
+export interface SkillCompatibility {
+  languages?: string[];
+  modules?: string[];
+  targets?: string[];
+  llms?: string[];
+}
+
+export interface SkillDefinition {
+  display: string;
+  path: string;
+  description?: string;
+  requires?: string[];
+  conflicts_with?: string[];
+  compatible?: SkillCompatibility;
+}
+
 export interface SlotDefinition {
   kind?: 'exclusive' | 'composable';
   description?: string;
@@ -45,6 +61,7 @@ export interface Registry {
   slot_alias_meta?: Record<string, SlotAliasMeta>;
   languages: Record<string, LanguageDefinition>;
   targets: Record<string, TargetDefinition>;
+  skills?: Record<string, SkillDefinition>;
 }
 
 export interface WorkspaceConfig {
@@ -55,6 +72,7 @@ export interface WorkspaceConfig {
   language?: string;
   modules?: string[];
   targets?: string[];
+  skills?: string[];
   targets_removed?: string[];
   docs_path?: string;
   workspaces?: string[];
@@ -87,6 +105,7 @@ export interface EffectiveWorkspaceConfig extends WorkspaceConfig {
   language: string;
   modules: string[];
   targets: string[];
+  skills: string[];
   docs_path: string;
   inheritedModules: string[];
   localModules: string[];

--- a/src/cli/workspace-assets.test.ts
+++ b/src/cli/workspace-assets.test.ts
@@ -19,6 +19,7 @@ function state(localModules: string[]): WorkspaceState {
       language: 'typescript',
       modules: localModules,
       targets: ['cursor'],
+      skills: [],
       docs_path: 'docs/',
       inheritedModules: [],
       localModules,

--- a/src/cli/workspace-state-pipeline.test.ts
+++ b/src/cli/workspace-state-pipeline.test.ts
@@ -39,7 +39,7 @@ test('splitModuleOwnership separates inherited and local', () => {
 
 test('buildEffectiveWorkspaceConfig builds expected shape', () => {
   const workspaceRaw: WorkspaceConfig = {};
-  const base: WorkspaceConfig = {};
+  const base: WorkspaceConfig = { skills: ['task-driven-gh-flow'] };
   const result = buildEffectiveWorkspaceConfig({
     workspaceRaw,
     base,
@@ -52,5 +52,6 @@ test('buildEffectiveWorkspaceConfig builds expected shape', () => {
     warnings: ['warn']
   });
   assert.equal(result.docs_path, 'docs/');
+  assert.deepEqual(result.skills, ['task-driven-gh-flow']);
   assert.deepEqual(result.warnings, ['warn']);
 });

--- a/src/cli/workspace-state-pipeline.ts
+++ b/src/cli/workspace-state-pipeline.ts
@@ -47,6 +47,7 @@ export function buildEffectiveWorkspaceConfig({
   localModules: string[];
   warnings: string[];
 }): EffectiveWorkspaceConfig {
+  const skills = workspaceRaw.skills || base.skills || [];
   return {
     $schema: workspaceRaw.$schema || base.$schema || 'https://ailib.dev/schema/config.schema.json',
     registry_ref: workspaceRaw.registry_ref || base.registry_ref,
@@ -54,6 +55,7 @@ export function buildEffectiveWorkspaceConfig({
     language,
     modules,
     targets,
+    skills,
     docs_path: workspaceRaw.docs_path || (isRootWorkspace ? 'docs/' : './docs/'),
     inheritedModules,
     localModules,


### PR DESCRIPTION
## Summary
- extend CLI type contracts with skills definitions in registry and workspace config
- carry `skills` through effective workspace config build output for serialization compatibility
- update typed unit-test fixtures to include the new required effective `skills` field

## Test plan
- [x] Run `bun run check`

Refs #125

Made with [Cursor](https://cursor.com)