### PR TITLE
test: add built-in skill asset coverage

### DIFF
--- a/src/cli/workspace-assets.test.ts
+++ b/src/cli/workspace-assets.test.ts
@@ -21,6 +21,10 @@ const registry: Registry = {
     cursor: { output: '.cursor/rules/ailib.mdc' }
   },
   skills: {
+    'architecture-decision-flow': {
+      display: 'Architecture decision flow',
+      path: 'skills/architecture-decision-flow.md'
+    },
     'task-driven-gh-flow': {
       display: 'Task-driven GH flow',
       path: '.cursor/skills/task-driven-gh-flow/SKILL.md'
@@ -65,11 +69,13 @@ function state(localModules: string[], localSkills: string[] = []): WorkspaceSta
 async function seedPackage(packageRoot: string) {
   await fs.mkdir(path.join(packageRoot, 'core'), { recursive: true });
   await fs.mkdir(path.join(packageRoot, 'languages/typescript/modules'), { recursive: true });
+  await fs.mkdir(path.join(packageRoot, 'skills'), { recursive: true });
   await fs.writeFile(path.join(packageRoot, 'core/behavior.md'), 'behavior', 'utf8');
   await fs.writeFile(path.join(packageRoot, 'core/development-standards.md'), 'dev', 'utf8');
   await fs.writeFile(path.join(packageRoot, 'core/test-standards.md'), 'test', 'utf8');
   await fs.writeFile(path.join(packageRoot, 'languages/typescript/core.md'), 'lang-core', 'utf8');
   await fs.writeFile(path.join(packageRoot, 'languages/typescript/modules/eslint.md'), 'eslint', 'utf8');
+  await fs.writeFile(path.join(packageRoot, 'skills/architecture-decision-flow.md'), 'architecture-flow', 'utf8');
   await fs.mkdir(path.join(packageRoot, '.cursor/skills/task-driven-gh-flow'), { recursive: true });
   await fs.writeFile(path.join(packageRoot, '.cursor/skills/task-driven-gh-flow/SKILL.md'), 'skill-flow', 'utf8');
 }
@@ -136,6 +142,26 @@ test('ensureWorkspaceAssets copies and prunes skill assets', async () => {
   );
   await assert.rejects(fs.readFile(path.join(workspaceDir, '.ailib/skills/legacy-skill.md'), 'utf8'));
   assert.equal(await fs.readFile(path.join(workspaceDir, '.ailib/skills/custom.md'), 'utf8'), 'custom-skill');
+});
+
+test('ensureWorkspaceAssets copies built-in skill assets from package sources', async () => {
+  const rootDir = await tempDir();
+  const workspaceDir = path.join(rootDir, 'apps/api');
+  const packageRoot = path.join(rootDir, 'pkg');
+  await seedPackage(packageRoot);
+
+  await ensureWorkspaceAssets({
+    workspaceDir,
+    packageRoot,
+    state: state([], ['architecture-decision-flow']),
+    rootDir,
+    registry
+  });
+
+  assert.equal(
+    await fs.readFile(path.join(workspaceDir, '.ailib/skills/architecture-decision-flow.md'), 'utf8'),
+    'architecture-flow'
+  );
 });
 
 test('ensureWorkspaceAssets prefers local custom skill over package source', async () => {


### PR DESCRIPTION
## Summary
- add workspace asset coverage for built-in skill sources under `skills/*.md`
- extend package fixture setup to include the built-in `architecture-decision-flow` skill source
- verify `ensureWorkspaceAssets` copies the built-in source into `.ailib/skills` for selected skills

## Test plan
- [x] bun test src/cli/workspace-assets.test.ts
- [x] bun run check

Refs #195
Closes #195

Made with [Cursor](https://cursor.com)