### PR TITLE
feat: validate skill frontmatter in doctor audit

### DIFF
--- a/src/cli/doctor-audit.test.ts
+++ b/src/cli/doctor-audit.test.ts
@@ -32,13 +32,32 @@ test('auditWorkspaceRequiredFiles reports pointer and frontmatter issues', async
   assert.doesNotMatch(joined, /Missing pointer file/);
 });
 
-test('auditWorkspaceRequiredFiles skips frontmatter validation for skill pointers', async () => {
+test('auditWorkspaceRequiredFiles validates skill frontmatter keys', async () => {
   const workspaceDir = await tempDir();
   const requiredFiles = ['.ailib/skills/task-driven-gh-flow.md'];
   await fs.mkdir(path.join(workspaceDir, '.ailib/skills'), { recursive: true });
   await fs.writeFile(
     path.join(workspaceDir, '.ailib/skills/task-driven-gh-flow.md'),
     '---\nname: task-driven-gh-flow\n---\ncontent',
+    'utf8'
+  );
+
+  const errors = await auditWorkspaceRequiredFiles({
+    workspaceDir,
+    workspaceLabel: '.',
+    requiredFiles
+  });
+
+  assert.match(errors.join('\n'), /Skill frontmatter missing 'description': \.ailib\/skills\/task-driven-gh-flow\.md/);
+});
+
+test('auditWorkspaceRequiredFiles accepts valid skill frontmatter', async () => {
+  const workspaceDir = await tempDir();
+  const requiredFiles = ['.ailib/skills/task-driven-gh-flow.md'];
+  await fs.mkdir(path.join(workspaceDir, '.ailib/skills'), { recursive: true });
+  await fs.writeFile(
+    path.join(workspaceDir, '.ailib/skills/task-driven-gh-flow.md'),
+    '---\nname: task-driven-gh-flow\ndescription: Track GH tasks\n---\ncontent',
     'utf8'
   );
 

--- a/src/cli/doctor-audit.ts
+++ b/src/cli/doctor-audit.ts
@@ -23,11 +23,18 @@ export async function auditWorkspaceRequiredFiles({
   for (const rel of requiredFiles) {
     const full = path.join(workspaceDir, rel);
     if (!(await exists(full))) continue;
-    if (rel.includes('/skills/')) continue;
     const text = await fs.readFile(full, 'utf8');
     const frontmatter = parseFrontmatter(text);
     if (!frontmatter) {
       errors.push(`[${workspaceLabel}] Missing frontmatter: ${rel}`);
+      continue;
+    }
+    if (rel.includes('/skills/')) {
+      for (const key of ['name', 'description']) {
+        if (!(key in frontmatter)) {
+          errors.push(`[${workspaceLabel}] Skill frontmatter missing '${key}': ${rel}`);
+        }
+      }
       continue;
     }
     for (const key of ['id', 'version', 'updated']) {


### PR DESCRIPTION
## Summary
- validate generated skill pointer frontmatter during doctor audit
- enforce required skill metadata keys (`name`, `description`) with clear diagnostics
- add doctor audit coverage for missing and valid skill frontmatter cases

## Test plan
- [x] `bun test src/cli/doctor-audit.test.ts src/cli/doctor.test.ts`
- [x] `bun run check`

Refs #141
Closes #141

Made with [Cursor](https://cursor.com)