### PR TITLE
feat: register clean code refactoring skill

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -283,6 +283,30 @@
         ]
       }
     },
+    "clean-code-refactoring": {
+      "display": "Clean code refactoring",
+      "description": "Plan and execute safe refactors with clear boundaries, SOLID checks, and behavior-preserving verification.",
+      "path": "skills/clean-code-refactoring.md",
+      "compatible": {
+        "languages": [
+          "typescript",
+          "python",
+          "go",
+          "java",
+          "rust",
+          "javascript"
+        ],
+        "targets": [
+          "cursor",
+          "claude-code",
+          "copilot",
+          "openai",
+          "gemini",
+          "windsurf",
+          "jetbrains"
+        ]
+      }
+    },
     "rfc-authoring": {
       "display": "RFC authoring",
       "description": "Write concise RFCs with context, options, tradeoffs, recommendation, and rollout planning.",

--- a/registry/core.json
+++ b/registry/core.json
@@ -140,6 +140,15 @@
         "targets": ["cursor", "claude-code", "copilot", "openai", "gemini", "windsurf", "jetbrains"]
       }
     },
+    "clean-code-refactoring": {
+      "display": "Clean code refactoring",
+      "description": "Plan and execute safe refactors with clear boundaries, SOLID checks, and behavior-preserving verification.",
+      "path": "skills/clean-code-refactoring.md",
+      "compatible": {
+        "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
+        "targets": ["cursor", "claude-code", "copilot", "openai", "gemini", "windsurf", "jetbrains"]
+      }
+    },
     "rfc-authoring": {
       "display": "RFC authoring",
       "description": "Write concise RFCs with context, options, tradeoffs, recommendation, and rollout planning.",


### PR DESCRIPTION
## Summary
- register `clean-code-refactoring` in `registry/core.json` as a built-in quality skill
- regenerate `registry.json` so discovery commands include the registered skill metadata
- keep compatibility targets/languages aligned with the current built-in skills baseline

## Test plan
- [x] bun run check

Refs #203
Closes #203

Made with [Cursor](https://cursor.com)