### PR TITLE
feat: add skills validate command

### DIFF
--- a/src/cli/help.test.ts
+++ b/src/cli/help.test.ts
@@ -31,4 +31,5 @@ test('printHelp renders expected command listing', () => {
   assert.match(output, /ailib init/);
   assert.match(output, /ailib modules explain <module>/);
   assert.match(output, /ailib skills init <skill-id>/);
+  assert.match(output, /ailib skills validate/);
 });

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -10,6 +10,7 @@ export function printHelp() {
       '  ailib slots list\n' +
       '  ailib modules list [--language=<lang>]\n' +
       '  ailib modules explain <module> [--language=<lang>]\n' +
-      '  ailib skills init <skill-id> [--workspace=<path>] [--path=<path>] [--description=<text>] [--force]\n'
+      '  ailib skills init <skill-id> [--workspace=<path>] [--path=<path>] [--description=<text>] [--force]\n' +
+      '  ailib skills validate [--workspace=<path>] [--path=<path>]\n'
   );
 }

--- a/src/cli/skills-validate.test.ts
+++ b/src/cli/skills-validate.test.ts
@@ -1,0 +1,88 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { skillsValidateCommand, validateSkillFile } from './skills-validate.ts';
+
+async function tempDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'ailib-skills-validate-'));
+}
+
+test('validateSkillFile accepts valid skill markdown', () => {
+  const issues = validateSkillFile({
+    file: '/tmp/SKILL.md',
+    content: [
+      '---',
+      'name: code-review',
+      'description: Validate pull request quality',
+      'compatible_languages: [typescript,python]',
+      '---',
+      '',
+      '# code-review',
+      '',
+      '## Purpose',
+      '- Review risky changes',
+      '',
+      '## Workflow',
+      '- Check tests and edge cases',
+      ''
+    ].join('\n')
+  });
+  assert.deepEqual(issues, []);
+});
+
+test('validateSkillFile returns actionable errors for malformed content', () => {
+  const issues = validateSkillFile({
+    file: '/tmp/SKILL.md',
+    content: ['---', 'name: ', 'description: ', 'compatible_targets: cursor', '---', '', '# broken skill'].join('\n')
+  });
+  assert.match(issues.join('\n'), /frontmatter 'name' must be a non-empty string/);
+  assert.match(issues.join('\n'), /frontmatter 'description' must be a non-empty string/);
+  assert.match(issues.join('\n'), /missing required section '## Purpose'/);
+  assert.match(issues.join('\n'), /missing required section '## Workflow'/);
+  assert.match(issues.join('\n'), /frontmatter 'compatible_targets' must be a list like \[a,b\]/);
+});
+
+test('skillsValidateCommand validates all workspace skill files', async () => {
+  const root = await tempDir();
+  await fs.writeFile(path.join(root, 'package.json'), '{"name":"tmp"}\n', 'utf8');
+  const skillDir = path.join(root, '.cursor/skills/release-manager');
+  await fs.mkdir(skillDir, { recursive: true });
+  await fs.writeFile(
+    path.join(skillDir, 'SKILL.md'),
+    [
+      '---',
+      'name: release-manager',
+      'description: Manage release flow',
+      '---',
+      '',
+      '# release-manager',
+      '',
+      '## Purpose',
+      '- Keep releases stable',
+      '',
+      '## Workflow',
+      '- Prepare checklist',
+      ''
+    ].join('\n'),
+    'utf8'
+  );
+
+  await skillsValidateCommand({
+    cwd: root,
+    flags: { _: ['validate'] }
+  });
+});
+
+test('skillsValidateCommand fails when no skill files are present', async () => {
+  const root = await tempDir();
+  await fs.writeFile(path.join(root, 'package.json'), '{"name":"tmp"}\n', 'utf8');
+  await assert.rejects(
+    skillsValidateCommand({
+      cwd: root,
+      flags: { _: ['validate'] }
+    }),
+    /No skill files found/
+  );
+});

