### PR TITLE
test: add override precedence regression tests

### DIFF
--- a/src/cli/workspace-assets.test.ts
+++ b/src/cli/workspace-assets.test.ts
@@ -166,6 +166,28 @@ test('ensureWorkspaceAssets prefers local custom skill over package source', asy
   );
 });
 
+test('ensureWorkspaceAssets prefers root local custom skill over package source', async () => {
+  const rootDir = await tempDir();
+  const workspaceDir = path.join(rootDir, 'apps/api');
+  const packageRoot = path.join(rootDir, 'pkg');
+  await seedPackage(packageRoot);
+  await fs.mkdir(path.join(rootDir, '.cursor/skills/task-driven-gh-flow'), { recursive: true });
+  await fs.writeFile(path.join(rootDir, '.cursor/skills/task-driven-gh-flow/SKILL.md'), 'root-local-skill', 'utf8');
+
+  await ensureWorkspaceAssets({
+    workspaceDir,
+    packageRoot,
+    state: state([], ['task-driven-gh-flow']),
+    rootDir,
+    registry
+  });
+
+  assert.equal(
+    await fs.readFile(path.join(workspaceDir, '.ailib/skills/task-driven-gh-flow.md'), 'utf8'),
+    'root-local-skill'
+  );
+});
+
 test('ensureWorkspaceAssets fails with actionable message for missing local custom skill source', async () => {
   const rootDir = await tempDir();
   const workspaceDir = path.join(rootDir, 'apps/api');

--- a/src/cli/workspace-state.test.ts
+++ b/src/cli/workspace-state.test.ts
@@ -227,6 +227,63 @@ test('applyLocalOverrides applies skills set/add/remove scopes', async () => {
   assert.deepEqual(result.skills, ['code-review']);
 });
 
+test('applyLocalOverrides applies deterministic precedence for default and workspace skill scopes', async () => {
+  const rootDir = await tempDir();
+  const workspaceDir = path.join(rootDir, 'apps/web');
+  const rootWithWorkspaces: WorkspaceConfig = {
+    ...rootConfig,
+    workspaces: ['apps/*']
+  };
+  await fs.mkdir(workspaceDir, { recursive: true });
+  await fs.writeFile(path.join(rootDir, configFile), `${JSON.stringify(rootWithWorkspaces, null, 2)}\n`, 'utf8');
+  await fs.writeFile(
+    path.join(workspaceDir, configFile),
+    `${JSON.stringify({ language: 'typescript', modules: ['eslint'], targets: ['cursor'] }, null, 2)}\n`,
+    'utf8'
+  );
+  await fs.writeFile(
+    path.join(rootDir, localOverrideFile),
+    `${JSON.stringify(
+      {
+        version: '1',
+        default_override: {
+          skills: {
+            set: ['task-driven-gh-flow'],
+            add: ['code-review']
+          }
+        },
+        workspace_overrides: {
+          'apps/web': {
+            skills: {
+              set: ['code-review'],
+              add: ['task-driven-gh-flow'],
+              remove: ['code-review']
+            }
+          }
+        }
+      },
+      null,
+      2
+    )}\n`,
+    'utf8'
+  );
+
+  const result = await applyLocalOverrides({
+    rootDir,
+    workspaceDir,
+    rootConfig: rootWithWorkspaces,
+    registry,
+    language: 'typescript',
+    modules: ['eslint'],
+    targets: ['cursor'],
+    skills: ['task-driven-gh-flow'],
+    canonicalSlot,
+    localOverrideFile
+  });
+
+  assert.deepEqual(result.skills, ['task-driven-gh-flow']);
+});
+
 test('getEffectiveWorkspaceConfig falls back to base modules and targets for root workspace', async () => {
   const rootDir = await tempDir();
   const rootConfigFromCaller: WorkspaceConfig = {


### PR DESCRIPTION
## Summary
- add regression coverage that root-local custom skill files win over package skill sources when workspace-local files are absent
- add regression coverage for deterministic `skills` override precedence across `default_override` and `workspace_overrides`

## Test plan
- [x] bun test src/cli/workspace-assets.test.ts src/cli/workspace-state.test.ts
- [x] bun run check

Refs #151
Closes #151

Made with [Cursor](https://cursor.com)