### PR TITLE
feat: add incident review skill

### DIFF
--- a/skills/incident-review.md
+++ b/skills/incident-review.md
@@ -1,0 +1,24 @@
+---
+name: incident-review
+description: Run a structured incident review with timeline reconstruction, contributing-factor analysis, action planning, and clear ownership.
+compatible_languages: [typescript, python, go, java, rust, javascript]
+compatible_targets: [cursor, claude-code, copilot, openai, gemini, windsurf, jetbrains]
+---
+
+# incident-review
+
+## Purpose
+
+- Build a clear, shared understanding of what happened and when.
+- Identify contributing factors across people, process, and systems without blame.
+- Convert findings into prioritized actions with named owners and follow-up dates.
+
+## Workflow
+
+- Define incident scope, impact window, and participating reviewers before analysis.
+- Reconstruct a factual timeline from detection through resolution with key decisions and signals.
+- Separate root causes from contributing factors, including detection, escalation, tooling, and communication gaps.
+- Group follow-up actions by prevention, detection, response, and recovery outcomes.
+- Assign a single accountable owner, due date, and success metric for each action item.
+- Capture unresolved risks, dependencies, and required leadership decisions.
+- Publish review notes and schedule a follow-up check to verify completion and effectiveness.


### PR DESCRIPTION
## Summary
- Add new `incident-review` skill in `skills/incident-review.md`
- Cover timeline reconstruction, contributing factors, and follow-up ownership workflow

## Test plan
- [x] Run `bun run check`

Refs #216
Closes #216

Made with [Cursor](https://cursor.com)