### PR TITLE
feat: extend workspace assets flow for skills

### DIFF
--- a/src/cli/skill-validation.test.ts
+++ b/src/cli/skill-validation.test.ts
@@ -21,7 +21,12 @@ const registry: Registry = {
     'code-review': {
       display: 'Code review workflow',
       path: '.cursor/skills/code-review/SKILL.md',
-      requires: ['task-driven-gh-flow']
+      requires: ['task-driven-gh-flow'],
+      compatible: {
+        languages: ['typescript'],
+        modules: ['eslint', 'biome'],
+        targets: ['cursor']
+      }
     },
     'release-manager': {
       display: 'Release manager workflow',
@@ -35,7 +40,10 @@ test('validateSkillSelection accepts valid dependency graph', () => {
   assert.doesNotThrow(() => {
     validateSkillSelection({
       registry,
-      skills: ['task-driven-gh-flow', 'code-review']
+      skills: ['task-driven-gh-flow', 'code-review'],
+      language: 'typescript',
+      modules: ['eslint'],
+      targets: ['cursor']
     });
   });
 });
@@ -45,7 +53,10 @@ test('validateSkillSelection rejects unknown skill id', () => {
     () =>
       validateSkillSelection({
         registry,
-        skills: ['unknown-skill']
+        skills: ['unknown-skill'],
+        language: 'typescript',
+        modules: ['eslint'],
+        targets: ['cursor']
       }),
     /Unsupported skill: unknown-skill/
   );
@@ -56,7 +67,10 @@ test('validateSkillSelection rejects missing required skill', () => {
     () =>
       validateSkillSelection({
         registry,
-        skills: ['code-review']
+        skills: ['code-review'],
+        language: 'typescript',
+        modules: ['eslint'],
+        targets: ['cursor']
       }),
     /Skill dependency missing: code-review requires task-driven-gh-flow/
   );
@@ -67,8 +81,53 @@ test('validateSkillSelection rejects conflicting skill set', () => {
     () =>
       validateSkillSelection({
         registry,
-        skills: ['task-driven-gh-flow', 'code-review', 'release-manager']
+        skills: ['task-driven-gh-flow', 'code-review', 'release-manager'],
+        language: 'typescript',
+        modules: ['eslint'],
+        targets: ['cursor']
       }),
     /Skill conflict: release-manager conflicts with code-review/
+  );
+});
+
+test('validateSkillSelection rejects incompatible language', () => {
+  assert.throws(
+    () =>
+      validateSkillSelection({
+        registry,
+        skills: ['task-driven-gh-flow', 'code-review'],
+        language: 'python',
+        modules: ['eslint'],
+        targets: ['cursor']
+      }),
+    /Skill compatibility mismatch: code-review supports languages \[typescript\], got python/
+  );
+});
+
+test('validateSkillSelection rejects incompatible target selection', () => {
+  assert.throws(
+    () =>
+      validateSkillSelection({
+        registry,
+        skills: ['task-driven-gh-flow', 'code-review'],
+        language: 'typescript',
+        modules: ['eslint'],
+        targets: ['copilot']
+      }),
+    /Skill compatibility mismatch: code-review supports targets \[cursor\], got \[copilot\]/
+  );
+});
+
+test('validateSkillSelection rejects incompatible module selection', () => {
+  assert.throws(
+    () =>
+      validateSkillSelection({
+        registry,
+        skills: ['task-driven-gh-flow', 'code-review'],
+        language: 'typescript',
+        modules: ['nextjs'],
+        targets: ['cursor']
+      }),
+    /Skill compatibility mismatch: code-review supports modules \[eslint, biome\], got \[nextjs\]/
   );
 });

--- a/src/cli/skill-validation.ts
+++ b/src/cli/skill-validation.ts
@@ -1,6 +1,18 @@
 import type { Registry } from './types.ts';
 
-export function validateSkillSelection({ registry, skills }: { registry: Registry; skills: string[] }) {
+export function validateSkillSelection({
+  registry,
+  skills,
+  language,
+  modules,
+  targets
+}: {
+  registry: Registry;
+  skills: string[];
+  language: string;
+  modules: string[];
+  targets: string[];
+}) {
   const selected = uniqueList(skills || []);
   const selectedSet = new Set(selected);
   const registrySkills = registry.skills || {};
@@ -14,6 +26,33 @@ export function validateSkillSelection({ registry, skills }: { registry: Registr
     for (const dependency of skillDef.requires || []) {
       if (!selectedSet.has(dependency)) {
         throw new Error(`Skill dependency missing: ${skillId} requires ${dependency}`);
+      }
+    }
+
+    const compatible = skillDef.compatible;
+    if (compatible?.languages?.length && !compatible.languages.includes(language)) {
+      throw new Error(
+        `Skill compatibility mismatch: ${skillId} supports languages [${compatible.languages.join(', ')}], got ${language}`
+      );
+    }
+
+    if (compatible?.targets?.length) {
+      const compatibleTargets = new Set(compatible.targets);
+      const targetMatch = uniqueList(targets).some((targetId) => compatibleTargets.has(targetId));
+      if (!targetMatch) {
+        throw new Error(
+          `Skill compatibility mismatch: ${skillId} supports targets [${compatible.targets.join(', ')}], got [${uniqueList(targets).join(', ')}]`
+        );
+      }
+    }
+
+    if (compatible?.modules?.length) {
+      const compatibleModules = new Set(compatible.modules);
+      const moduleMatch = uniqueList(modules).some((moduleId) => compatibleModules.has(moduleId));
+      if (!moduleMatch) {
+        throw new Error(
+          `Skill compatibility mismatch: ${skillId} supports modules [${compatible.modules.join(', ')}], got [${uniqueList(modules).join(', ')}]`
+        );
       }
     }
   }

--- a/src/cli/workspace-assets.test.ts
+++ b/src/cli/workspace-assets.test.ts
@@ -4,13 +4,31 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { ensureWorkspaceAssets } from './workspace-assets.ts';
-import type { WorkspaceState } from './types.ts';
+import type { Registry, WorkspaceState } from './types.ts';
 
 async function tempDir() {
   return fs.mkdtemp(path.join(os.tmpdir(), 'ailib-workspace-assets-'));
 }
 
-function state(localModules: string[]): WorkspaceState {
+const registry: Registry = {
+  version: 'test-registry',
+  languages: {
+    typescript: {
+      modules: {}
+    }
+  },
+  targets: {
+    cursor: { output: '.cursor/rules/ailib.mdc' }
+  },
+  skills: {
+    'task-driven-gh-flow': {
+      display: 'Task-driven GH flow',
+      path: '.cursor/skills/task-driven-gh-flow/SKILL.md'
+    }
+  }
+};
+
+function state(localModules: string[], localSkills: string[] = []): WorkspaceState {
   return {
     effective: {
       $schema: 'https://ailib.dev/schema/config.schema.json',
@@ -19,18 +37,18 @@ function state(localModules: string[]): WorkspaceState {
       language: 'typescript',
       modules: localModules,
       targets: ['cursor'],
-      skills: [],
+      skills: localSkills,
       docs_path: 'docs/',
       inheritedModules: [],
       localModules,
       inheritedSkills: [],
-      localSkills: [],
+      localSkills,
       warnings: []
     },
     inheritedModules: [],
     localModules,
     inheritedSkills: [],
-    localSkills: [],
+    localSkills,
     requiredFiles: [],
     warnings: []
   };
@@ -44,6 +62,8 @@ async function seedPackage(packageRoot: string) {
   await fs.writeFile(path.join(packageRoot, 'core/test-standards.md'), 'test', 'utf8');
   await fs.writeFile(path.join(packageRoot, 'languages/typescript/core.md'), 'lang-core', 'utf8');
   await fs.writeFile(path.join(packageRoot, 'languages/typescript/modules/eslint.md'), 'eslint', 'utf8');
+  await fs.mkdir(path.join(packageRoot, '.cursor/skills/task-driven-gh-flow'), { recursive: true });
+  await fs.writeFile(path.join(packageRoot, '.cursor/skills/task-driven-gh-flow/SKILL.md'), 'skill-flow', 'utf8');
 }
 
 test('ensureWorkspaceAssets copies core and module assets for root workspace', async () => {
@@ -55,7 +75,8 @@ test('ensureWorkspaceAssets copies core and module assets for root workspace', a
     workspaceDir: rootDir,
     packageRoot,
     state: state(['eslint']),
-    rootDir
+    rootDir,
+    registry
   });
 
   assert.equal(await fs.readFile(path.join(rootDir, '.ailib/behavior.md'), 'utf8'), 'behavior');
@@ -76,9 +97,33 @@ test('ensureWorkspaceAssets keeps local-only modules and removes stale module fi
     workspaceDir,
     packageRoot,
     state: state(['custom']),
-    rootDir
+    rootDir,
+    registry
   });
 
   assert.equal(await fs.readFile(path.join(workspaceDir, '.ailib/modules/custom.md'), 'utf8'), 'custom');
   await assert.rejects(fs.readFile(path.join(workspaceDir, '.ailib/modules/stale.md'), 'utf8'));
+});
+
+test('ensureWorkspaceAssets copies and prunes skill assets', async () => {
+  const rootDir = await tempDir();
+  const workspaceDir = path.join(rootDir, 'apps/api');
+  const packageRoot = path.join(rootDir, 'pkg');
+  await seedPackage(packageRoot);
+  await fs.mkdir(path.join(workspaceDir, '.ailib/skills'), { recursive: true });
+  await fs.writeFile(path.join(workspaceDir, '.ailib/skills/stale.md'), 'stale-skill', 'utf8');
+
+  await ensureWorkspaceAssets({
+    workspaceDir,
+    packageRoot,
+    state: state([], ['task-driven-gh-flow']),
+    rootDir,
+    registry
+  });
+
+  assert.equal(
+    await fs.readFile(path.join(workspaceDir, '.ailib/skills/task-driven-gh-flow.md'), 'utf8'),
+    'skill-flow'
+  );
+  await assert.rejects(fs.readFile(path.join(workspaceDir, '.ailib/skills/stale.md'), 'utf8'));
 });

--- a/src/cli/workspace-assets.ts
+++ b/src/cli/workspace-assets.ts
@@ -2,21 +2,24 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { copySourceFile } from './file-helpers.ts';
 import { exists, rmIfExists } from './utils.ts';
-import type { WorkspaceState } from './types.ts';
+import type { Registry, WorkspaceState } from './types.ts';
 
 export async function ensureWorkspaceAssets({
   workspaceDir,
   packageRoot,
   state,
-  rootDir
+  rootDir,
+  registry
 }: {
   workspaceDir: string;
   packageRoot: string;
   state: WorkspaceState;
   rootDir: string;
+  registry: Registry;
 }) {
   const outRoot = path.join(workspaceDir, '.ailib');
   await fs.mkdir(path.join(outRoot, 'modules'), { recursive: true });
+  await fs.mkdir(path.join(outRoot, 'skills'), { recursive: true });
 
   if (path.resolve(workspaceDir) === path.resolve(rootDir)) {
     await copySourceFile({ packageRoot, sourceRel: 'core/behavior.md', target: path.join(outRoot, 'behavior.md') });
@@ -61,6 +64,34 @@ export async function ensureWorkspaceAssets({
       if (!entry.endsWith('.md')) continue;
       const id = entry.replace(/\.md$/u, '');
       if (!localSet.has(id)) await rmIfExists(path.join(moduleDir, entry));
+    }
+  }
+
+  const localSkills = state.localSkills;
+  const localSkillSet = new Set(localSkills);
+  const registrySkills = registry.skills || {};
+  for (const skillId of localSkills) {
+    const skillDef = registrySkills[skillId];
+    ensure(skillDef, `Missing skill definition: ${skillId}`);
+
+    const sourceRel = skillDef.path;
+    const source = path.join(packageRoot, sourceRel);
+    const target = path.join(outRoot, 'skills', `${skillId}.md`);
+    if (await exists(source)) {
+      await copySourceFile({ packageRoot, sourceRel, target });
+      continue;
+    }
+
+    const existing = path.join(outRoot, 'skills', `${skillId}.md`);
+    ensure(await exists(existing), `Missing skill source: ${sourceRel}`);
+  }
+
+  const skillDir = path.join(outRoot, 'skills');
+  if (await exists(skillDir)) {
+    for (const entry of await fs.readdir(skillDir)) {
+      if (!entry.endsWith('.md')) continue;
+      const id = entry.replace(/\.md$/u, '');
+      if (!localSkillSet.has(id)) await rmIfExists(path.join(skillDir, entry));
     }
   }
 }

--- a/src/cli/workspace-state.ts
+++ b/src/cli/workspace-state.ts
@@ -48,7 +48,10 @@ export async function buildWorkspaceState({
   });
   validateSkillSelection({
     registry,
-    skills: effective.skills
+    skills: effective.skills,
+    language: effective.language,
+    modules: effective.modules,
+    targets: effective.targets
   });
 
   const requiredFiles = [

--- a/src/cli/workspace-update.ts
+++ b/src/cli/workspace-update.ts
@@ -63,7 +63,7 @@ export async function applyWorkspaceUpdate({
   for (const workspaceDir of workspaceDirs) {
     const state = stateMap.get(workspaceDir);
     ensure(state, `Missing workspace state for ${workspaceDir}`);
-    await ensureWorkspaceAssets({ workspaceDir, packageRoot, state, rootDir });
+    await ensureWorkspaceAssets({ workspaceDir, packageRoot, state, rootDir, registry });
   }
 
   for (const workspaceDir of workspaceDirs) {


### PR DESCRIPTION
## Summary
- copy selected local skills into `.ailib/skills` during workspace updates
- remove stale generated skill files when they are no longer selected
- wire registry skills into asset generation and add focused coverage in `workspace-assets.test.ts`

## Test plan
- [x] `bun run check`

Refs #134

Made with [Cursor](https://cursor.com)

Closes #134
