### PR TITLE
feat: validate skill compatibility matrices

### DIFF
--- a/src/cli/skill-validation.test.ts
+++ b/src/cli/skill-validation.test.ts
@@ -21,7 +21,12 @@ const registry: Registry = {
     'code-review': {
       display: 'Code review workflow',
       path: '.cursor/skills/code-review/SKILL.md',
-      requires: ['task-driven-gh-flow']
+      requires: ['task-driven-gh-flow'],
+      compatible: {
+        languages: ['typescript'],
+        modules: ['eslint', 'biome'],
+        targets: ['cursor']
+      }
     },
     'release-manager': {
       display: 'Release manager workflow',
@@ -35,7 +40,10 @@ test('validateSkillSelection accepts valid dependency graph', () => {
   assert.doesNotThrow(() => {
     validateSkillSelection({
       registry,
-      skills: ['task-driven-gh-flow', 'code-review']
+      skills: ['task-driven-gh-flow', 'code-review'],
+      language: 'typescript',
+      modules: ['eslint'],
+      targets: ['cursor']
     });
   });
 });
@@ -45,7 +53,10 @@ test('validateSkillSelection rejects unknown skill id', () => {
     () =>
       validateSkillSelection({
         registry,
-        skills: ['unknown-skill']
+        skills: ['unknown-skill'],
+        language: 'typescript',
+        modules: ['eslint'],
+        targets: ['cursor']
       }),
     /Unsupported skill: unknown-skill/
   );
@@ -56,7 +67,10 @@ test('validateSkillSelection rejects missing required skill', () => {
     () =>
       validateSkillSelection({
         registry,
-        skills: ['code-review']
+        skills: ['code-review'],
+        language: 'typescript',
+        modules: ['eslint'],
+        targets: ['cursor']
       }),
     /Skill dependency missing: code-review requires task-driven-gh-flow/
   );
@@ -67,8 +81,53 @@ test('validateSkillSelection rejects conflicting skill set', () => {
     () =>
       validateSkillSelection({
         registry,
-        skills: ['task-driven-gh-flow', 'code-review', 'release-manager']
+        skills: ['task-driven-gh-flow', 'code-review', 'release-manager'],
+        language: 'typescript',
+        modules: ['eslint'],
+        targets: ['cursor']
       }),
     /Skill conflict: release-manager conflicts with code-review/
+  );
+});
+
+test('validateSkillSelection rejects incompatible language', () => {
+  assert.throws(
+    () =>
+      validateSkillSelection({
+        registry,
+        skills: ['task-driven-gh-flow', 'code-review'],
+        language: 'python',
+        modules: ['eslint'],
+        targets: ['cursor']
+      }),
+    /Skill compatibility mismatch: code-review supports languages \[typescript\], got python/
+  );
+});
+
+test('validateSkillSelection rejects incompatible target selection', () => {
+  assert.throws(
+    () =>
+      validateSkillSelection({
+        registry,
+        skills: ['task-driven-gh-flow', 'code-review'],
+        language: 'typescript',
+        modules: ['eslint'],
+        targets: ['copilot']
+      }),
+    /Skill compatibility mismatch: code-review supports targets \[cursor\], got \[copilot\]/
+  );
+});
+
+test('validateSkillSelection rejects incompatible module selection', () => {
+  assert.throws(
+    () =>
+      validateSkillSelection({
+        registry,
+        skills: ['task-driven-gh-flow', 'code-review'],
+        language: 'typescript',
+        modules: ['nextjs'],
+        targets: ['cursor']
+      }),
+    /Skill compatibility mismatch: code-review supports modules \[eslint, biome\], got \[nextjs\]/
   );
 });

--- a/src/cli/skill-validation.ts
+++ b/src/cli/skill-validation.ts
@@ -1,6 +1,18 @@
 import type { Registry } from './types.ts';
 
-export function validateSkillSelection({ registry, skills }: { registry: Registry; skills: string[] }) {
+export function validateSkillSelection({
+  registry,
+  skills,
+  language,
+  modules,
+  targets
+}: {
+  registry: Registry;
+  skills: string[];
+  language: string;
+  modules: string[];
+  targets: string[];
+}) {
   const selected = uniqueList(skills || []);
   const selectedSet = new Set(selected);
   const registrySkills = registry.skills || {};
@@ -14,6 +26,33 @@ export function validateSkillSelection({ registry, skills }: { registry: Registr
     for (const dependency of skillDef.requires || []) {
       if (!selectedSet.has(dependency)) {
         throw new Error(`Skill dependency missing: ${skillId} requires ${dependency}`);
+      }
+    }
+
+    const compatible = skillDef.compatible;
+    if (compatible?.languages?.length && !compatible.languages.includes(language)) {
+      throw new Error(
+        `Skill compatibility mismatch: ${skillId} supports languages [${compatible.languages.join(', ')}], got ${language}`
+      );
+    }
+
+    if (compatible?.targets?.length) {
+      const compatibleTargets = new Set(compatible.targets);
+      const targetMatch = uniqueList(targets).some((targetId) => compatibleTargets.has(targetId));
+      if (!targetMatch) {
+        throw new Error(
+          `Skill compatibility mismatch: ${skillId} supports targets [${compatible.targets.join(', ')}], got [${uniqueList(targets).join(', ')}]`
+        );
+      }
+    }
+
+    if (compatible?.modules?.length) {
+      const compatibleModules = new Set(compatible.modules);
+      const moduleMatch = uniqueList(modules).some((moduleId) => compatibleModules.has(moduleId));
+      if (!moduleMatch) {
+        throw new Error(
+          `Skill compatibility mismatch: ${skillId} supports modules [${compatible.modules.join(', ')}], got [${uniqueList(modules).join(', ')}]`
+        );
       }
     }
   }

--- a/src/cli/workspace-state.ts
+++ b/src/cli/workspace-state.ts
@@ -48,7 +48,10 @@ export async function buildWorkspaceState({
   });
   validateSkillSelection({
     registry,
-    skills: effective.skills
+    skills: effective.skills,
+    language: effective.language,
+    modules: effective.modules,
+    targets: effective.targets
   });
 
   const requiredFiles = [


### PR DESCRIPTION
## Summary
- extend skill selection validation to enforce compatibility constraints for language, modules, and targets
- fail fast with actionable mismatch diagnostics when selected context is incompatible
- expand skill validation tests to cover incompatible language, module, and target scenarios

## Test plan
- [x] Run `bun test src/cli/skill-validation.test.ts`
- [x] Run `bun run check`

Refs #131

Made with [Cursor](https://cursor.com)