### PR TITLE
feat: add skills init cli command

### DIFF
--- a/src/cli/command-handlers.test.ts
+++ b/src/cli/command-handlers.test.ts
@@ -20,7 +20,8 @@ test('createCommandHandlers wires calls to provided runners', async () => {
     doctorCommand: async () => void calls.push('doctor'),
     uninstallCommand: async () => void calls.push('uninstall'),
     slotsCommand: async () => void calls.push('slots'),
-    modulesCommand: async () => void calls.push('modules')
+    modulesCommand: async () => void calls.push('modules'),
+    skillsCommand: async () => void calls.push('skills')
   };
 
   const handlers = createCommandHandlers({
@@ -40,6 +41,7 @@ test('createCommandHandlers wires calls to provided runners', async () => {
   await handlers.uninstall(context);
   await handlers.slots(context);
   await handlers.modules(context);
+  await handlers.skills(context);
 
-  assert.deepEqual(calls, ['init', 'update', 'add', 'remove', 'doctor', 'uninstall', 'slots', 'modules']);
+  assert.deepEqual(calls, ['init', 'update', 'add', 'remove', 'doctor', 'uninstall', 'slots', 'modules', 'skills']);
 });

--- a/src/cli/command-handlers.ts
+++ b/src/cli/command-handlers.ts
@@ -7,6 +7,7 @@ import {
   removeCommand as runRemoveCommand,
   updateCommand as runUpdateCommand
 } from './module-mutations.ts';
+import { skillsCommand as runSkillsCommand } from './skills.ts';
 import { uninstallCommand as runUninstallCommand } from './uninstall.ts';
 
 export type CanonicalSlotResolver = (registry: Registry, slot: string | undefined) => string | null;
@@ -26,6 +27,7 @@ type Runners = {
   uninstallCommand: typeof runUninstallCommand;
   slotsCommand: typeof runSlotsCommand;
   modulesCommand: typeof runModulesCommand;
+  skillsCommand: typeof runSkillsCommand;
 };
 
 const DEFAULT_RUNNERS: Runners = {
@@ -36,7 +38,8 @@ const DEFAULT_RUNNERS: Runners = {
   doctorCommand: runDoctorCommand,
   uninstallCommand: runUninstallCommand,
   slotsCommand: runSlotsCommand,
-  modulesCommand: runModulesCommand
+  modulesCommand: runModulesCommand,
+  skillsCommand: runSkillsCommand
 };
 
 export function createCommandHandlers({
@@ -112,6 +115,7 @@ export function createCommandHandlers({
           applyWorkspaceUpdate({ packageRoot: rootPackage, rootDir, forceOnConflict })
       }),
     slots: async ({ packageRoot, flags }: CommandContext) => runners.slotsCommand({ packageRoot, flags }),
-    modules: async ({ packageRoot, flags }: CommandContext) => runners.modulesCommand({ packageRoot, flags })
+    modules: async ({ packageRoot, flags }: CommandContext) => runners.modulesCommand({ packageRoot, flags }),
+    skills: async ({ cwd, flags }: CommandContext) => runners.skillsCommand({ cwd, flags })
   };
 }

--- a/src/cli/help.test.ts
+++ b/src/cli/help.test.ts
@@ -30,4 +30,5 @@ test('printHelp renders expected command listing', () => {
   assert.match(output, /ailib commands:/);
   assert.match(output, /ailib init/);
   assert.match(output, /ailib modules explain <module>/);
+  assert.match(output, /ailib skills init <skill-id>/);
 });

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -9,6 +9,7 @@ export function printHelp() {
       '  ailib uninstall [--all]\n' +
       '  ailib slots list\n' +
       '  ailib modules list [--language=<lang>]\n' +
-      '  ailib modules explain <module> [--language=<lang>]\n'
+      '  ailib modules explain <module> [--language=<lang>]\n' +
+      '  ailib skills init <skill-id> [--workspace=<path>] [--path=<path>] [--description=<text>] [--force]\n'
   );
 }

--- a/src/cli/skills.test.ts
+++ b/src/cli/skills.test.ts
@@ -1,0 +1,94 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { skillsCommand } from './skills.ts';
+
+async function tempDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'ailib-skills-command-'));
+}
+
+test('skillsCommand rejects unsupported subcommands', async () => {
+  await assert.rejects(
+    skillsCommand({ cwd: process.cwd(), flags: { _: ['unknown'] } }),
+    /Usage: ailib skills init <skill-id>/
+  );
+});
+
+test('skillsCommand scaffolds default skill path', async () => {
+  const cwd = await tempDir();
+  await fs.writeFile(path.join(cwd, 'package.json'), '{"name":"tmp"}\n', 'utf8');
+
+  await skillsCommand({
+    cwd,
+    flags: { _: ['init', 'task-driven-gh-flow'] }
+  });
+
+  const content = await fs.readFile(path.join(cwd, '.cursor/skills/task-driven-gh-flow/SKILL.md'), 'utf8');
+  assert.match(content, /name: task-driven-gh-flow/);
+  assert.match(content, /description: TODO: describe this skill/);
+});
+
+test('skillsCommand scaffolds using custom path and description', async () => {
+  const cwd = await tempDir();
+  await fs.writeFile(path.join(cwd, 'package.json'), '{"name":"tmp"}\n', 'utf8');
+
+  await skillsCommand({
+    cwd,
+    flags: {
+      _: ['init', 'release-manager'],
+      path: '.cursor/skills/custom-release',
+      description: 'Release workflow automation'
+    }
+  });
+
+  const content = await fs.readFile(path.join(cwd, '.cursor/skills/custom-release/SKILL.md'), 'utf8');
+  assert.match(content, /name: release-manager/);
+  assert.match(content, /description: Release workflow automation/);
+});
+
+test('skillsCommand rejects invalid skill id and existing files without force', async () => {
+  const cwd = await tempDir();
+  await fs.writeFile(path.join(cwd, 'package.json'), '{"name":"tmp"}\n', 'utf8');
+
+  await assert.rejects(skillsCommand({ cwd, flags: { _: ['init', 'BadId'] } }), /Invalid skill id: BadId/);
+
+  await skillsCommand({ cwd, flags: { _: ['init', 'code-review'] } });
+  await assert.rejects(
+    skillsCommand({ cwd, flags: { _: ['init', 'code-review'] } }),
+    /Skill file already exists: .*Re-run with --force to overwrite/
+  );
+
+  await skillsCommand({
+    cwd,
+    flags: { _: ['init', 'code-review'], force: true, description: 'Overwritten content' }
+  });
+  const content = await fs.readFile(path.join(cwd, '.cursor/skills/code-review/SKILL.md'), 'utf8');
+  assert.match(content, /description: Overwritten content/);
+});
+
+test('skillsCommand supports --workspace targeting and blocks path escapes', async () => {
+  const root = await tempDir();
+  await fs.writeFile(path.join(root, 'package.json'), '{"name":"tmp"}\n', 'utf8');
+  const workspace = path.join(root, 'apps/web');
+  await fs.mkdir(workspace, { recursive: true });
+  await fs.writeFile(path.join(workspace, 'ailib.config.json'), '{"language":"typescript"}\n', 'utf8');
+
+  await skillsCommand({
+    cwd: root,
+    flags: { _: ['init', 'triage'], workspace: 'apps/web' }
+  });
+
+  const scaffoldPath = path.join(workspace, '.cursor/skills/triage/SKILL.md');
+  const content = await fs.readFile(scaffoldPath, 'utf8');
+  assert.match(content, /name: triage/);
+
+  await assert.rejects(
+    skillsCommand({
+      cwd: root,
+      flags: { _: ['init', 'escape-test'], workspace: 'apps/web', path: '../outside' }
+    }),
+    /Skill path must be within workspace/
+  );
+});

