### PR TITLE
feat: resolve skill sources with local precedence

### DIFF
--- a/src/cli/workspace-assets.test.ts
+++ b/src/cli/workspace-assets.test.ts
@@ -133,3 +133,31 @@ test('ensureWorkspaceAssets copies and prunes skill assets', async () => {
   await assert.rejects(fs.readFile(path.join(workspaceDir, '.ailib/skills/legacy-skill.md'), 'utf8'));
   assert.equal(await fs.readFile(path.join(workspaceDir, '.ailib/skills/custom.md'), 'utf8'), 'custom-skill');
 });
+
+test('ensureWorkspaceAssets prefers local custom skill over package source', async () => {
+  const rootDir = await tempDir();
+  const workspaceDir = path.join(rootDir, 'apps/api');
+  const packageRoot = path.join(rootDir, 'pkg');
+  await seedPackage(packageRoot);
+  await fs.mkdir(path.join(workspaceDir, '.cursor/skills/task-driven-gh-flow'), { recursive: true });
+  await fs.writeFile(
+    path.join(workspaceDir, '.cursor/skills/task-driven-gh-flow/SKILL.md'),
+    'workspace-local-skill',
+    'utf8'
+  );
+  await fs.mkdir(path.join(rootDir, '.cursor/skills/task-driven-gh-flow'), { recursive: true });
+  await fs.writeFile(path.join(rootDir, '.cursor/skills/task-driven-gh-flow/SKILL.md'), 'root-local-skill', 'utf8');
+
+  await ensureWorkspaceAssets({
+    workspaceDir,
+    packageRoot,
+    state: state([], ['task-driven-gh-flow']),
+    rootDir,
+    registry
+  });
+
+  assert.equal(
+    await fs.readFile(path.join(workspaceDir, '.ailib/skills/task-driven-gh-flow.md'), 'utf8'),
+    'workspace-local-skill'
+  );
+});

--- a/src/cli/workspace-assets.ts
+++ b/src/cli/workspace-assets.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { copySourceFile } from './file-helpers.ts';
+import { localCustomSkillPath } from './skill-paths.ts';
 import { exists, rmIfExists } from './utils.ts';
 import type { Registry, WorkspaceState } from './types.ts';
 
@@ -74,9 +75,21 @@ export async function ensureWorkspaceAssets({
     const skillDef = registrySkills[skillId];
     ensure(skillDef, `Missing skill definition: ${skillId}`);
 
+    const target = path.join(outRoot, 'skills', `${skillId}.md`);
+    const workspaceLocalSource = path.join(workspaceDir, localCustomSkillPath(skillId));
+    if (await exists(workspaceLocalSource)) {
+      await copyFileFromSource(workspaceLocalSource, target);
+      continue;
+    }
+
+    const rootLocalSource = path.join(rootDir, localCustomSkillPath(skillId));
+    if (await exists(rootLocalSource)) {
+      await copyFileFromSource(rootLocalSource, target);
+      continue;
+    }
+
     const sourceRel = skillDef.path;
     const source = path.join(packageRoot, sourceRel);
-    const target = path.join(outRoot, 'skills', `${skillId}.md`);
     if (await exists(source)) {
       await copySourceFile({ packageRoot, sourceRel, target });
       continue;
@@ -98,4 +111,9 @@ export async function ensureWorkspaceAssets({
 
 function ensure(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(message);
+}
+
+async function copyFileFromSource(source: string, target: string) {
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  await fs.copyFile(source, target);
 }


### PR DESCRIPTION
## Summary
- resolve selected skill sources with explicit precedence: workspace local > root local > package registry
- keep deterministic behavior when local and built-in skills share the same id
- add workspace-assets coverage for local-over-built-in source selection

## Test plan
- [x] `bun test src/cli/workspace-assets.test.ts`
- [x] `bun run check`

Refs #145
Closes #145

Made with [Cursor](https://cursor.com)