### PR TITLE
feat: register tdd skill metadata

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -528,6 +528,30 @@
           "jetbrains"
         ]
       }
+    },
+    "tdd-cycle-workflow": {
+      "display": "TDD cycle workflow",
+      "description": "Drive implementation with red-green-refactor loops and seam-first testability for safe, incremental delivery.",
+      "path": "skills/tdd-cycle-workflow.md",
+      "compatible": {
+        "languages": [
+          "typescript",
+          "python",
+          "go",
+          "java",
+          "rust",
+          "javascript"
+        ],
+        "targets": [
+          "cursor",
+          "claude-code",
+          "copilot",
+          "openai",
+          "gemini",
+          "windsurf",
+          "jetbrains"
+        ]
+      }
     }
   },
   "languages": {

--- a/registry/core.json
+++ b/registry/core.json
@@ -231,6 +231,15 @@
         "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
         "targets": ["cursor", "claude-code", "copilot", "openai", "gemini", "windsurf", "jetbrains"]
       }
+    },
+    "tdd-cycle-workflow": {
+      "display": "TDD cycle workflow",
+      "description": "Drive implementation with red-green-refactor loops and seam-first testability for safe, incremental delivery.",
+      "path": "skills/tdd-cycle-workflow.md",
+      "compatible": {
+        "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
+        "targets": ["cursor", "claude-code", "copilot", "openai", "gemini", "windsurf", "jetbrains"]
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- register `tdd-cycle-workflow` in the split core skills registry
- regenerate `registry.json` from split registry sources
- keep registry metadata aligned with the skill frontmatter contract

## Test plan
- [x] bun test test/registry-governance.test.ts
- [x] bun run check

Refs #254
Closes #254

Made with [Cursor](https://cursor.com)