### PR TITLE
feat: add skills scope to override schema

### DIFF
--- a/src/cli/local-override-config.test.ts
+++ b/src/cli/local-override-config.test.ts
@@ -30,6 +30,12 @@ const registry: Registry = {
   },
   targets: {
     cursor: { output: '.cursor/rules' }
+  },
+  skills: {
+    'task-driven-gh-flow': {
+      display: 'Task-driven GH flow',
+      path: '.cursor/skills/task-driven-gh-flow/SKILL.md'
+    }
   }
 };
 
@@ -84,7 +90,8 @@ test('loadLocalOverrideConfig accepts a valid override file', async () => {
   const config: LocalOverrideConfig = {
     version: '1',
     default_override: {
-      modules: { set: ['eslint'] }
+      modules: { set: ['eslint'] },
+      skills: { add: ['task-driven-gh-flow'] }
     }
   };
   await fs.writeFile(path.join(rootDir, 'ailib.local.json'), `${JSON.stringify(config, null, 2)}\n`, 'utf8');

--- a/src/cli/local-overrides.test.ts
+++ b/src/cli/local-overrides.test.ts
@@ -30,11 +30,20 @@ const registry: Registry = {
 
 test('mergeWorkspaceOverrides merges list scopes and slot overrides', () => {
   const merged = mergeWorkspaceOverrides(
-    { targets: { add: ['claude-code'] }, slots: { linter: { set: 'eslint' } } },
-    { targets: { remove: ['claude-code'] }, slots: { framework: { set: 'nextjs' } } }
+    {
+      targets: { add: ['claude-code'] },
+      skills: { add: ['task-driven-gh-flow'] },
+      slots: { linter: { set: 'eslint' } }
+    },
+    {
+      targets: { remove: ['claude-code'] },
+      skills: { remove: ['task-driven-gh-flow'] },
+      slots: { framework: { set: 'nextjs' } }
+    }
   );
 
   assert.deepEqual(merged.targets, { set: undefined, add: ['claude-code'], remove: ['claude-code'] });
+  assert.deepEqual(merged.skills, { set: undefined, add: ['task-driven-gh-flow'], remove: ['task-driven-gh-flow'] });
   assert.deepEqual(merged.slots, { linter: { set: 'eslint' }, framework: { set: 'nextjs' } });
 });
 

--- a/src/cli/local-overrides.ts
+++ b/src/cli/local-overrides.ts
@@ -7,6 +7,7 @@ export function mergeWorkspaceOverrides(
   return {
     targets: mergeListOverrideScope(base?.targets, workspace?.targets),
     modules: mergeListOverrideScope(base?.modules, workspace?.modules),
+    skills: mergeListOverrideScope(base?.skills, workspace?.skills),
     slots: {
       ...(base?.slots || {}),
       ...(workspace?.slots || {})

--- a/src/cli/override-validation.test.ts
+++ b/src/cli/override-validation.test.ts
@@ -26,6 +26,12 @@ const registry: Registry = {
   targets: {
     'claude-code': { output: 'CLAUDE.md' },
     cursor: { output: '.cursor/rules/ailib.mdc' }
+  },
+  skills: {
+    'task-driven-gh-flow': {
+      display: 'Task-driven GH flow',
+      path: '.cursor/skills/task-driven-gh-flow/SKILL.md'
+    }
   }
 };
 
@@ -65,6 +71,19 @@ test('validateWorkspaceOverride validates non-object values and unsupported keys
   });
 
   assert.match(errors.join('\n'), /'default_override' has unsupported key 'unknown'/);
+});
+
+test('validateWorkspaceOverride validates skills scope and unknown values', () => {
+  const errors = validateWorkspaceOverride({
+    override: {
+      skills: { set: ['task-driven-gh-flow', 'unknown-skill'] }
+    },
+    label: 'default_override',
+    registry,
+    canonicalSlot: (slot) => slot ?? null
+  });
+
+  assert.match(errors.join('\n'), /contains unknown skill 'unknown-skill'/);
 });
 
 test('validateWorkspaceOverride validates slots and alias resolution', () => {

--- a/src/cli/override-validation.ts
+++ b/src/cli/override-validation.ts
@@ -16,7 +16,7 @@ export function validateWorkspaceOverride({
     return [`'${label}' must be an object`];
   }
 
-  const allowed = new Set(['targets', 'modules', 'slots']);
+  const allowed = new Set(['targets', 'modules', 'skills', 'slots']);
   for (const key of Object.keys(override)) {
     if (!allowed.has(key)) {
       errors.push(`'${label}' has unsupported key '${key}'`);
@@ -40,6 +40,17 @@ export function validateWorkspaceOverride({
         scope: override.modules,
         label: `${label}.modules`,
         valueLabel: 'module'
+      })
+    );
+  }
+
+  if (override.skills !== undefined) {
+    errors.push(
+      ...validateListOverrideScope({
+        scope: override.skills,
+        label: `${label}.skills`,
+        validSet: new Set(Object.keys(registry.skills || {})),
+        valueLabel: 'skill'
       })
     );
   }

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -92,6 +92,7 @@ export interface SlotOverrideRule {
 export interface WorkspaceOverrideConfig {
   targets?: ListOverrideScope;
   modules?: ListOverrideScope;
+  skills?: ListOverrideScope;
   slots?: Record<string, SlotOverrideRule>;
 }
 


### PR DESCRIPTION
## Summary
- extend local override schema/model to support `skills` add/remove/set scopes
- validate skills override values against known registry skills in override validation
- add tests for skills schema validation, merge behavior, and config loading

## Test plan
- [x] `bun test src/cli/override-validation.test.ts src/cli/local-overrides.test.ts src/cli/local-override-config.test.ts`
- [x] `bun run check`

Refs #147
Closes #147

Made with [Cursor](https://cursor.com)