### PR TITLE
docs: clarify skills discovery prerequisites

### DIFF
--- a/docs/cli-usage-guide.md
+++ b/docs/cli-usage-guide.md
@@ -130,10 +130,12 @@ List available skills:
 ailib skills list
 ```
 
+If the list is empty, no skills are currently registered in your project registry yet.
+
 Explain one skill:
 
 ```bash
-ailib skills explain task-driven-gh-flow
+ailib skills explain <skill-id>
 ```
 
 ## Skills workflow (select, override, author)
@@ -147,7 +149,7 @@ Add `skills` to `ailib.config.json`:
   "language": "typescript",
   "modules": ["eslint"],
   "targets": ["claude-code", "cursor"],
-  "skills": ["task-driven-gh-flow"]
+  "skills": ["<skill-id-from-registry>"]
 }
 ```
 


### PR DESCRIPTION
## Summary
- update CLI guide discovery examples to avoid implying built-in skills exist by default
- document that `skills list` can be empty when project registry has no skill entries
- switch configuration and explain examples to placeholder ids sourced from registry

## Test plan
- [x] bun run check

Refs #152

Made with [Cursor](https://cursor.com)