### PR TITLE
test: expand malformed skill validation coverage

### DIFF
--- a/src/cli/skills-validate.test.ts
+++ b/src/cli/skills-validate.test.ts
@@ -44,6 +44,37 @@ test('validateSkillFile returns actionable errors for malformed content', () => 
   assert.match(issues.join('\n'), /frontmatter 'compatible_targets' must be a list like \[a,b\]/);
 });
 
+test('validateSkillFile rejects missing frontmatter and empty compatibility lists', () => {
+  const noFrontmatter = validateSkillFile({
+    file: '/tmp/SKILL.md',
+    content: '# no frontmatter'
+  });
+  assert.match(noFrontmatter.join('\n'), /missing frontmatter/);
+
+  const malformedCompatibility = validateSkillFile({
+    file: '/tmp/SKILL.md',
+    content: [
+      '---',
+      'name: compatibility-check',
+      'description: Verify compatibility declarations',
+      'compatible_modules: []',
+      'compatible_targets: []',
+      '---',
+      '',
+      '# compatibility-check',
+      '',
+      '## Purpose',
+      '- Validate compatibility declarations',
+      '',
+      '## Workflow',
+      '- Run checks',
+      ''
+    ].join('\n')
+  });
+  assert.match(malformedCompatibility.join('\n'), /frontmatter 'compatible_modules' must include at least one value/);
+  assert.match(malformedCompatibility.join('\n'), /frontmatter 'compatible_targets' must include at least one value/);
+});
+
 test('skillsValidateCommand validates all workspace skill files', async () => {
   const root = await tempDir();
   await fs.writeFile(path.join(root, 'package.json'), '{"name":"tmp"}\n', 'utf8');
@@ -84,5 +115,56 @@ test('skillsValidateCommand fails when no skill files are present', async () => 
       flags: { _: ['validate'] }
     }),
     /No skill files found/
+  );
+});
+
+test('skillsValidateCommand supports validating a single SKILL.md path', async () => {
+  const root = await tempDir();
+  await fs.writeFile(path.join(root, 'package.json'), '{"name":"tmp"}\n', 'utf8');
+  const target = path.join(root, '.cursor/skills/code-review/SKILL.md');
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  await fs.writeFile(
+    target,
+    [
+      '---',
+      'name: code-review',
+      'description: Validate PR quality',
+      '---',
+      '',
+      '# code-review',
+      '',
+      '## Purpose',
+      '- Review risks',
+      '',
+      '## Workflow',
+      '- Report findings',
+      ''
+    ].join('\n'),
+    'utf8'
+  );
+
+  await skillsValidateCommand({
+    cwd: root,
+    flags: { _: ['validate'], path: target }
+  });
+});
+
+test('skillsValidateCommand aggregates malformed skill diagnostics', async () => {
+  const root = await tempDir();
+  await fs.writeFile(path.join(root, 'package.json'), '{"name":"tmp"}\n', 'utf8');
+
+  const first = path.join(root, '.cursor/skills/broken-a/SKILL.md');
+  const second = path.join(root, '.cursor/skills/broken-b/SKILL.md');
+  await fs.mkdir(path.dirname(first), { recursive: true });
+  await fs.mkdir(path.dirname(second), { recursive: true });
+  await fs.writeFile(first, ['---', 'name: broken-a', '---', '', '# broken-a'].join('\n'), 'utf8');
+  await fs.writeFile(second, '# no frontmatter', 'utf8');
+
+  await assert.rejects(
+    skillsValidateCommand({
+      cwd: root,
+      flags: { _: ['validate'] }
+    }),
+    /skills validate failed:\n- .*broken-a.*frontmatter 'description' must be a non-empty string[\s\S]*broken-b.*missing frontmatter/
   );
 });


### PR DESCRIPTION
## Summary
- expand skills validate test coverage for malformed frontmatter and compatibility declaration edge cases
- add explicit coverage for validating a single SKILL.md path via `--path`
- verify aggregated diagnostics behavior when multiple malformed skills are present

## Test plan
- [x] bun test src/cli/skills-validate.test.ts src/cli/skills.test.ts test/cli.test.ts
- [x] bun run check

Refs #158
Closes #158

Made with [Cursor](https://cursor.com)