### PR TITLE
feat: validate selected skills dependencies

### DIFF
--- a/src/cli/skill-validation.test.ts
+++ b/src/cli/skill-validation.test.ts
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { validateSkillSelection } from './skill-validation.ts';
+import type { Registry } from './types.ts';
+
+const registry: Registry = {
+  version: '1.0.0',
+  languages: {
+    typescript: {
+      modules: {}
+    }
+  },
+  targets: {
+    cursor: { output: '.cursor/rules/ailib.mdc' }
+  },
+  skills: {
+    'task-driven-gh-flow': {
+      display: 'Task-driven GH flow',
+      path: '.cursor/skills/task-driven-gh-flow/SKILL.md'
+    },
+    'code-review': {
+      display: 'Code review workflow',
+      path: '.cursor/skills/code-review/SKILL.md',
+      requires: ['task-driven-gh-flow']
+    },
+    'release-manager': {
+      display: 'Release manager workflow',
+      path: '.cursor/skills/release-manager/SKILL.md',
+      conflicts_with: ['code-review']
+    }
+  }
+};
+
+test('validateSkillSelection accepts valid dependency graph', () => {
+  assert.doesNotThrow(() => {
+    validateSkillSelection({
+      registry,
+      skills: ['task-driven-gh-flow', 'code-review']
+    });
+  });
+});
+
+test('validateSkillSelection rejects unknown skill id', () => {
+  assert.throws(
+    () =>
+      validateSkillSelection({
+        registry,
+        skills: ['unknown-skill']
+      }),
+    /Unsupported skill: unknown-skill/
+  );
+});
+
+test('validateSkillSelection rejects missing required skill', () => {
+  assert.throws(
+    () =>
+      validateSkillSelection({
+        registry,
+        skills: ['code-review']
+      }),
+    /Skill dependency missing: code-review requires task-driven-gh-flow/
+  );
+});
+
+test('validateSkillSelection rejects conflicting skill set', () => {
+  assert.throws(
+    () =>
+      validateSkillSelection({
+        registry,
+        skills: ['task-driven-gh-flow', 'code-review', 'release-manager']
+      }),
+    /Skill conflict: release-manager conflicts with code-review/
+  );
+});

--- a/src/cli/skill-validation.ts
+++ b/src/cli/skill-validation.ts
@@ -1,0 +1,33 @@
+import type { Registry } from './types.ts';
+
+export function validateSkillSelection({ registry, skills }: { registry: Registry; skills: string[] }) {
+  const selected = uniqueList(skills || []);
+  const selectedSet = new Set(selected);
+  const registrySkills = registry.skills || {};
+
+  for (const skillId of selected) {
+    const skillDef = registrySkills[skillId];
+    if (!skillDef) {
+      throw new Error(`Unsupported skill: ${skillId}`);
+    }
+
+    for (const dependency of skillDef.requires || []) {
+      if (!selectedSet.has(dependency)) {
+        throw new Error(`Skill dependency missing: ${skillId} requires ${dependency}`);
+      }
+    }
+  }
+
+  for (const skillId of selected) {
+    const conflicts = new Set(registrySkills[skillId]?.conflicts_with || []);
+    for (const other of selected) {
+      if (other !== skillId && conflicts.has(other)) {
+        throw new Error(`Skill conflict: ${skillId} conflicts with ${other}`);
+      }
+    }
+  }
+}
+
+function uniqueList(items: string[]) {
+  return [...new Set(items)];
+}

--- a/src/cli/workspace-state.test.ts
+++ b/src/cli/workspace-state.test.ts
@@ -26,6 +26,17 @@ const registry: Registry = {
   },
   targets: {
     cursor: { output: '.cursor/rules' }
+  },
+  skills: {
+    'task-driven-gh-flow': {
+      display: 'Task-driven GH flow',
+      path: '.cursor/skills/task-driven-gh-flow/SKILL.md'
+    },
+    'code-review': {
+      display: 'Code review',
+      path: '.cursor/skills/code-review/SKILL.md',
+      requires: ['task-driven-gh-flow']
+    }
   }
 };
 

--- a/src/cli/workspace-state.ts
+++ b/src/cli/workspace-state.ts
@@ -3,6 +3,7 @@ import { loadLocalOverrideConfig } from './local-override-config.ts';
 import { applyListOverride, applySlotOverrides, mergeWorkspaceOverrides } from './local-overrides.ts';
 import { mergeModules, mergeTargets } from './module-selection.ts';
 import { validateModuleSelection } from './module-validation.ts';
+import { validateSkillSelection } from './skill-validation.ts';
 import { readJson, toPosix } from './utils.ts';
 import { resolveExtendsBase } from './workspace-config.ts';
 import {
@@ -44,6 +45,10 @@ export async function buildWorkspaceState({
     language: effective.language,
     modules: effective.modules,
     canonicalSlot
+  });
+  validateSkillSelection({
+    registry,
+    skills: effective.skills
   });
 
   const requiredFiles = [


### PR DESCRIPTION
## Summary
- add `validateSkillSelection` to enforce skill `requires` and `conflicts_with` rules
- run skill validation during workspace state build to fail fast on invalid skill sets
- add unit coverage for valid selection, unknown skill, missing dependency, and conflicts

## Test plan
- [x] Run `bun test src/cli/workspace-state.test.ts src/cli/skill-validation.test.ts`
- [x] Run `bun run check`

Refs #130

Made with [Cursor](https://cursor.com)