### PR TITLE
feat: extract skill template generator

### DIFF
--- a/src/cli/skill-template.test.ts
+++ b/src/cli/skill-template.test.ts
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { DEFAULT_SKILL_DESCRIPTION, renderSkillTemplate } from './skill-template.ts';
+
+test('renderSkillTemplate builds expected default scaffold', () => {
+  const rendered = renderSkillTemplate({ skillId: 'task-driven-gh-flow' });
+  assert.equal(
+    rendered,
+    [
+      '---',
+      'name: task-driven-gh-flow',
+      `description: ${DEFAULT_SKILL_DESCRIPTION}`,
+      '---',
+      '',
+      '# task-driven-gh-flow',
+      '',
+      '## Purpose',
+      '- TODO: describe when to use this skill',
+      '',
+      '## Workflow',
+      '- TODO: add concrete implementation steps',
+      ''
+    ].join('\n')
+  );
+});
+
+test('renderSkillTemplate uses explicit description when provided', () => {
+  const rendered = renderSkillTemplate({
+    skillId: 'release-manager',
+    description: 'Automate release checklists'
+  });
+  assert.match(rendered, /name: release-manager/);
+  assert.match(rendered, /description: Automate release checklists/);
+});

--- a/src/cli/skill-template.ts
+++ b/src/cli/skill-template.ts
@@ -1,0 +1,20 @@
+export const DEFAULT_SKILL_DESCRIPTION = 'TODO: describe this skill';
+
+export function renderSkillTemplate({ skillId, description }: { skillId: string; description?: string }) {
+  const resolvedDescription = description || DEFAULT_SKILL_DESCRIPTION;
+  return [
+    '---',
+    `name: ${skillId}`,
+    `description: ${resolvedDescription}`,
+    '---',
+    '',
+    `# ${skillId}`,
+    '',
+    '## Purpose',
+    '- TODO: describe when to use this skill',
+    '',
+    '## Workflow',
+    '- TODO: add concrete implementation steps',
+    ''
+  ].join('\n');
+}

--- a/src/cli/skills.ts
+++ b/src/cli/skills.ts
@@ -3,9 +3,9 @@ import path from 'node:path';
 import { ensure } from './assertions.ts';
 import { resolveContext, resolveDefaultWorkspaceForMutation } from './context-resolution.ts';
 import { getStringFlag } from './flags.ts';
+import { renderSkillTemplate } from './skill-template.ts';
 import type { CliFlags } from './types.ts';
 
-const DEFAULT_SKILL_DESCRIPTION = 'TODO: describe this skill';
 const SKILL_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
 
 export async function skillsCommand({ cwd, flags }: { cwd: string; flags: CliFlags }) {
@@ -31,7 +31,7 @@ export async function skillsInitCommand({ cwd, flags }: { cwd: string; flags: Cl
   const workspaceFlag = getStringFlag(flags, 'workspace');
   const targetWorkspace = resolveDefaultWorkspaceForMutation(context, workspaceFlag);
   const pathFlag = getStringFlag(flags, 'path');
-  const description = getStringFlag(flags, 'description') || DEFAULT_SKILL_DESCRIPTION;
+  const description = getStringFlag(flags, 'description');
   const force = flags.force === true;
 
   const target = resolveSkillFilePath({ targetWorkspace, skillId, pathFlag });
@@ -71,22 +71,4 @@ export function resolveSkillFilePath({
 function assertPathUnderWorkspace({ targetWorkspace, target }: { targetWorkspace: string; target: string }) {
   const rel = path.relative(path.resolve(targetWorkspace), path.resolve(target));
   ensure(!rel.startsWith('..') && !path.isAbsolute(rel), `Skill path must be within workspace: ${targetWorkspace}`);
-}
-
-function renderSkillTemplate({ skillId, description }: { skillId: string; description: string }) {
-  return [
-    '---',
-    `name: ${skillId}`,
-    `description: ${description}`,
-    '---',
-    '',
-    `# ${skillId}`,
-    '',
-    '## Purpose',
-    '- TODO: describe when to use this skill',
-    '',
-    '## Workflow',
-    '- TODO: add concrete implementation steps',
-    ''
-  ].join('\n');
 }


### PR DESCRIPTION
## Summary
- extract SKILL scaffold generation into a dedicated template module for clearer reuse and isolated testability
- keep `skills init` behavior unchanged while routing generation through the shared renderer
- add focused template tests for default description fallback and explicit description output

## Test plan
- [x] bun test src/cli/skill-template.test.ts src/cli/skills.test.ts src/cli/command-handlers.test.ts src/cli/help.test.ts test/cli.test.ts
- [x] bun run check

Refs #155
Closes #155

Made with [Cursor](https://cursor.com)