### PR TITLE
feat: define local custom skill path rules

### DIFF
--- a/src/cli/skill-paths.test.ts
+++ b/src/cli/skill-paths.test.ts
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isLocalCustomSkillPath,
+  isUnderLocalCustomSkillsRoot,
+  localCustomSkillPath,
+  normalizeRelativeSkillPath
+} from './skill-paths.ts';
+
+test('localCustomSkillPath builds canonical skill source path', () => {
+  assert.equal(localCustomSkillPath('task-driven-gh-flow'), '.cursor/skills/task-driven-gh-flow/SKILL.md');
+});
+
+test('normalizeRelativeSkillPath normalizes slashes and leading dot slash', () => {
+  assert.equal(normalizeRelativeSkillPath('./.cursor/skills/review/SKILL.md'), '.cursor/skills/review/SKILL.md');
+  assert.equal(normalizeRelativeSkillPath('.cursor/skills\\review\\SKILL.md'), '.cursor/skills/review/SKILL.md');
+});
+
+test('isUnderLocalCustomSkillsRoot detects paths under local skills root', () => {
+  assert.equal(isUnderLocalCustomSkillsRoot('.cursor/skills/review/SKILL.md'), true);
+  assert.equal(isUnderLocalCustomSkillsRoot('skills/review/SKILL.md'), false);
+});
+
+test('isLocalCustomSkillPath validates skill-id specific location', () => {
+  assert.equal(isLocalCustomSkillPath('review', '.cursor/skills/review/SKILL.md'), true);
+  assert.equal(isLocalCustomSkillPath('review', '.cursor/skills/other/SKILL.md'), false);
+});

--- a/src/cli/skill-paths.ts
+++ b/src/cli/skill-paths.ts
@@ -1,0 +1,22 @@
+import { toPosix } from './utils.ts';
+
+export const LOCAL_CUSTOM_SKILLS_ROOT = '.cursor/skills';
+export const LOCAL_CUSTOM_SKILL_ENTRY = 'SKILL.md';
+
+export function normalizeRelativeSkillPath(pathValue: string) {
+  const normalized = toPosix(pathValue).replaceAll('\\', '/').trim();
+  return normalized.startsWith('./') ? normalized.slice(2) : normalized;
+}
+
+export function localCustomSkillPath(skillId: string) {
+  return `${LOCAL_CUSTOM_SKILLS_ROOT}/${skillId}/${LOCAL_CUSTOM_SKILL_ENTRY}`;
+}
+
+export function isUnderLocalCustomSkillsRoot(pathValue: string) {
+  const normalized = normalizeRelativeSkillPath(pathValue);
+  return normalized === LOCAL_CUSTOM_SKILLS_ROOT || normalized.startsWith(`${LOCAL_CUSTOM_SKILLS_ROOT}/`);
+}
+
+export function isLocalCustomSkillPath(skillId: string, pathValue: string) {
+  return normalizeRelativeSkillPath(pathValue) === localCustomSkillPath(skillId);
+}

--- a/src/cli/skill-validation.test.ts
+++ b/src/cli/skill-validation.test.ts
@@ -32,6 +32,10 @@ const registry: Registry = {
       display: 'Release manager workflow',
       path: '.cursor/skills/release-manager/SKILL.md',
       conflicts_with: ['code-review']
+    },
+    'bad-path': {
+      display: 'Invalid path skill',
+      path: '.cursor/skills/other-id/SKILL.md'
     }
   }
 };
@@ -129,5 +133,19 @@ test('validateSkillSelection rejects incompatible module selection', () => {
         targets: ['cursor']
       }),
     /Skill compatibility mismatch: code-review supports modules \[eslint, biome\], got \[nextjs\]/
+  );
+});
+
+test('validateSkillSelection rejects non-canonical local skill paths', () => {
+  assert.throws(
+    () =>
+      validateSkillSelection({
+        registry,
+        skills: ['bad-path'],
+        language: 'typescript',
+        modules: ['eslint'],
+        targets: ['cursor']
+      }),
+    /Skill path convention mismatch: bad-path must use \.cursor\/skills\/bad-path\/SKILL\.md, got \.cursor\/skills\/other-id\/SKILL\.md/
   );
 });

--- a/src/cli/skill-validation.ts
+++ b/src/cli/skill-validation.ts
@@ -1,3 +1,9 @@
+import {
+  isLocalCustomSkillPath,
+  isUnderLocalCustomSkillsRoot,
+  localCustomSkillPath,
+  normalizeRelativeSkillPath
+} from './skill-paths.ts';
 import type { Registry } from './types.ts';
 
 export function validateSkillSelection({
@@ -21,6 +27,11 @@ export function validateSkillSelection({
     const skillDef = registrySkills[skillId];
     if (!skillDef) {
       throw new Error(`Unsupported skill: ${skillId}`);
+    }
+    if (isUnderLocalCustomSkillsRoot(skillDef.path) && !isLocalCustomSkillPath(skillId, skillDef.path)) {
+      throw new Error(
+        `Skill path convention mismatch: ${skillId} must use ${localCustomSkillPath(skillId)}, got ${normalizeRelativeSkillPath(skillDef.path)}`
+      );
     }
 
     for (const dependency of skillDef.requires || []) {


### PR DESCRIPTION
## Summary
- add canonical helper utilities for local custom skill source path conventions
- enforce local-skill path/id conventions during skill selection validation
- add tests for path normalization and mismatch diagnostics

## Test plan
- [x] `bun test src/cli/skill-paths.test.ts src/cli/skill-validation.test.ts`
- [x] `bun run check`

Refs #144
Closes #144

Made with [Cursor](https://cursor.com)