### PR TITLE
feat: add review skill discovery coverage

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -307,6 +307,30 @@
         ]
       }
     },
+    "code-review-rigor": {
+      "display": "Code review rigor",
+      "description": "Run bug-risk-first code reviews that prioritize behavioral regressions, test gaps, and unsafe assumptions.",
+      "path": "skills/code-review-rigor.md",
+      "compatible": {
+        "languages": [
+          "typescript",
+          "python",
+          "go",
+          "java",
+          "rust",
+          "javascript"
+        ],
+        "targets": [
+          "cursor",
+          "claude-code",
+          "copilot",
+          "openai",
+          "gemini",
+          "windsurf",
+          "jetbrains"
+        ]
+      }
+    },
     "rfc-authoring": {
       "display": "RFC authoring",
       "description": "Write concise RFCs with context, options, tradeoffs, recommendation, and rollout planning.",

--- a/registry/core.json
+++ b/registry/core.json
@@ -149,6 +149,15 @@
         "targets": ["cursor", "claude-code", "copilot", "openai", "gemini", "windsurf", "jetbrains"]
       }
     },
+    "code-review-rigor": {
+      "display": "Code review rigor",
+      "description": "Run bug-risk-first code reviews that prioritize behavioral regressions, test gaps, and unsafe assumptions.",
+      "path": "skills/code-review-rigor.md",
+      "compatible": {
+        "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
+        "targets": ["cursor", "claude-code", "copilot", "openai", "gemini", "windsurf", "jetbrains"]
+      }
+    },
     "rfc-authoring": {
       "display": "RFC authoring",
       "description": "Write concise RFCs with context, options, tradeoffs, recommendation, and rollout planning.",

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -163,6 +163,26 @@ test('skills list and explain include built-in architecture skills', async () =>
   assert.match(explainRfc, /requires: architecture-decision-flow/);
 });
 
+test('skills list and explain include review and refactor skills', async () => {
+  const listOutput = await captureStdout(async () => {
+    await run(['skills', 'list'], { packageRoot });
+  });
+  assert.match(listOutput, /- clean-code-refactoring - Clean code refactoring/);
+  assert.match(listOutput, /- code-review-rigor - Code review rigor/);
+
+  const explainRefactor = await captureStdout(async () => {
+    await run(['skills', 'explain', 'clean-code-refactoring'], { packageRoot });
+  });
+  assert.match(explainRefactor, /skill: clean-code-refactoring/);
+  assert.match(explainRefactor, /path: skills\/clean-code-refactoring\.md/);
+
+  const explainReview = await captureStdout(async () => {
+    await run(['skills', 'explain', 'code-review-rigor'], { packageRoot });
+  });
+  assert.match(explainReview, /skill: code-review-rigor/);
+  assert.match(explainReview, /path: skills\/code-review-rigor\.md/);
+});
+
 test('skills explain rejects unknown skill id', async () => {
   await assert.rejects(run(['skills', 'explain', 'missing-skill'], { packageRoot }), /Unknown skill: missing-skill/);
 });


### PR DESCRIPTION
## Summary
- register `code-review-rigor` in the split and generated skill registries
- add integration coverage that review/refactor skills appear in `skills list`
- verify `skills explain` outputs metadata for `clean-code-refactoring` and `code-review-rigor`

## Test plan
- [x] bun test test/cli.test.ts
- [x] bun run check

Refs #206
Closes #206

Made with [Cursor](https://cursor.com)