### PR TITLE
feat: add skills section to target routers

### DIFF
--- a/src/cli/router-generation.test.ts
+++ b/src/cli/router-generation.test.ts
@@ -10,7 +10,13 @@ async function tempDir() {
   return fs.mkdtemp(path.join(os.tmpdir(), 'ailib-router-generation-'));
 }
 
-function state(targets: string[], inheritedModules: string[] = [], localModules: string[] = []): WorkspaceState {
+function state(
+  targets: string[],
+  inheritedModules: string[] = [],
+  localModules: string[] = [],
+  inheritedSkills: string[] = [],
+  localSkills: string[] = []
+): WorkspaceState {
   return {
     effective: {
       $schema: 'https://ailib.dev/schema/config.schema.json',
@@ -19,18 +25,18 @@ function state(targets: string[], inheritedModules: string[] = [], localModules:
       language: 'typescript',
       modules: [...inheritedModules, ...localModules],
       targets,
-      skills: [],
+      skills: [...inheritedSkills, ...localSkills],
       docs_path: 'docs/',
       inheritedModules,
       localModules,
-      inheritedSkills: [],
-      localSkills: [],
+      inheritedSkills,
+      localSkills,
       warnings: []
     },
     inheritedModules,
     localModules,
-    inheritedSkills: [],
-    localSkills: [],
+    inheritedSkills,
+    localSkills,
     requiredFiles: [],
     warnings: []
   };
@@ -60,19 +66,23 @@ test('renderRouterDoc renders root and service docs with correct references', ()
     label: 'Cursor',
     workspaceDir: rootDir,
     rootDir,
-    state: state(['cursor'], ['eslint'], ['pytest'])
+    state: state(['cursor'], ['eslint'], ['pytest'], [], ['task-driven-gh-flow'])
   });
   assert.match(rootDoc, /Act as the AI Agent defined in @\.ailib\/behavior\.md/);
   assert.match(rootDoc, /- @\.ailib\/modules\/pytest\.md/);
+  assert.match(rootDoc, /# SKILLS/);
+  assert.match(rootDoc, /- @\.ailib\/skills\/task-driven-gh-flow\.md/);
 
   const serviceDoc = renderRouterDoc({
     label: 'Cursor',
     workspaceDir: '/repo/apps/api',
     rootDir,
-    state: state(['cursor'], ['eslint'], ['pytest'])
+    state: state(['cursor'], ['eslint'], ['pytest'], ['task-driven-gh-flow'], ['local-skill'])
   });
   assert.match(serviceDoc, /@\.\.\/\.\.\/\.ailib\/behavior\.md/);
   assert.match(serviceDoc, /consult @\.\.\/\.\.\/docs\//);
+  assert.match(serviceDoc, /- @\.\.\/\.\.\/\.ailib\/skills\/task-driven-gh-flow\.md/);
+  assert.match(serviceDoc, /- @\.ailib\/skills\/local-skill\.md/);
 });
 
 test('generateWorkspaceRouters writes target outputs and copilot bundle', async () => {

--- a/src/cli/router-generation.ts
+++ b/src/cli/router-generation.ts
@@ -148,11 +148,18 @@ export function renderRouterDoc({
 
   const localModuleLines = state.localModules.map((mod) => `- @.ailib/modules/${mod}.md`);
   const moduleLines = [...inheritedModuleLines, ...localModuleLines];
+  const inheritedSkillLines = state.inheritedSkills.map((skill) => {
+    const skillPath = `@${toPosix(path.join(relToRoot, '.ailib/skills', `${skill}.md`))}`;
+    return `- ${skillPath}`;
+  });
+  const localSkillLines = state.localSkills.map((skill) => `- @.ailib/skills/${skill}.md`);
+  const skillLines = [...inheritedSkillLines, ...localSkillLines];
   const docsBlock =
     path.resolve(workspaceDir) === path.resolve(rootDir)
       ? '# PROJECT-SPECIFIC CONTEXT\nPrioritize project context in @./docs/.\n'
       : `# PROJECT-SPECIFIC CONTEXT\nPrioritize service-local business logic in @./docs/.\nFor cross-service context, consult @${toPosix(path.join(relToRoot, 'docs/'))}.\nIf guidance conflicts, service-local docs win for service-scoped work.\n`;
 
   const modulesText = moduleLines.length ? moduleLines.join('\n') : '- (none)';
-  return `# ailib Router (${label})\n\n# AILIB SYSTEM PROMPT\nAct as the AI Agent defined in ${behaviorRef}.\nAdhere to the coding standards in @.ailib/standards.md.\nApply development workflow rules in @.ailib/development-standards.md.\nApply test and coverage rules in @.ailib/test-standards.md.\n\n# MODULES & EXTENSIONS\n${modulesText}\n\n${docsBlock}`;
+  const skillsText = skillLines.length ? skillLines.join('\n') : '- (none)';
+  return `# ailib Router (${label})\n\n# AILIB SYSTEM PROMPT\nAct as the AI Agent defined in ${behaviorRef}.\nAdhere to the coding standards in @.ailib/standards.md.\nApply development workflow rules in @.ailib/development-standards.md.\nApply test and coverage rules in @.ailib/test-standards.md.\n\n# MODULES & EXTENSIONS\n${modulesText}\n\n# SKILLS\n${skillsText}\n\n${docsBlock}`;
 }


### PR DESCRIPTION
## Summary
- render selected skills in generated router markdown for all standard targets
- include both inherited and local skill pointer references in workspace/router output
- extend router-generation tests to verify skill section rendering and pointer paths

## Test plan
- [x] `bun test src/cli/router-generation.test.ts`
- [x] `bun run check`

Refs #137

Made with [Cursor](https://cursor.com)

Closes #137