--- a/src/cli/skills.ts
+++ b/src/cli/skills.ts
@@ -1,0 +1,92 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { ensure } from './assertions.ts';
+import { resolveContext, resolveDefaultWorkspaceForMutation } from './context-resolution.ts';
+import { getStringFlag } from './flags.ts';
+import type { CliFlags } from './types.ts';
+
+const DEFAULT_SKILL_DESCRIPTION = 'TODO: describe this skill';
+const SKILL_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+export async function skillsCommand({ cwd, flags }: { cwd: string; flags: CliFlags }) {
+  const sub = flags._[0];
+  if (sub === 'init') {
+    await skillsInitCommand({ cwd, flags });
+    return;
+  }
+  throw new Error(
+    'Usage: ailib skills init <skill-id> [--workspace=<path>] [--path=<path>] [--description=<text>] [--force]'
+  );
+}
+
+export async function skillsInitCommand({ cwd, flags }: { cwd: string; flags: CliFlags }) {
+  const skillId = flags._[1];
+  ensure(
+    skillId,
+    'Usage: ailib skills init <skill-id> [--workspace=<path>] [--path=<path>] [--description=<text>] [--force]'
+  );
+  ensure(SKILL_ID_RE.test(skillId), `Invalid skill id: ${skillId}`);
+
+  const context = await resolveContext(cwd);
+  const workspaceFlag = getStringFlag(flags, 'workspace');
+  const targetWorkspace = resolveDefaultWorkspaceForMutation(context, workspaceFlag);
+  const pathFlag = getStringFlag(flags, 'path');
+  const description = getStringFlag(flags, 'description') || DEFAULT_SKILL_DESCRIPTION;
+  const force = flags.force === true;
+
+  const target = resolveSkillFilePath({ targetWorkspace, skillId, pathFlag });
+  assertPathUnderWorkspace({ targetWorkspace, target });
+
+  await fs.mkdir(path.dirname(target), { recursive: true });
+
+  if (!force) {
+    try {
+      await fs.access(target);
+      throw new Error(`Skill file already exists: ${target}. Re-run with --force to overwrite.`);
+    } catch (error) {
+      if (!(error instanceof Error) || !('code' in error) || error.code !== 'ENOENT') throw error;
+    }
+  }
+
+  await fs.writeFile(target, renderSkillTemplate({ skillId, description }), 'utf8');
+  process.stdout.write(`skill scaffolded: ${skillId} -> ${target}\n`);
+}
+
+export function resolveSkillFilePath({
+  targetWorkspace,
+  skillId,
+  pathFlag
+}: {
+  targetWorkspace: string;
+  skillId: string;
+  pathFlag: string | undefined;
+}) {
+  if (!pathFlag) return path.join(targetWorkspace, '.cursor/skills', skillId, 'SKILL.md');
+
+  const resolved = path.isAbsolute(pathFlag) ? path.resolve(pathFlag) : path.resolve(targetWorkspace, pathFlag);
+  if (path.basename(resolved).toLowerCase() === 'skill.md') return resolved;
+  return path.join(resolved, 'SKILL.md');
+}
+
+function assertPathUnderWorkspace({ targetWorkspace, target }: { targetWorkspace: string; target: string }) {
+  const rel = path.relative(path.resolve(targetWorkspace), path.resolve(target));
+  ensure(!rel.startsWith('..') && !path.isAbsolute(rel), `Skill path must be within workspace: ${targetWorkspace}`);
+}
+
+function renderSkillTemplate({ skillId, description }: { skillId: string; description: string }) {
+  return [
+    '---',
+    `name: ${skillId}`,
+    `description: ${description}`,
+    '---',
+    '',
+    `# ${skillId}`,
+    '',
+    '## Purpose',
+    '- TODO: describe when to use this skill',
+    '',
+    '## Workflow',
+    '- TODO: add concrete implementation steps',
+    ''
+  ].join('\n');
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -296,6 +296,32 @@ test('add and remove enforce module argument', async () => {
   await assert.rejects(run(['remove'], { cwd: root, packageRoot }), /Usage: ailib remove <module>/);
 });
 
+test('skills init scaffolds skill file in target workspace', async () => {
+  const root = await makeMonorepo();
+  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code', '--on-conflict=overwrite'], {
+    cwd: root,
+    packageRoot
+  });
+  await run(['init', '--language=typescript', '--modules=biome', '--targets=claude-code'], {
+    cwd: path.join(root, 'apps', 'web'),
+    packageRoot
+  });
+
+  await run(
+    ['skills', 'init', 'release-manager', '--workspace=apps/web', '--description=Release orchestration workflow'],
+    {
+      cwd: root,
+      packageRoot
+    }
+  );
+
+  const skillPath = path.join(root, 'apps', 'web', '.cursor', 'skills', 'release-manager', 'SKILL.md');
+  assert.equal(await exists(skillPath), true);
+  const content = await fs.readFile(skillPath, 'utf8');
+  assert.match(content, /name: release-manager/);
+  assert.match(content, /description: Release orchestration workflow/);
+});
+
 test('doctor validates all workspaces and keeps healthy status', async () => {
   const root = await makeMonorepo();
   await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code', '--on-conflict=overwrite'], {


### PR DESCRIPTION
## Summary
- add `ailib skills init` command with skill-id validation and options parsing for `--workspace`, `--path`, `--description`, and `--force`
- scaffold `SKILL.md` output with a standard frontmatter/template shape while blocking path escapes outside the target workspace
- wire command routing/help output and add unit + integration coverage for the new command behavior

## Test plan
- [x] bun test src/cli/skills.test.ts src/cli/command-handlers.test.ts src/cli/help.test.ts test/cli.test.ts
- [x] bun run check

Refs #154
Closes #154

Made with [Cursor](https://cursor.com)