--- a/src/cli/skills-validate.ts
+++ b/src/cli/skills-validate.ts
@@ -1,0 +1,107 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { ensure } from './assertions.ts';
+import { resolveContext, resolveDefaultWorkspaceForMutation } from './context-resolution.ts';
+import { getStringFlag } from './flags.ts';
+import { parseFrontmatter } from './file-helpers.ts';
+import type { CliFlags } from './types.ts';
+
+const REQUIRED_SECTIONS = ['Purpose', 'Workflow'] as const;
+const COMPATIBILITY_KEYS = [
+  'compatible_languages',
+  'compatible_modules',
+  'compatible_targets',
+  'compatible_llms'
+] as const;
+
+export async function skillsValidateCommand({ cwd, flags }: { cwd: string; flags: CliFlags }) {
+  const context = await resolveContext(cwd);
+  const workspaceFlag = getStringFlag(flags, 'workspace');
+  const targetWorkspace = resolveDefaultWorkspaceForMutation(context, workspaceFlag);
+  const pathFlag = getStringFlag(flags, 'path');
+  const targetPath = pathFlag
+    ? path.isAbsolute(pathFlag)
+      ? path.resolve(pathFlag)
+      : path.resolve(targetWorkspace, pathFlag)
+    : path.join(targetWorkspace, '.cursor/skills');
+
+  const files = await collectSkillFiles(targetPath);
+  ensure(files.length > 0, `No skill files found at: ${targetPath}`);
+
+  const issues: string[] = [];
+  for (const file of files) {
+    const content = await fs.readFile(file, 'utf8');
+    issues.push(...validateSkillFile({ file, content }));
+  }
+
+  if (issues.length > 0) {
+    throw new Error(`skills validate failed:\n- ${issues.join('\n- ')}`);
+  }
+
+  process.stdout.write(`skills validate ok (${files.length} file${files.length === 1 ? '' : 's'})\n`);
+}
+
+export function validateSkillFile({ file, content }: { file: string; content: string }) {
+  const issues: string[] = [];
+  const frontmatter = parseFrontmatter(content);
+
+  if (!frontmatter) {
+    return [`${file}: missing frontmatter`];
+  }
+
+  const name = frontmatter.name;
+  if (typeof name !== 'string' || !name.trim()) {
+    issues.push(`${file}: frontmatter 'name' must be a non-empty string`);
+  }
+
+  const description = frontmatter.description;
+  if (typeof description !== 'string' || !description.trim()) {
+    issues.push(`${file}: frontmatter 'description' must be a non-empty string`);
+  }
+
+  for (const heading of REQUIRED_SECTIONS) {
+    if (!new RegExp(`^## ${heading}\\s*$`, 'm').test(content)) {
+      issues.push(`${file}: missing required section '## ${heading}'`);
+    }
+  }
+
+  for (const key of COMPATIBILITY_KEYS) {
+    const value = frontmatter[key];
+    if (value === undefined) continue;
+    if (!Array.isArray(value)) {
+      issues.push(`${file}: frontmatter '${key}' must be a list like [a,b]`);
+      continue;
+    }
+    if (value.length === 0 || value.some((entry) => !entry.trim())) {
+      issues.push(`${file}: frontmatter '${key}' must include at least one value`);
+    }
+  }
+
+  return issues;
+}
+
+async function collectSkillFiles(targetPath: string): Promise<string[]> {
+  try {
+    const stat = await fs.stat(targetPath);
+    if (stat.isFile()) return path.basename(targetPath).toLowerCase() === 'skill.md' ? [targetPath] : [];
+    if (!stat.isDirectory()) return [];
+  } catch {
+    return [];
+  }
+
+  const files: string[] = [];
+  await walkDir(targetPath, files);
+  return files.filter((file) => path.basename(file).toLowerCase() === 'skill.md').sort((a, b) => a.localeCompare(b));
+}
+
+async function walkDir(dir: string, files: string[]) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await walkDir(full, files);
+      continue;
+    }
+    if (entry.isFile()) files.push(full);
+  }
+}

