### PR TITLE
feat: add skills discovery introspection

### DIFF
--- a/src/cli/command-handlers.ts
+++ b/src/cli/command-handlers.ts
@@ -116,6 +116,6 @@ export function createCommandHandlers({
       }),
     slots: async ({ packageRoot, flags }: CommandContext) => runners.slotsCommand({ packageRoot, flags }),
     modules: async ({ packageRoot, flags }: CommandContext) => runners.modulesCommand({ packageRoot, flags }),
-    skills: async ({ cwd, flags }: CommandContext) => runners.skillsCommand({ cwd, flags })
+    skills: async ({ cwd, packageRoot, flags }: CommandContext) => runners.skillsCommand({ cwd, packageRoot, flags })
   };
 }

--- a/src/cli/help.test.ts
+++ b/src/cli/help.test.ts
@@ -30,6 +30,8 @@ test('printHelp renders expected command listing', () => {
   assert.match(output, /ailib commands:/);
   assert.match(output, /ailib init/);
   assert.match(output, /ailib modules explain <module>/);
+  assert.match(output, /ailib skills list/);
+  assert.match(output, /ailib skills explain <skill-id>/);
   assert.match(output, /ailib skills init <skill-id>/);
   assert.match(output, /ailib skills validate/);
 });

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -10,6 +10,8 @@ export function printHelp() {
       '  ailib slots list\n' +
       '  ailib modules list [--language=<lang>]\n' +
       '  ailib modules explain <module> [--language=<lang>]\n' +
+      '  ailib skills list\n' +
+      '  ailib skills explain <skill-id>\n' +
       '  ailib skills init <skill-id> [--workspace=<path>] [--path=<path>] [--description=<text>] [--force]\n' +
       '  ailib skills validate [--workspace=<path>] [--path=<path>]\n'
   );

--- a/src/cli/introspection.test.ts
+++ b/src/cli/introspection.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { modulesCommand, slotsCommand } from './introspection.ts';
+import { modulesCommand, skillsCatalogCommand, slotsCommand } from './introspection.ts';
 import type { CliFlags, Registry } from './types.ts';
 
 async function tempDir() {
@@ -45,7 +45,22 @@ const registry: Registry = {
       }
     }
   },
