### PR TITLE
feat: resolve inherited skills in workspace state

### DIFF
--- a/src/cli/lockfile.test.ts
+++ b/src/cli/lockfile.test.ts
@@ -35,10 +35,14 @@ function state(language: string, localModules: string[]): WorkspaceState {
       docs_path: 'docs/',
       inheritedModules: [],
       localModules,
+      inheritedSkills: [],
+      localSkills: [],
       warnings: []
     },
     inheritedModules: [],
     localModules,
+    inheritedSkills: [],
+    localSkills: [],
     requiredFiles: [],
     warnings: []
   };

--- a/src/cli/router-generation.test.ts
+++ b/src/cli/router-generation.test.ts
@@ -23,10 +23,14 @@ function state(targets: string[], inheritedModules: string[] = [], localModules:
       docs_path: 'docs/',
       inheritedModules,
       localModules,
+      inheritedSkills: [],
+      localSkills: [],
       warnings: []
     },
     inheritedModules,
     localModules,
+    inheritedSkills: [],
+    localSkills: [],
     requiredFiles: [],
     warnings: []
   };

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -109,6 +109,8 @@ export interface EffectiveWorkspaceConfig extends WorkspaceConfig {
   docs_path: string;
   inheritedModules: string[];
   localModules: string[];
+  inheritedSkills: string[];
+  localSkills: string[];
   warnings: string[];
 }
 
@@ -116,6 +118,8 @@ export interface WorkspaceState {
   effective: EffectiveWorkspaceConfig;
   inheritedModules: string[];
   localModules: string[];
+  inheritedSkills: string[];
+  localSkills: string[];
   requiredFiles: string[];
   warnings: string[];
 }

--- a/src/cli/workspace-assets.test.ts
+++ b/src/cli/workspace-assets.test.ts
@@ -23,10 +23,14 @@ function state(localModules: string[]): WorkspaceState {
       docs_path: 'docs/',
       inheritedModules: [],
       localModules,
+      inheritedSkills: [],
+      localSkills: [],
       warnings: []
     },
     inheritedModules: [],
     localModules,
+    inheritedSkills: [],
+    localSkills: [],
     requiredFiles: [],
     warnings: []
   };

--- a/src/cli/workspace-config.ts
+++ b/src/cli/workspace-config.ts
@@ -56,6 +56,7 @@ export function normalizeRootConfig(rootConfig: WorkspaceConfig, registry: Regis
     language: rootConfig.language,
     modules: rootConfig.modules || [],
     targets: rootConfig.targets || Object.keys(registry.targets),
+    skills: rootConfig.skills || [],
     docs_path: rootConfig.docs_path || 'docs/',
     workspaces: rootConfig.workspaces
   };

--- a/src/cli/workspace-state-pipeline.test.ts
+++ b/src/cli/workspace-state-pipeline.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 import {
   buildEffectiveWorkspaceConfig,
   resolveWorkspaceLanguage,
+  splitListOwnership,
   splitModuleOwnership
 } from './workspace-state-pipeline.ts';
 import type { Registry, WorkspaceConfig } from './types.ts';
@@ -37,6 +38,15 @@ test('splitModuleOwnership separates inherited and local', () => {
   assert.deepEqual(ownership.local, ['biome']);
 });
 
+test('splitListOwnership separates inherited and local values', () => {
+  const ownership = splitListOwnership({
+    values: ['task-driven-gh-flow', 'code-review'],
+    inheritedValues: ['task-driven-gh-flow']
+  });
+  assert.deepEqual(ownership.inherited, ['task-driven-gh-flow']);
+  assert.deepEqual(ownership.local, ['code-review']);
+});
+
 test('buildEffectiveWorkspaceConfig builds expected shape', () => {
   const workspaceRaw: WorkspaceConfig = {};
   const base: WorkspaceConfig = { skills: ['task-driven-gh-flow'] };
@@ -47,11 +57,15 @@ test('buildEffectiveWorkspaceConfig builds expected shape', () => {
     language: 'typescript',
     modules: ['eslint'],
     targets: ['cursor'],
+    skills: ['task-driven-gh-flow'],
     inheritedModules: [],
     localModules: ['eslint'],
+    inheritedSkills: [],
+    localSkills: ['task-driven-gh-flow'],
     warnings: ['warn']
   });
   assert.equal(result.docs_path, 'docs/');
   assert.deepEqual(result.skills, ['task-driven-gh-flow']);
+  assert.deepEqual(result.localSkills, ['task-driven-gh-flow']);
   assert.deepEqual(result.warnings, ['warn']);
 });

