### PR TITLE
feat: validate reliability skill registry

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -432,6 +432,102 @@
           "jetbrains"
         ]
       }
+    },
+    "release-readiness": {
+      "display": "Release readiness",
+      "description": "Validate a change is safe to release with checklist-driven checks, rollback preparation, and post-merge verification.",
+      "path": "skills/release-readiness.md",
+      "compatible": {
+        "languages": [
+          "typescript",
+          "python",
+          "go",
+          "java",
+          "rust",
+          "javascript"
+        ],
+        "targets": [
+          "cursor",
+          "claude-code",
+          "copilot",
+          "openai",
+          "gemini",
+          "windsurf",
+          "jetbrains"
+        ]
+      }
+    },
+    "observability-design": {
+      "display": "Observability design",
+      "description": "Design observability across logs, metrics, traces, alerts, and dashboards to detect and diagnose production issues quickly.",
+      "path": "skills/observability-design.md",
+      "compatible": {
+        "languages": [
+          "typescript",
+          "python",
+          "go",
+          "java",
+          "rust",
+          "javascript"
+        ],
+        "targets": [
+          "cursor",
+          "claude-code",
+          "copilot",
+          "openai",
+          "gemini",
+          "windsurf",
+          "jetbrains"
+        ]
+      }
+    },
+    "incident-review": {
+      "display": "Incident review",
+      "description": "Run a structured incident review with timeline reconstruction, contributing-factor analysis, action planning, and clear ownership.",
+      "path": "skills/incident-review.md",
+      "compatible": {
+        "languages": [
+          "typescript",
+          "python",
+          "go",
+          "java",
+          "rust",
+          "javascript"
+        ],
+        "targets": [
+          "cursor",
+          "claude-code",
+          "copilot",
+          "openai",
+          "gemini",
+          "windsurf",
+          "jetbrains"
+        ]
+      }
+    },
+    "migration-planning": {
+      "display": "Migration planning",
+      "description": "Plan data and API migrations with phased rollouts, compatibility safeguards, and tested fallback paths.",
+      "path": "skills/migration-planning.md",
+      "compatible": {
+        "languages": [
+          "typescript",
+          "python",
+          "go",
+          "java",
+          "rust",
+          "javascript"
+        ],
+        "targets": [
+          "cursor",
+          "claude-code",
+          "copilot",
+          "openai",
+          "gemini",
+          "windsurf",
+          "jetbrains"
+        ]
+      }
     }
   },
   "languages": {

--- a/registry/core.json
+++ b/registry/core.json
@@ -195,6 +195,42 @@
         "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
         "targets": ["cursor", "claude-code", "copilot", "openai", "gemini", "windsurf", "jetbrains"]
       }
+    },
+    "release-readiness": {
+      "display": "Release readiness",
+      "description": "Validate a change is safe to release with checklist-driven checks, rollback preparation, and post-merge verification.",
+      "path": "skills/release-readiness.md",
+      "compatible": {
+        "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
+        "targets": ["cursor", "claude-code", "copilot", "openai", "gemini", "windsurf", "jetbrains"]
+      }
+    },
+    "observability-design": {
+      "display": "Observability design",
+      "description": "Design observability across logs, metrics, traces, alerts, and dashboards to detect and diagnose production issues quickly.",
+      "path": "skills/observability-design.md",
+      "compatible": {
+        "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
+        "targets": ["cursor", "claude-code", "copilot", "openai", "gemini", "windsurf", "jetbrains"]
+      }
+    },
+    "incident-review": {
+      "display": "Incident review",
+      "description": "Run a structured incident review with timeline reconstruction, contributing-factor analysis, action planning, and clear ownership.",
+      "path": "skills/incident-review.md",
+      "compatible": {
+        "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
+        "targets": ["cursor", "claude-code", "copilot", "openai", "gemini", "windsurf", "jetbrains"]
+      }
+    },
+    "migration-planning": {
+      "display": "Migration planning",
+      "description": "Plan data and API migrations with phased rollouts, compatibility safeguards, and tested fallback paths.",
+      "path": "skills/migration-planning.md",
+      "compatible": {
+        "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
+        "targets": ["cursor", "claude-code", "copilot", "openai", "gemini", "windsurf", "jetbrains"]
+      }
     }
   }
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -183,6 +183,28 @@ test('skills list and explain include review and refactor skills', async () => {
   assert.match(explainReview, /path: skills\/code-review-rigor\.md/);
 });
 
+test('skills list and explain include reliability skills', async () => {
+  const listOutput = await captureStdout(async () => {
+    await run(['skills', 'list'], { packageRoot });
+  });
+  assert.match(listOutput, /- release-readiness - Release readiness/);
+  assert.match(listOutput, /- observability-design - Observability design/);
+  assert.match(listOutput, /- incident-review - Incident review/);
+  assert.match(listOutput, /- migration-planning - Migration planning/);
+
+  const explainRelease = await captureStdout(async () => {
+    await run(['skills', 'explain', 'release-readiness'], { packageRoot });
+  });
+  assert.match(explainRelease, /skill: release-readiness/);
+  assert.match(explainRelease, /path: skills\/release-readiness\.md/);
+
+  const explainMigration = await captureStdout(async () => {
+    await run(['skills', 'explain', 'migration-planning'], { packageRoot });
+  });
+  assert.match(explainMigration, /skill: migration-planning/);
+  assert.match(explainMigration, /path: skills\/migration-planning\.md/);
+});
+
 test('skills explain rejects unknown skill id', async () => {
   await assert.rejects(run(['skills', 'explain', 'missing-skill'], { packageRoot }), /Unknown skill: missing-skill/);
 });


### PR DESCRIPTION
## Summary
- register reliability-phase skills in split and generated registries
- align registry metadata with skill frontmatter for governance validation
- add CLI coverage for reliability skill discovery and explain output

## Test plan
- [x] bun test test/cli.test.ts test/registry-governance.test.ts
- [x] bun run check

Refs #219
Closes #219

Made with [Cursor](https://cursor.com)