### PR TITLE
docs: add starter skill bundle docs

### DIFF
--- a/docs/built-in-skills-catalog.md
+++ b/docs/built-in-skills-catalog.md
@@ -56,6 +56,30 @@ All built-in skills currently declare compatibility with:
 - Dependency notes: no required skills.
 - Recommended usage: use when cycle time, handoff friction, or rollout sequencing is slowing delivery.
 
+### `release-readiness`
+
+- Purpose: Validate a change is safe to release with checklist-driven checks, rollback preparation, and post-merge verification.
+- Dependency notes: no required skills.
+- Recommended usage: apply near merge windows or rollout cutovers where operational confidence and fallback discipline matter most.
+
+### `observability-design`
+
+- Purpose: Design observability across logs, metrics, traces, alerts, and dashboards to detect and diagnose production issues quickly.
+- Dependency notes: no required skills.
+- Recommended usage: add when a change introduces new failure modes or service boundaries that need better runtime visibility.
+
+### `incident-review`
+
+- Purpose: Run a structured incident review with timeline reconstruction, contributing-factor analysis, action planning, and clear ownership.
+- Dependency notes: no required skills.
+- Recommended usage: use after reliability events to convert learnings into prioritized remediation and prevention actions.
+
+### `migration-planning`
+
+- Purpose: Plan data and API migrations with phased rollouts, compatibility safeguards, and tested fallback paths.
+- Dependency notes: no required skills.
+- Recommended usage: add when schema contracts, data movement, or client compatibility risks need explicit sequencing.
+
 ### `design-review-checklist`
 
 - Purpose: Run consistent technical design reviews for correctness, operability, security, and maintainability.
@@ -67,3 +91,58 @@ All built-in skills currently declare compatibility with:
 - Purpose: Write concise RFCs with context, options, tradeoffs, recommendation, and rollout planning.
 - Dependency notes: requires `architecture-decision-flow`.
 - Recommended usage: add when the task requires a formal decision record with clear alternatives and migration plan.
+
+## Starter skill bundles
+
+Starter bundles provide default skill combinations by workflow. Treat these as practical baselines and refine per workspace using `ailib.local.json`.
+
+### Architecture workflow bundle
+
+- Include: `architecture-decision-flow`, `rfc-authoring`, `daci-facilitation`, `design-review-checklist`
+- Best for: cross-team changes that need clear tradeoff documentation, decision ownership, and design quality gates.
+
+```json
+{
+  "skills": ["architecture-decision-flow", "rfc-authoring", "daci-facilitation", "design-review-checklist"]
+}
+```
+
+### Delivery workflow bundle
+
+- Include: `delivery-flow-refinement`, `release-readiness`, `migration-planning`
+- Best for: execution-heavy initiatives focused on sequencing, safe rollout steps, and fallback planning.
+
+```json
+{
+  "skills": ["delivery-flow-refinement", "release-readiness", "migration-planning"]
+}
+```
+
+### Quality workflow bundle
+
+- Include: `clean-code-refactoring`, `code-review-rigor`, `design-review-checklist`
+- Best for: implementation and review loops where maintainability, regression prevention, and technical quality checks are the priority.
+
+```json
+{
+  "skills": ["clean-code-refactoring", "code-review-rigor", "design-review-checklist"]
+}
+```
+
+### Operations workflow bundle
+
+- Include: `release-readiness`, `observability-design`, `incident-review`
+- Best for: production-facing reliability work that needs release safety checks, stronger telemetry coverage, and incident follow-through.
+
+```json
+{
+  "skills": ["release-readiness", "observability-design", "incident-review"]
+}
+```
+
+After selecting a bundle in `ailib.config.json`, run:
+
+```bash
+ailib update
+ailib doctor
+```

--- a/docs/cli-usage-guide.md
+++ b/docs/cli-usage-guide.md
@@ -140,6 +140,48 @@ ailib skills explain architecture-decision-flow
 
 ## Skills workflow (select, override, author)
 
+### 0) Pick a starter workflow bundle
+
+Choose one of these starter bundles as your baseline, then tune per workspace with `ailib.local.json`.
+
+- Architecture workflow:
+  - `architecture-decision-flow`
+  - `rfc-authoring`
+  - `daci-facilitation`
+  - `design-review-checklist`
+- Delivery workflow:
+  - `delivery-flow-refinement`
+  - `release-readiness`
+  - `migration-planning`
+- Quality workflow:
+  - `clean-code-refactoring`
+  - `code-review-rigor`
+  - `design-review-checklist`
+- Operations workflow:
+  - `release-readiness`
+  - `observability-design`
+  - `incident-review`
+
+Example starter bundle in `ailib.config.json`:
+
+```json
+{
+  "language": "typescript",
+  "modules": ["eslint", "vitest"],
+  "targets": ["claude-code", "cursor", "copilot"],
+  "skills": ["delivery-flow-refinement", "release-readiness", "migration-planning"]
+}
+```
+
+Then apply and verify:
+
+```bash
+ailib update
+ailib doctor
+```
+
+For bundle rationale and expanded examples, see [Built-In Skills Catalog](./built-in-skills-catalog.md#starter-skill-bundles).
+
 ### 1) Select skills in workspace config
 
 Add `skills` to `ailib.config.json`:


### PR DESCRIPTION
## Summary
- Add starter skill bundle documentation for architecture, delivery, quality, and operations workflows.
- Expand catalog guidance with bundle-specific skill sets and configuration snippets.
- Add CLI guide quick-start bundle selection guidance with apply/verify commands.

## Test plan
- [x] Run `bun run check`

Refs #223
Closes #223

Made with [Cursor](https://cursor.com)