### PR TITLE
feat: add architecture decision skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 - Creates and updates `.ailib/` pointer files from the built-in registry.
 - Generates target-specific instruction files (for example `CLAUDE.md`, `.github/copilot-instructions.md`, `.cursor/rules/ailib.mdc`).
+- Installs and validates reusable AI skills for architecture, RFCs, DACI, design review, and delivery flow.
 - Supports monorepos with root + service workspaces.
 - Verifies generated files with `ailib doctor`.
 

--- a/docs/cli-usage-guide.md
+++ b/docs/cli-usage-guide.md
@@ -135,7 +135,7 @@ If the list is empty, no skills are currently registered in your project registr
 Explain one skill:
 
 ```bash
-ailib skills explain <skill-id>
+ailib skills explain architecture-decision-flow
 ```
 
 ## Skills workflow (select, override, author)
@@ -149,7 +149,7 @@ Add `skills` to `ailib.config.json`:
   "language": "typescript",
   "modules": ["eslint"],
   "targets": ["claude-code", "cursor"],
-  "skills": ["<skill-id-from-registry>"]
+  "skills": ["architecture-decision-flow"]
 }
 ```
 

--- a/registry.json
+++ b/registry.json
@@ -258,7 +258,134 @@
       "template": "targets/gemini.md.tmpl"
     }
   },
-  "skills": {},
+  "skills": {
+    "architecture-decision-flow": {
+      "display": "Architecture decision flow",
+      "description": "Drive architecture decisions end-to-end using RFC and DACI, from problem framing to rollout review.",
+      "path": "skills/architecture-decision-flow.md",
+      "compatible": {
+        "languages": [
+          "typescript",
+          "python",
+          "go",
+          "java",
+          "rust",
+          "javascript"
+        ],
+        "targets": [
+          "cursor",
+          "claude-code",
+          "copilot",
+          "openai",
+          "gemini",
+          "windsurf",
+          "jetbrains"
+        ]
+      }
+    },
+    "rfc-authoring": {
+      "display": "RFC authoring",
+      "description": "Write concise RFCs with context, options, tradeoffs, recommendation, and rollout planning.",
+      "path": "skills/rfc-authoring.md",
+      "requires": [
+        "architecture-decision-flow"
+      ],
+      "compatible": {
+        "languages": [
+          "typescript",
+          "python",
+          "go",
+          "java",
+          "rust",
+          "javascript"
+        ],
+        "targets": [
+          "cursor",
+          "claude-code",
+          "copilot",
+          "openai",
+          "gemini",
+          "windsurf",
+          "jetbrains"
+        ]
+      }
+    },
+    "daci-facilitation": {
+      "display": "DACI facilitation",
+      "description": "Establish DACI ownership and run efficient decision reviews with clear accountability.",
+      "path": "skills/daci-facilitation.md",
+      "requires": [
+        "architecture-decision-flow"
+      ],
+      "compatible": {
+        "languages": [
+          "typescript",
+          "python",
+          "go",
+          "java",
+          "rust",
+          "javascript"
+        ],
+        "targets": [
+          "cursor",
+          "claude-code",
+          "copilot",
+          "openai",
+          "gemini",
+          "windsurf",
+          "jetbrains"
+        ]
+      }
+    },
+    "design-review-checklist": {
+      "display": "Design review checklist",
+      "description": "Run consistent technical design reviews for correctness, operability, security, and maintainability.",
+      "path": "skills/design-review-checklist.md",
+      "compatible": {
+        "languages": [
+          "typescript",
+          "python",
+          "go",
+          "java",
+          "rust",
+          "javascript"
+        ],
+        "targets": [
+          "cursor",
+          "claude-code",
+          "copilot",
+          "openai",
+          "gemini",
+          "windsurf",
+          "jetbrains"
+        ]
+      }
+    },
+    "delivery-flow-refinement": {
+      "display": "Delivery flow refinement",
+      "description": "Improve software delivery flow by reducing bottlenecks across planning, implementation, review, and release.",
+      "path": "skills/delivery-flow-refinement.md",
+      "compatible": {
+        "languages": [
+          "typescript",
+          "python",
+          "go",
+          "java",
+          "rust",
+          "javascript"
+        ],
+        "targets": [
+          "cursor",
+          "claude-code",
+          "copilot",
+          "openai",
+          "gemini",
+          "windsurf",
+          "jetbrains"
+        ]
+      }
+    }
+  },
   "languages": {
     "go": {
       "display": "Go",

--- a/registry/core.json
+++ b/registry/core.json
@@ -130,5 +130,53 @@
       "template": "targets/gemini.md.tmpl"
     }
   },
-  "skills": {}
+  "skills": {
+    "architecture-decision-flow": {
+      "display": "Architecture decision flow",
+      "description": "Drive architecture decisions end-to-end using RFC and DACI, from problem framing to rollout review.",
+      "path": "skills/architecture-decision-flow.md",
+      "compatible": {
+        "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
+        "targets": ["cursor", "claude-code", "copilot", "openai", "gemini", "windsurf", "jetbrains"]
+      }
+    },
+    "rfc-authoring": {
+      "display": "RFC authoring",
+      "description": "Write concise RFCs with context, options, tradeoffs, recommendation, and rollout planning.",
+      "path": "skills/rfc-authoring.md",
+      "requires": ["architecture-decision-flow"],
+      "compatible": {
+        "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
+        "targets": ["cursor", "claude-code", "copilot", "openai", "gemini", "windsurf", "jetbrains"]
+      }
+    },
+    "daci-facilitation": {
+      "display": "DACI facilitation",
+      "description": "Establish DACI ownership and run efficient decision reviews with clear accountability.",
+      "path": "skills/daci-facilitation.md",
+      "requires": ["architecture-decision-flow"],
+      "compatible": {
+        "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
+        "targets": ["cursor", "claude-code", "copilot", "openai", "gemini", "windsurf", "jetbrains"]
+      }
+    },
+    "design-review-checklist": {
+      "display": "Design review checklist",
+      "description": "Run consistent technical design reviews for correctness, operability, security, and maintainability.",
+      "path": "skills/design-review-checklist.md",
+      "compatible": {
+        "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
+        "targets": ["cursor", "claude-code", "copilot", "openai", "gemini", "windsurf", "jetbrains"]
+      }
+    },
+    "delivery-flow-refinement": {
+      "display": "Delivery flow refinement",
+      "description": "Improve software delivery flow by reducing bottlenecks across planning, implementation, review, and release.",
+      "path": "skills/delivery-flow-refinement.md",
+      "compatible": {
+        "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
+        "targets": ["cursor", "claude-code", "copilot", "openai", "gemini", "windsurf", "jetbrains"]
+      }
+    }
+  }
 }

--- a/skills/architecture-decision-flow.md
+++ b/skills/architecture-decision-flow.md
@@ -1,0 +1,30 @@
+---
+name: architecture-decision-flow
+description: Drive architecture decisions end-to-end using RFC and DACI, from problem framing to rollout review.
+compatible_languages: [typescript, python, go, java, rust, javascript]
+compatible_targets: [cursor, claude-code, copilot, openai, gemini, windsurf, jetbrains]
+---
+
+# architecture-decision-flow
+
+## Purpose
+
+- Create a repeatable architecture decision process.
+- Require explicit tradeoffs, ownership, and rollout planning.
+- Preserve decision history and avoid undocumented tribal choices.
+
+## Workflow
+
+- Confirm decision scope, urgency, and blast radius.
+- Define problem statement, constraints, non-goals, and success criteria.
+- Generate 2-4 viable options with pros, cons, risks, and operational impact.
+- Draft an RFC with context, options, recommendation, and migration plan.
+- Assign DACI roles:
+  - Driver: accountable for the process and timeline.
+  - Approver: final decision owner.
+  - Contributors: subject-matter input providers.
+  - Informed: stakeholders who need outcomes.
+- Facilitate review and resolve open questions.
+- Record final decision with rationale and rejected alternatives.
+- Define implementation phases, rollback strategy, and validation checks.
+- Schedule a decision retrospective after rollout.

--- a/skills/daci-facilitation.md
+++ b/skills/daci-facilitation.md
@@ -1,0 +1,25 @@
+---
+name: daci-facilitation
+description: Establish DACI ownership and run efficient decision reviews with clear accountability.
+compatible_languages: [typescript, python, go, java, rust, javascript]
+compatible_targets: [cursor, claude-code, copilot, openai, gemini, windsurf, jetbrains]
+---
+
+# daci-facilitation
+
+## Purpose
+
+- Prevent decision ambiguity by clarifying who drives, approves, contributes, and is informed.
+- Reduce stalled architecture reviews and unclear ownership.
+- Make decision authority explicit before implementation starts.
+
+## Workflow
+
+- Identify the decision topic, deadline, and required confidence level.
+- Assign DACI roles with named owners rather than team aliases.
+- Confirm approver authority and escalation path.
+- Collect structured input from contributors.
+- Track disagreements, dependencies, and decision blockers.
+- Drive toward final approval with documented rationale.
+- Communicate outcome to informed stakeholders with implementation expectations.
+- Log follow-up actions, owners, and deadlines.

--- a/skills/delivery-flow-refinement.md
+++ b/skills/delivery-flow-refinement.md
@@ -1,0 +1,25 @@
+---
+name: delivery-flow-refinement
+description: Improve software delivery flow by reducing bottlenecks across planning, implementation, review, and release.
+compatible_languages: [typescript, python, go, java, rust, javascript]
+compatible_targets: [cursor, claude-code, copilot, openai, gemini, windsurf, jetbrains]
+---
+
+# delivery-flow-refinement
+
+## Purpose
+
+- Optimize end-to-end engineering flow with measurable improvements.
+- Reduce lead time, PR cycle time, rework, and release friction.
+- Turn recurring delivery pain into targeted process experiments.
+
+## Workflow
+
+- Map current flow from idea to production.
+- Identify bottlenecks, queues, handoffs, and recurring failure patterns.
+- Define baseline metrics such as cycle time, review latency, deployment frequency, and rollback rate.
+- Propose process experiments with clear hypotheses.
+- Prioritize low-risk, high-impact improvements.
+- Roll out changes incrementally with owner and timeline.
+- Measure outcomes against baseline and adjust the approach.
+- Capture refined standards and update team playbooks.

--- a/skills/design-review-checklist.md
+++ b/skills/design-review-checklist.md
@@ -1,0 +1,26 @@
+---
+name: design-review-checklist
+description: Run consistent technical design reviews for correctness, operability, security, and maintainability.
+compatible_languages: [typescript, python, go, java, rust, javascript]
+compatible_targets: [cursor, claude-code, copilot, openai, gemini, windsurf, jetbrains]
+---
+
+# design-review-checklist
+
+## Purpose
+
+- Standardize design quality gates before implementation.
+- Catch high-cost issues early in the architecture and design stage.
+- Produce review outcomes that are concrete enough to unblock delivery.
+
+## Workflow
+
+- Verify scope, non-goals, and interface boundaries are explicit.
+- Review data model impacts and migration implications.
+- Check performance assumptions, expected load, and scaling limits.
+- Validate failure modes, retries, timeouts, and fallback behavior.
+- Review security, privacy, and compliance implications.
+- Confirm observability plan: logs, metrics, traces, dashboards, and alerts.
+- Validate test strategy: unit, integration, end-to-end, migration, and rollback verification.
+- Document operational runbook requirements.
+- Record open risks and assign an owner for each unresolved item.

--- a/skills/rfc-authoring.md
+++ b/skills/rfc-authoring.md
@@ -1,0 +1,25 @@
+---
+name: rfc-authoring
+description: Write concise RFCs with context, options, tradeoffs, recommendation, and rollout planning.
+compatible_languages: [typescript, python, go, java, rust, javascript]
+compatible_targets: [cursor, claude-code, copilot, openai, gemini, windsurf, jetbrains]
+---
+
+# rfc-authoring
+
+## Purpose
+
+- Produce RFCs that are concise, decision-oriented, and reviewable.
+- Make assumptions, constraints, and risks explicit before implementation.
+- Help reviewers focus on unresolved decisions instead of rediscovering context.
+
+## Workflow
+
+- Capture context, problem statement, and non-goals.
+- Define success metrics and acceptance criteria.
+- Describe current state and pain points.
+- Present options with technical, operational, and migration tradeoffs.
+- Recommend one option with rationale and known limitations.
+- Provide rollout plan, migration path, rollback strategy, and validation checks.
+- Include unresolved questions and decisions needed from reviewers.
+- Finalize RFC with clear status (`draft`, `review`, `approved`, `rejected`, or `superseded`).


### PR DESCRIPTION
## Summary
- add five built-in skills for architecture decision flow, RFC authoring, DACI facilitation, design review, and delivery flow refinement
- register the skills in the generated registry with broad language/target compatibility and dependency links for RFC/DACI workflows
- update README and CLI usage examples to point at the new built-in architecture decision skill

## Test plan
- [x] bun run check

Refs #192
Closes #192

Made with [Cursor](https://cursor.com)