--- a/src/cli/workspace-state-pipeline.ts
+++ b/src/cli/workspace-state-pipeline.ts
@@ -20,10 +20,7 @@ export function resolveWorkspaceLanguage({
 }
 
 export function splitModuleOwnership({ modules, inheritedModules }: { modules: string[]; inheritedModules: string[] }) {
-  const inheritedModuleSet = new Set(inheritedModules);
-  const inherited = modules.filter((mod) => inheritedModuleSet.has(mod));
-  const local = modules.filter((mod) => !inheritedModuleSet.has(mod));
-  return { inherited, local };
+  return splitListOwnership({ values: modules, inheritedValues: inheritedModules });
 }
 
 export function buildEffectiveWorkspaceConfig({
@@ -33,8 +30,11 @@ export function buildEffectiveWorkspaceConfig({
   language,
   modules,
   targets,
+  skills,
   inheritedModules,
   localModules,
+  inheritedSkills,
+  localSkills,
   warnings
 }: {
   workspaceRaw: WorkspaceConfig;
@@ -43,11 +43,13 @@ export function buildEffectiveWorkspaceConfig({
   language: string;
   modules: string[];
   targets: string[];
+  skills: string[];
   inheritedModules: string[];
   localModules: string[];
+  inheritedSkills: string[];
+  localSkills: string[];
   warnings: string[];
 }): EffectiveWorkspaceConfig {
-  const skills = workspaceRaw.skills || base.skills || [];
   return {
     $schema: workspaceRaw.$schema || base.$schema || 'https://ailib.dev/schema/config.schema.json',
     registry_ref: workspaceRaw.registry_ref || base.registry_ref,
@@ -59,8 +61,17 @@ export function buildEffectiveWorkspaceConfig({
     docs_path: workspaceRaw.docs_path || (isRootWorkspace ? 'docs/' : './docs/'),
     inheritedModules,
     localModules,
+    inheritedSkills,
+    localSkills,
     warnings
   };
+}
+
+export function splitListOwnership({ values, inheritedValues }: { values: string[]; inheritedValues: string[] }) {
+  const inheritedSet = new Set(inheritedValues);
+  const inherited = values.filter((value) => inheritedSet.has(value));
+  const local = values.filter((value) => !inheritedSet.has(value));
+  return { inherited, local };
 }
 
 function ensure(condition: unknown, message: string): asserts condition {

--- a/src/cli/workspace-state.test.ts
+++ b/src/cli/workspace-state.test.ts
@@ -34,6 +34,7 @@ const rootConfig: WorkspaceConfig = {
   language: 'typescript',
   modules: ['eslint'],
   targets: ['cursor'],
+  skills: ['task-driven-gh-flow'],
   docs_path: 'docs/'
 };
 
@@ -80,6 +81,7 @@ test('getEffectiveWorkspaceConfig applies local override module swap', async () 
   assert.deepEqual(effective.modules, ['biome']);
   assert.deepEqual(effective.localModules, ['biome']);
   assert.deepEqual(effective.targets, ['cursor']);
+  assert.deepEqual(effective.skills, ['task-driven-gh-flow']);
 });
 
 test('buildWorkspaceState includes root behavior file for root workspace', async () => {
@@ -198,6 +200,8 @@ test('getEffectiveWorkspaceConfig falls back to base modules and targets for roo
 
   assert.deepEqual(effective.modules, ['eslint']);
   assert.deepEqual(effective.targets, ['cursor']);
+  assert.deepEqual(effective.skills, ['task-driven-gh-flow']);
+  assert.deepEqual(effective.localSkills, ['task-driven-gh-flow']);
   assert.equal(effective.docs_path, 'docs/');
 });
 
@@ -229,4 +233,7 @@ test('getEffectiveWorkspaceConfig inherits parent modules in non-root workspace'
   assert.deepEqual(effective.inheritedModules, ['eslint']);
   assert.deepEqual(effective.localModules, []);
   assert.deepEqual(effective.modules, ['eslint']);
+  assert.deepEqual(effective.inheritedSkills, ['task-driven-gh-flow']);
+  assert.deepEqual(effective.localSkills, []);
+  assert.deepEqual(effective.skills, ['task-driven-gh-flow']);
 });

--- a/src/cli/workspace-state.ts
+++ b/src/cli/workspace-state.ts
@@ -8,6 +8,7 @@ import { resolveExtendsBase } from './workspace-config.ts';
 import {
   buildEffectiveWorkspaceConfig,
   resolveWorkspaceLanguage,
+  splitListOwnership,
   splitModuleOwnership
 } from './workspace-state-pipeline.ts';
 import type { EffectiveWorkspaceConfig, Registry, WorkspaceConfig, WorkspaceState } from './types.ts';
@@ -57,6 +58,8 @@ export async function buildWorkspaceState({
     effective,
     inheritedModules: effective.inheritedModules,
     localModules: effective.localModules,
+    inheritedSkills: effective.inheritedSkills,
+    localSkills: effective.localSkills,
     requiredFiles,
     warnings: effective.warnings
   };
@@ -104,6 +107,10 @@ export async function getEffectiveWorkspaceConfig({
     localTargets: workspaceRaw.targets || [],
     targetsRemoved: workspaceRaw.targets_removed || []
   });
+  const skills = mergeSelectedSkills({
+    parentSkills: isRootWorkspace ? [] : base.skills || [],
+    localSkills: workspaceRaw.skills || (isRootWorkspace ? base.skills || [] : [])
+  });
 
   const overrideResult = await applyLocalOverrides({
     rootDir,
@@ -120,6 +127,10 @@ export async function getEffectiveWorkspaceConfig({
     modules: overrideResult.modules,
     inheritedModules: mergedModules.inheritedModules || []
   });
+  const skillOwnership = splitListOwnership({
+    values: skills,
+    inheritedValues: isRootWorkspace ? [] : base.skills || []
+  });
 
   return buildEffectiveWorkspaceConfig({
     workspaceRaw,
@@ -128,8 +139,11 @@ export async function getEffectiveWorkspaceConfig({
     language,
     modules: overrideResult.modules,
     targets: overrideResult.targets,
+    skills,
     inheritedModules: ownership.inherited,
     localModules: ownership.local,
+    inheritedSkills: skillOwnership.inherited,
+    localSkills: skillOwnership.local,
     warnings: [...mergedModules.warnings, ...overrideResult.warnings]
   });
 }
@@ -203,4 +217,10 @@ export async function applyLocalOverrides({
     targets: targetResult.values,
     warnings
   };
+}
+
+function mergeSelectedSkills({ parentSkills, localSkills }: { parentSkills: string[]; localSkills: string[] }) {
+  const merged = new Set(parentSkills || []);
+  for (const skill of localSkills || []) merged.add(skill);
+  return [...merged];
 }


### PR DESCRIPTION
## Summary
- merge root and workspace skill selections into effective workspace state
- track `inheritedSkills` and `localSkills` alongside existing module ownership
- update pipeline, config normalization, and workspace-state fixtures/tests for skills inheritance

## Test plan
- [x] Run `bun run check`

Refs #127

Made with [Cursor](https://cursor.com)