### PR TITLE
feat: add skill pointers to doctor required files

### DIFF
--- a/src/cli/doctor-audit.test.ts
+++ b/src/cli/doctor-audit.test.ts
@@ -31,3 +31,22 @@ test('auditWorkspaceRequiredFiles reports pointer and frontmatter issues', async
   assert.match(joined, /Frontmatter missing 'slot': \.ailib\/modules\/eslint\.md/);
   assert.doesNotMatch(joined, /Missing pointer file/);
 });
+
+test('auditWorkspaceRequiredFiles skips frontmatter validation for skill pointers', async () => {
+  const workspaceDir = await tempDir();
+  const requiredFiles = ['.ailib/skills/task-driven-gh-flow.md'];
+  await fs.mkdir(path.join(workspaceDir, '.ailib/skills'), { recursive: true });
+  await fs.writeFile(
+    path.join(workspaceDir, '.ailib/skills/task-driven-gh-flow.md'),
+    '---\nname: task-driven-gh-flow\n---\ncontent',
+    'utf8'
+  );
+
+  const errors = await auditWorkspaceRequiredFiles({
+    workspaceDir,
+    workspaceLabel: '.',
+    requiredFiles
+  });
+
+  assert.deepEqual(errors, []);
+});

--- a/src/cli/doctor-audit.ts
+++ b/src/cli/doctor-audit.ts
@@ -23,6 +23,7 @@ export async function auditWorkspaceRequiredFiles({
   for (const rel of requiredFiles) {
     const full = path.join(workspaceDir, rel);
     if (!(await exists(full))) continue;
+    if (rel.includes('/skills/')) continue;
     const text = await fs.readFile(full, 'utf8');
     const frontmatter = parseFrontmatter(text);
     if (!frontmatter) {

--- a/src/cli/workspace-state.test.ts
+++ b/src/cli/workspace-state.test.ts
@@ -111,6 +111,7 @@ test('buildWorkspaceState includes root behavior file for root workspace', async
 
   assert.ok(state.requiredFiles.includes('.ailib/behavior.md'));
   assert.ok(state.requiredFiles.includes('.ailib/standards.md'));
+  assert.ok(state.requiredFiles.includes('.ailib/skills/task-driven-gh-flow.md'));
 });
 
 test('getEffectiveWorkspaceConfig propagates module merge warnings', async () => {

--- a/src/cli/workspace-state.ts
+++ b/src/cli/workspace-state.ts
@@ -58,7 +58,8 @@ export async function buildWorkspaceState({
     '.ailib/development-standards.md',
     '.ailib/test-standards.md',
     '.ailib/standards.md',
-    ...effective.localModules.map((m) => `.ailib/modules/${m}.md`)
+    ...effective.localModules.map((m) => `.ailib/modules/${m}.md`),
+    ...effective.localSkills.map((s) => `.ailib/skills/${s}.md`)
   ];
   if (path.resolve(workspaceDir) === path.resolve(rootDir)) requiredFiles.unshift('.ailib/behavior.md');
 


### PR DESCRIPTION
## Summary
- include local generated skill pointer files in the doctor required-file matrix
- keep this task focused on pointer presence by skipping skill frontmatter validation for now
- add tests covering required skill file inclusion and skill audit behavior

## Test plan
- [x] `bun test src/cli/workspace-state.test.ts src/cli/doctor-audit.test.ts`
- [x] `bun run check`

Refs #140
Closes #140

Made with [Cursor](https://cursor.com)