### PR TITLE
docs: require issue development field linking

### DIFF
--- a/.cursor/skills/task-driven-gh-flow/SKILL.md
+++ b/.cursor/skills/task-driven-gh-flow/SKILL.md
@@ -18,6 +18,7 @@ Use this workflow for every roadmap or backlog implementation task.
 7. Set real GitHub Issue Types (`Epic`, `Story`, `Task`) on every created item; never rely only on title prefixes.
 8. Keep `Phase XX` in Epic titles only. Story and Task titles must be clean, without `[Phase XX][Story]` or `[Phase XX][Task]` prefixes.
 9. Add all created items to the target GitHub Project and set required fields (at minimum `Status` and `Team` when configured).
+10. Every task issue must show its PR in the GitHub issue `Development` field (not only in comments/body links).
 
 ## Default PR Metadata
 
@@ -119,12 +120,14 @@ PR requirements:
   - Test plan checklist
   - `Refs #<task>`
 - Set assignee and label at creation time.
+- Verify the task issue `Development` field shows the created PR link.
 
 ## 7) Sync task issue immediately after PR creation
 
 - Update task body checkboxes to reflect progress.
 - Maintain a `## Mapped PRs` section and append the PR.
 - Add a short comment like `Implemented in #<pr>`.
+- Confirm `Development` still references the PR after any PR body/title edits.
 
 ## 8) Post-merge sync (mandatory before next task)
 

--- a/src/cli/workspace-state.test.ts
+++ b/src/cli/workspace-state.test.ts
@@ -237,3 +237,43 @@ test('getEffectiveWorkspaceConfig inherits parent modules in non-root workspace'
   assert.deepEqual(effective.localSkills, []);
   assert.deepEqual(effective.skills, ['task-driven-gh-flow']);
 });
+
+test('getEffectiveWorkspaceConfig merges inherited and local skills in workspace', async () => {
+  const rootDir = await tempDir();
+  const workspaceDir = path.join(rootDir, 'apps/web');
+  const rootWithWorkspaces: WorkspaceConfig = {
+    ...rootConfig,
+    skills: ['task-driven-gh-flow'],
+    workspaces: ['apps/*']
+  };
+  await fs.mkdir(workspaceDir, { recursive: true });
+  await fs.writeFile(path.join(rootDir, configFile), `${JSON.stringify(rootWithWorkspaces, null, 2)}\n`, 'utf8');
+  await fs.writeFile(
+    path.join(workspaceDir, configFile),
+    `${JSON.stringify(
+      {
+        language: 'typescript',
+        modules: ['eslint'],
+        targets: ['cursor'],
+        skills: ['task-driven-gh-flow', 'code-review']
+      },
+      null,
+      2
+    )}\n`,
+    'utf8'
+  );
+
+  const effective = await getEffectiveWorkspaceConfig({
+    workspaceDir,
+    rootDir,
+    rootConfig: rootWithWorkspaces,
+    registry,
+    canonicalSlot,
+    configFile,
+    localOverrideFile
+  });
+
+  assert.deepEqual(effective.skills, ['task-driven-gh-flow', 'code-review']);
+  assert.deepEqual(effective.inheritedSkills, ['task-driven-gh-flow']);
+  assert.deepEqual(effective.localSkills, ['code-review']);
+});


### PR DESCRIPTION
## Summary
- add a non-negotiable rule that each task issue must show its PR in the GitHub Development field
- require explicit Development field verification during PR creation and task sync steps

## Test plan
- [x] Review `.cursor/skills/task-driven-gh-flow/SKILL.md` updates


Made with [Cursor](https://cursor.com)