### PR TITLE
docs: add architecture skill selection guidance

### DIFF
--- a/docs/cli-usage-guide.md
+++ b/docs/cli-usage-guide.md
@@ -160,6 +160,22 @@ ailib update
 ailib doctor
 ```
 
+### 1.1) Choose umbrella vs focused architecture skills
+
+Use `architecture-decision-flow` as the umbrella skill when your team needs an end-to-end decision workflow that spans framing, RFC drafting, DACI alignment, rollout planning, and retrospective follow-up.
+
+Use focused skills when you only need one part of that flow:
+
+- `rfc-authoring`: writing or reviewing RFC content and tradeoffs.
+- `daci-facilitation`: decision role alignment and review facilitation.
+- `design-review-checklist`: design quality/risk checks before implementation.
+- `delivery-flow-refinement`: implementation sequencing, rollout safety, and verification loops.
+
+Practical default:
+
+- Start with `architecture-decision-flow` for cross-team or high-impact changes.
+- Add focused skills for deep dives in specific steps (for example RFC-heavy or review-heavy work).
+
 ### 2) Override skill selection locally
 
 Use `ailib.local.json` to add/remove/set skills without changing managed config:


### PR DESCRIPTION
## Summary
- add guidance for choosing umbrella versus focused architecture skills in the CLI usage guide
- clarify when `architecture-decision-flow` is the default choice for cross-team or high-impact changes
- document focused use-cases for `rfc-authoring`, `daci-facilitation`, `design-review-checklist`, and `delivery-flow-refinement`

## Test plan
- [x] bun run check

Refs #198
Closes #198

Made with [Cursor](https://cursor.com)