### PR TITLE
fix: prune only managed stale skill assets

### DIFF
--- a/src/cli/workspace-assets.test.ts
+++ b/src/cli/workspace-assets.test.ts
@@ -24,6 +24,10 @@ const registry: Registry = {
     'task-driven-gh-flow': {
       display: 'Task-driven GH flow',
       path: '.cursor/skills/task-driven-gh-flow/SKILL.md'
+    },
+    'legacy-skill': {
+      display: 'Legacy skill',
+      path: '.cursor/skills/legacy-skill/SKILL.md'
     }
   }
 };
@@ -111,7 +115,8 @@ test('ensureWorkspaceAssets copies and prunes skill assets', async () => {
   const packageRoot = path.join(rootDir, 'pkg');
   await seedPackage(packageRoot);
   await fs.mkdir(path.join(workspaceDir, '.ailib/skills'), { recursive: true });
-  await fs.writeFile(path.join(workspaceDir, '.ailib/skills/stale.md'), 'stale-skill', 'utf8');
+  await fs.writeFile(path.join(workspaceDir, '.ailib/skills/legacy-skill.md'), 'stale-skill', 'utf8');
+  await fs.writeFile(path.join(workspaceDir, '.ailib/skills/custom.md'), 'custom-skill', 'utf8');
 
   await ensureWorkspaceAssets({
     workspaceDir,
@@ -125,5 +130,6 @@ test('ensureWorkspaceAssets copies and prunes skill assets', async () => {
     await fs.readFile(path.join(workspaceDir, '.ailib/skills/task-driven-gh-flow.md'), 'utf8'),
     'skill-flow'
   );
-  await assert.rejects(fs.readFile(path.join(workspaceDir, '.ailib/skills/stale.md'), 'utf8'));
+  await assert.rejects(fs.readFile(path.join(workspaceDir, '.ailib/skills/legacy-skill.md'), 'utf8'));
+  assert.equal(await fs.readFile(path.join(workspaceDir, '.ailib/skills/custom.md'), 'utf8'), 'custom-skill');
 });

--- a/src/cli/workspace-assets.ts
+++ b/src/cli/workspace-assets.ts
@@ -91,7 +91,7 @@ export async function ensureWorkspaceAssets({
     for (const entry of await fs.readdir(skillDir)) {
       if (!entry.endsWith('.md')) continue;
       const id = entry.replace(/\.md$/u, '');
-      if (!localSkillSet.has(id)) await rmIfExists(path.join(skillDir, entry));
+      if (!localSkillSet.has(id) && registrySkills[id]) await rmIfExists(path.join(skillDir, entry));
     }
   }
 }


### PR DESCRIPTION
## Summary
- restrict stale skill cleanup to registry-managed skill ids only
- preserve non-managed markdown files under `.ailib/skills` during updates
- extend `workspace-assets` test coverage for safe pruning scenarios

## Test plan
- [x] `bun test src/cli/workspace-assets.test.ts`
- [x] `bun run check`

Refs #135

Made with [Cursor](https://cursor.com)