### PR TITLE
feat: apply skills overrides in workspace state

### DIFF
--- a/src/cli/workspace-state.test.ts
+++ b/src/cli/workspace-state.test.ts
@@ -64,10 +64,11 @@ test('applyLocalOverrides returns original values when local file is absent', as
     language: 'typescript',
     modules: ['eslint'],
     targets: ['cursor'],
+    skills: ['task-driven-gh-flow'],
     canonicalSlot,
     localOverrideFile
   });
-  assert.deepEqual(result, { modules: ['eslint'], targets: ['cursor'], warnings: [] });
+  assert.deepEqual(result, { modules: ['eslint'], targets: ['cursor'], skills: ['task-driven-gh-flow'], warnings: [] });
 });
 
 test('getEffectiveWorkspaceConfig applies local override module swap', async () => {
@@ -179,12 +180,51 @@ test('applyLocalOverrides supports workspace-specific overrides', async () => {
     language: 'typescript',
     modules: ['eslint'],
     targets: ['cursor'],
+    skills: ['task-driven-gh-flow'],
     canonicalSlot,
     localOverrideFile
   });
 
   assert.deepEqual(result.modules, ['biome']);
   assert.deepEqual(result.targets, ['cursor']);
+  assert.deepEqual(result.skills, ['task-driven-gh-flow']);
+});
+
+test('applyLocalOverrides applies skills set/add/remove scopes', async () => {
+  const rootDir = await tempDir();
+  await fs.writeFile(path.join(rootDir, configFile), `${JSON.stringify(rootConfig, null, 2)}\n`, 'utf8');
+  await fs.writeFile(
+    path.join(rootDir, localOverrideFile),
+    `${JSON.stringify(
+      {
+        version: '1',
+        default_override: {
+          skills: {
+            add: ['code-review'],
+            remove: ['task-driven-gh-flow']
+          }
+        }
+      },
+      null,
+      2
+    )}\n`,
+    'utf8'
+  );
+
+  const result = await applyLocalOverrides({
+    rootDir,
+    workspaceDir: rootDir,
+    rootConfig,
+    registry,
+    language: 'typescript',
+    modules: ['eslint'],
+    targets: ['cursor'],
+    skills: ['task-driven-gh-flow'],
+    canonicalSlot,
+    localOverrideFile
+  });
+
+  assert.deepEqual(result.skills, ['code-review']);
 });
 
 test('getEffectiveWorkspaceConfig falls back to base modules and targets for root workspace', async () => {

--- a/src/cli/workspace-state.ts
+++ b/src/cli/workspace-state.ts
@@ -129,6 +129,7 @@ export async function getEffectiveWorkspaceConfig({
     language,
     modules: mergedModules.modules,
     targets,
+    skills,
     canonicalSlot,
     localOverrideFile
   });
@@ -137,7 +138,7 @@ export async function getEffectiveWorkspaceConfig({
     inheritedModules: mergedModules.inheritedModules || []
   });
   const skillOwnership = splitListOwnership({
-    values: skills,
+    values: overrideResult.skills,
     inheritedValues: isRootWorkspace ? [] : base.skills || []
   });
 
@@ -148,7 +149,7 @@ export async function getEffectiveWorkspaceConfig({
     language,
     modules: overrideResult.modules,
     targets: overrideResult.targets,
-    skills,
+    skills: overrideResult.skills,
     inheritedModules: ownership.inherited,
     localModules: ownership.local,
     inheritedSkills: skillOwnership.inherited,
@@ -165,6 +166,7 @@ export async function applyLocalOverrides({
   language,
   modules,
   targets,
+  skills,
   canonicalSlot,
   localOverrideFile
 }: {
@@ -175,9 +177,10 @@ export async function applyLocalOverrides({
   language: string;
   modules: string[];
   targets: string[];
+  skills: string[];
   canonicalSlot: (slot: string | undefined) => string | null;
   localOverrideFile: string;
-}): Promise<{ modules: string[]; targets: string[]; warnings: string[] }> {
+}): Promise<{ modules: string[]; targets: string[]; skills: string[]; warnings: string[] }> {
   const warnings: string[] = [];
   const config = await loadLocalOverrideConfig({
     rootDir,
@@ -186,7 +189,7 @@ export async function applyLocalOverrides({
     canonicalSlot,
     localOverrideFile
   });
-  if (!config) return { modules, targets, warnings };
+  if (!config) return { modules, targets, skills, warnings };
 
   const workspaceKey =
     path.resolve(workspaceDir) === path.resolve(rootDir) ? '.' : toPosix(path.relative(rootDir, workspaceDir));
@@ -194,6 +197,7 @@ export async function applyLocalOverrides({
 
   const validTargets = new Set(Object.keys(registry.targets || {}));
   const validModules = new Set(Object.keys(registry.languages[language]?.modules || {}));
+  const validSkills = new Set(Object.keys(registry.skills || {}));
 
   const targetResult = applyListOverride({
     values: targets,
@@ -212,6 +216,15 @@ export async function applyLocalOverrides({
   });
   warnings.push(...moduleResult.warnings);
 
+  const skillResult = applyListOverride({
+    values: skills,
+    scope: override.skills,
+    validSet: validSkills,
+    label: 'skills',
+    localOverrideFile
+  });
+  warnings.push(...skillResult.warnings);
+
   const slotResult = applySlotOverrides({
     registry,
     language,
@@ -224,6 +237,7 @@ export async function applyLocalOverrides({
   return {
     modules: slotResult.modules,
     targets: targetResult.values,
+    skills: skillResult.values,
     warnings
   };
 }


### PR DESCRIPTION
## Summary
- apply skills list overrides (`set`/`add`/`remove`) in local override runtime flow
- use overridden skills set when calculating effective workspace state and ownership
- add workspace-state tests for skills override behavior and return shape

## Test plan
- [x] `bun test src/cli/workspace-state.test.ts`
- [x] `bun run check`

Refs #148
Closes #148

Made with [Cursor](https://cursor.com)