--- a/src/cli/skills.test.ts
+++ b/src/cli/skills.test.ts
@@ -12,7 +12,7 @@ async function tempDir() {
 test('skillsCommand rejects unsupported subcommands', async () => {
   await assert.rejects(
     skillsCommand({ cwd: process.cwd(), flags: { _: ['unknown'] } }),
-    /Usage: ailib skills init <skill-id>/
+    /Usage: ailib skills init <skill-id>.*ailib skills validate/s
   );
 });
 

--- a/src/cli/skills.ts
+++ b/src/cli/skills.ts
@@ -4,6 +4,7 @@ import { ensure } from './assertions.ts';
 import { resolveContext, resolveDefaultWorkspaceForMutation } from './context-resolution.ts';
 import { getStringFlag } from './flags.ts';
 import { renderSkillTemplate } from './skill-template.ts';
+import { skillsValidateCommand } from './skills-validate.ts';
 import type { CliFlags } from './types.ts';
 
 const SKILL_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
@@ -14,8 +15,12 @@ export async function skillsCommand({ cwd, flags }: { cwd: string; flags: CliFla
     await skillsInitCommand({ cwd, flags });
     return;
   }
+  if (sub === 'validate') {
+    await skillsValidateCommand({ cwd, flags });
+    return;
+  }
   throw new Error(
-    'Usage: ailib skills init <skill-id> [--workspace=<path>] [--path=<path>] [--description=<text>] [--force]'
+    'Usage: ailib skills init <skill-id> [--workspace=<path>] [--path=<path>] [--description=<text>] [--force] | ailib skills validate [--workspace=<path>] [--path=<path>]'
   );
 }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -322,6 +322,30 @@ test('skills init scaffolds skill file in target workspace', async () => {
   assert.match(content, /description: Release orchestration workflow/);
 });
 
+test('skills validate reports workspace skill quality issues', async () => {
+  const root = await makeMonorepo();
+  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code', '--on-conflict=overwrite'], {
+    cwd: root,
+    packageRoot
+  });
+  await run(['init', '--language=typescript', '--modules=biome', '--targets=claude-code'], {
+    cwd: path.join(root, 'apps', 'web'),
+    packageRoot
+  });
+  await run(['skills', 'init', 'release-manager', '--workspace=apps/web'], { cwd: root, packageRoot });
+
+  await run(['skills', 'validate', '--workspace=apps/web'], { cwd: root, packageRoot });
+
+  const invalid = path.join(root, 'apps', 'web', '.cursor', 'skills', 'broken', 'SKILL.md');
+  await fs.mkdir(path.dirname(invalid), { recursive: true });
+  await fs.writeFile(invalid, '---\nname: broken\n---\n# broken\n', 'utf8');
+
+  await assert.rejects(
+    run(['skills', 'validate', '--workspace=apps/web'], { cwd: root, packageRoot }),
+    /skills validate failed:/
+  );
+});
+
 test('doctor validates all workspaces and keeps healthy status', async () => {
   const root = await makeMonorepo();
   await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code', '--on-conflict=overwrite'], {


### PR DESCRIPTION
## Summary
- add `ailib skills validate` to audit skill files in a workspace or custom path and emit actionable diagnostics
- validate frontmatter (`name`, `description`), required section headings (`## Purpose`, `## Workflow`), and compatibility declaration shape
- extend help text and add unit + CLI integration coverage for success and failure paths

## Test plan
- [x] bun test src/cli/skills-validate.test.ts src/cli/skills.test.ts src/cli/help.test.ts test/cli.test.ts
- [x] bun run check

Refs #157
Closes #157

Made with [Cursor](https://cursor.com)