-  targets: { cursor: { output: '.cursor/rules/ai.md' } }
+  targets: { cursor: { output: '.cursor/rules/ai.md' } },
+  skills: {
+    'task-driven-gh-flow': {
+      display: 'Task-driven GH flow',
+      path: '.cursor/skills/task-driven-gh-flow/SKILL.md',
+      description: 'Track and execute GH tasks',
+      requires: ['release-manager'],
+      conflicts_with: ['code-review'],
+      compatible: {
+        languages: ['typescript'],
+        modules: ['eslint'],
+        targets: ['cursor'],
+        llms: ['claude']
+      }
+    }
+  }
 };
 
 test('slotsCommand prints slot definitions', async () => {
@@ -75,5 +90,29 @@ test('modulesCommand explain throws for unknown module', async () => {
   await assert.rejects(
     modulesCommand({ packageRoot, flags: { _: ['explain', 'missing'], language: 'typescript' } as CliFlags }),
     /Unknown module for typescript: missing/
+  );
+});
+
+test('skillsCatalogCommand list and explain produce expected output', async () => {
+  const packageRoot = await withRegistry(registry);
+  const listOutput = await captureStdout(() =>
+    skillsCatalogCommand({ packageRoot, flags: { _: ['list'] } as CliFlags })
+  );
+  assert.match(listOutput, /skills:/);
+  assert.match(listOutput, /task-driven-gh-flow - Task-driven GH flow/);
+
+  const explainOutput = await captureStdout(() =>
+    skillsCatalogCommand({ packageRoot, flags: { _: ['explain', 'task-driven-gh-flow'] } as CliFlags })
+  );
+  assert.match(explainOutput, /skill: task-driven-gh-flow/);
+  assert.match(explainOutput, /path: \.cursor\/skills\/task-driven-gh-flow\/SKILL\.md/);
+  assert.match(explainOutput, /compatible.languages: typescript/);
+});
+
+test('skillsCatalogCommand explain throws for unknown skill', async () => {
+  const packageRoot = await withRegistry(registry);
+  await assert.rejects(
+    skillsCatalogCommand({ packageRoot, flags: { _: ['explain', 'missing'] } as CliFlags }),
+    /Unknown skill: missing/
   );
 });

--- a/src/cli/introspection.ts
+++ b/src/cli/introspection.ts
@@ -73,6 +73,46 @@ export async function modulesCommand({ packageRoot, flags }: { packageRoot: stri
   throw new Error('Usage: ailib modules list [--language=<lang>] | ailib modules explain <module> [--language=<lang>]');
 }
 
+export async function skillsCatalogCommand({ packageRoot, flags }: { packageRoot: string; flags: CliFlags }) {
+  const sub = flags._[0];
+  const registry = await readJson<Registry>(path.join(packageRoot, 'registry.json'));
+  const skills = registry.skills || {};
+
+  if (sub === 'list') {
+    const lines = ['skills:'];
+    for (const [skillId, skillDef] of Object.entries(skills).sort(([a], [b]) => a.localeCompare(b))) {
+      lines.push(`- ${skillId} - ${skillDef.display}`);
+    }
+    process.stdout.write(`${lines.join('\n')}\n`);
+    return;
+  }
+
+  if (sub === 'explain') {
+    const skillId = flags._[1];
+    ensure(skillId, 'Usage: ailib skills explain <skill-id>');
+    const skillDef = skills[skillId];
+    ensure(skillDef, `Unknown skill: ${skillId}`);
+
+    const compatible = skillDef.compatible || {};
+    const lines = [
+      `skill: ${skillId}`,
+      `display: ${skillDef.display}`,
+      `path: ${skillDef.path}`,
+      `description: ${skillDef.description || '(none)'}`,
+      `requires: ${(skillDef.requires || []).join(', ') || '(none)'}`,
+      `conflicts_with: ${(skillDef.conflicts_with || []).join(', ') || '(none)'}`,
+      `compatible.languages: ${(compatible.languages || []).join(', ') || '(none)'}`,
+      `compatible.modules: ${(compatible.modules || []).join(', ') || '(none)'}`,
+      `compatible.targets: ${(compatible.targets || []).join(', ') || '(none)'}`,
+      `compatible.llms: ${(compatible.llms || []).join(', ') || '(none)'}`
+    ];
+    process.stdout.write(`${lines.join('\n')}\n`);
+    return;
+  }
+
+  throw new Error('Usage: ailib skills list | ailib skills explain <skill-id>');
+}
+
 function ensure(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(message);
 }

--- a/src/cli/skills.test.ts
+++ b/src/cli/skills.test.ts
@@ -12,7 +12,7 @@ async function tempDir() {
 test('skillsCommand rejects unsupported subcommands', async () => {
   await assert.rejects(
     skillsCommand({ cwd: process.cwd(), flags: { _: ['unknown'] } }),
-    /Usage: ailib skills init <skill-id>.*ailib skills validate/s
+    /Usage: ailib skills list.*ailib skills validate/s
   );
 });
 

--- a/src/cli/skills.ts
+++ b/src/cli/skills.ts
@@ -3,14 +3,28 @@ import path from 'node:path';
 import { ensure } from './assertions.ts';
 import { resolveContext, resolveDefaultWorkspaceForMutation } from './context-resolution.ts';
 import { getStringFlag } from './flags.ts';
+import { skillsCatalogCommand } from './introspection.ts';
 import { renderSkillTemplate } from './skill-template.ts';
 import { skillsValidateCommand } from './skills-validate.ts';
 import type { CliFlags } from './types.ts';
 
 const SKILL_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
 
-export async function skillsCommand({ cwd, flags }: { cwd: string; flags: CliFlags }) {
+export async function skillsCommand({
+  cwd,
+  packageRoot,
+  flags
+}: {
+  cwd: string;
+  packageRoot?: string;
+  flags: CliFlags;
+}) {
   const sub = flags._[0];
+  if (sub === 'list' || sub === 'explain') {
+    ensure(packageRoot, 'Internal error: packageRoot is required for skills discovery commands');
+    await skillsCatalogCommand({ packageRoot, flags });
+    return;
+  }
   if (sub === 'init') {
     await skillsInitCommand({ cwd, flags });
     return;
@@ -20,7 +34,7 @@ export async function skillsCommand({ cwd, flags }: { cwd: string; flags: CliFla
     return;
   }
   throw new Error(
-    'Usage: ailib skills init <skill-id> [--workspace=<path>] [--path=<path>] [--description=<text>] [--force] | ailib skills validate [--workspace=<path>] [--path=<path>]'
+    'Usage: ailib skills list | ailib skills explain <skill-id> | ailib skills init <skill-id> [--workspace=<path>] [--path=<path>] [--description=<text>] [--force] | ailib skills validate [--workspace=<path>] [--path=<path>]'
   );
 }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -141,6 +141,17 @@ test('modules explain rejects unknown module in requested language', async () =>
   );
 });
 
+test('skills list prints discovery header', async () => {
+  const listOutput = await captureStdout(async () => {
+    await run(['skills', 'list'], { packageRoot });
+  });
+  assert.match(listOutput, /skills:/);
+});
+
+test('skills explain rejects unknown skill id', async () => {
+  await assert.rejects(run(['skills', 'explain', 'missing-skill'], { packageRoot }), /Unknown skill: missing-skill/);
+});
+
 test('modules command rejects invalid subcommand usage', async () => {
   await assert.rejects(run(['modules', 'invalid-subcommand'], { packageRoot }), /Usage: ailib modules list/);
 });


### PR DESCRIPTION
## Summary
- add skills discovery introspection via `ailib skills list` and `ailib skills explain <skill-id>`
- route discovery subcommands through the existing top-level `skills` command and command-handler plumbing
- extend help output and test coverage for introspection behavior and CLI discovery usage

## Test plan
- [x] bun run check

Refs #160
Closes #160

Made with [Cursor](https://cursor.com)