### PR TITLE
fix: add diagnostics for skill source collisions

### DIFF
--- a/src/cli/skill-validation.test.ts
+++ b/src/cli/skill-validation.test.ts
@@ -30,12 +30,16 @@ const registry: Registry = {
     },
     'release-manager': {
       display: 'Release manager workflow',
-      path: '.cursor/skills/release-manager/SKILL.md',
+      path: 'skills/shared-skill.md',
       conflicts_with: ['code-review']
     },
     'bad-path': {
       display: 'Invalid path skill',
       path: '.cursor/skills/other-id/SKILL.md'
+    },
+    'duplicate-path': {
+      display: 'Duplicate path skill',
+      path: 'skills/shared-skill.md'
     }
   }
 };
@@ -147,5 +151,19 @@ test('validateSkillSelection rejects non-canonical local skill paths', () => {
         targets: ['cursor']
       }),
     /Skill path convention mismatch: bad-path must use \.cursor\/skills\/bad-path\/SKILL\.md, got \.cursor\/skills\/other-id\/SKILL\.md/
+  );
+});
+
+test('validateSkillSelection rejects source path collisions', () => {
+  assert.throws(
+    () =>
+      validateSkillSelection({
+        registry,
+        skills: ['release-manager', 'duplicate-path'],
+        language: 'typescript',
+        modules: ['eslint'],
+        targets: ['cursor']
+      }),
+    /Skill source collision: release-manager and duplicate-path map to skills\/shared-skill\.md/
   );
 });

--- a/src/cli/skill-validation.ts
+++ b/src/cli/skill-validation.ts
@@ -22,6 +22,7 @@ export function validateSkillSelection({
   const selected = uniqueList(skills || []);
   const selectedSet = new Set(selected);
   const registrySkills = registry.skills || {};
+  const selectedSourcePaths = new Map<string, string>();
 
   for (const skillId of selected) {
     const skillDef = registrySkills[skillId];
@@ -33,6 +34,12 @@ export function validateSkillSelection({
         `Skill path convention mismatch: ${skillId} must use ${localCustomSkillPath(skillId)}, got ${normalizeRelativeSkillPath(skillDef.path)}`
       );
     }
+    const sourcePath = normalizeRelativeSkillPath(skillDef.path);
+    const existingOwner = selectedSourcePaths.get(sourcePath);
+    if (existingOwner && existingOwner !== skillId) {
+      throw new Error(`Skill source collision: ${existingOwner} and ${skillId} map to ${sourcePath}`);
+    }
+    selectedSourcePaths.set(sourcePath, skillId);
 
     for (const dependency of skillDef.requires || []) {
       if (!selectedSet.has(dependency)) {

--- a/src/cli/workspace-assets.test.ts
+++ b/src/cli/workspace-assets.test.ts
@@ -28,6 +28,10 @@ const registry: Registry = {
     'legacy-skill': {
       display: 'Legacy skill',
       path: '.cursor/skills/legacy-skill/SKILL.md'
+    },
+    'custom-only': {
+      display: 'Custom only skill',
+      path: '.cursor/skills/custom-only/SKILL.md'
     }
   }
 };
@@ -159,5 +163,23 @@ test('ensureWorkspaceAssets prefers local custom skill over package source', asy
   assert.equal(
     await fs.readFile(path.join(workspaceDir, '.ailib/skills/task-driven-gh-flow.md'), 'utf8'),
     'workspace-local-skill'
+  );
+});
+
+test('ensureWorkspaceAssets fails with actionable message for missing local custom skill source', async () => {
+  const rootDir = await tempDir();
+  const workspaceDir = path.join(rootDir, 'apps/api');
+  const packageRoot = path.join(rootDir, 'pkg');
+  await seedPackage(packageRoot);
+
+  await assert.rejects(
+    ensureWorkspaceAssets({
+      workspaceDir,
+      packageRoot,
+      state: state([], ['custom-only']),
+      rootDir,
+      registry
+    }),
+    /Missing local custom skill source: custom-only/
   );
 });

--- a/src/cli/workspace-assets.ts
+++ b/src/cli/workspace-assets.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { copySourceFile } from './file-helpers.ts';
-import { localCustomSkillPath } from './skill-paths.ts';
+import { isUnderLocalCustomSkillsRoot, localCustomSkillPath } from './skill-paths.ts';
 import { exists, rmIfExists } from './utils.ts';
 import type { Registry, WorkspaceState } from './types.ts';
 
@@ -96,7 +96,15 @@ export async function ensureWorkspaceAssets({
     }
 
     const existing = path.join(outRoot, 'skills', `${skillId}.md`);
-    ensure(await exists(existing), `Missing skill source: ${sourceRel}`);
+    if (await exists(existing)) continue;
+
+    if (isUnderLocalCustomSkillsRoot(sourceRel)) {
+      throw new Error(
+        `Missing local custom skill source: ${skillId} (checked ${localCustomSkillPath(skillId)} in workspace and root)`
+      );
+    }
+
+    ensure(false, `Missing skill source: ${sourceRel}`);
   }
 
   const skillDir = path.join(outRoot, 'skills');


### PR DESCRIPTION
## Summary
- fail fast when selected skills resolve to the same source path
- emit explicit diagnostics when local custom skill sources are missing
- add coverage for collision and missing-source diagnostic paths

## Test plan
- [x] `bun test src/cli/skill-validation.test.ts src/cli/workspace-assets.test.ts`
- [x] `bun run check`

Refs #150
Closes #150

Made with [Cursor](https://cursor.com)