### PR TITLE
feat: register solid skill metadata

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -529,6 +529,30 @@
         ]
       }
     },
+    "solid-principles-application": {
+      "display": "SOLID principles application",
+      "description": "Apply SRP, OCP, LSP, ISP, and DIP with practical design checks during implementation and refactoring.",
+      "path": "skills/solid-principles-application.md",
+      "compatible": {
+        "languages": [
+          "typescript",
+          "python",
+          "go",
+          "java",
+          "rust",
+          "javascript"
+        ],
+        "targets": [
+          "cursor",
+          "claude-code",
+          "copilot",
+          "openai",
+          "gemini",
+          "windsurf",
+          "jetbrains"
+        ]
+      }
+    },
     "tdd-cycle-workflow": {
       "display": "TDD cycle workflow",
       "description": "Drive implementation with red-green-refactor loops and seam-first testability for safe, incremental delivery.",

--- a/registry/core.json
+++ b/registry/core.json
@@ -232,6 +232,15 @@
         "targets": ["cursor", "claude-code", "copilot", "openai", "gemini", "windsurf", "jetbrains"]
       }
     },
+    "solid-principles-application": {
+      "display": "SOLID principles application",
+      "description": "Apply SRP, OCP, LSP, ISP, and DIP with practical design checks during implementation and refactoring.",
+      "path": "skills/solid-principles-application.md",
+      "compatible": {
+        "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
+        "targets": ["cursor", "claude-code", "copilot", "openai", "gemini", "windsurf", "jetbrains"]
+      }
+    },
     "tdd-cycle-workflow": {
       "display": "TDD cycle workflow",
       "description": "Drive implementation with red-green-refactor loops and seam-first testability for safe, incremental delivery.",


### PR DESCRIPTION
## Summary
- Add `solid-principles-application` to `registry/core.json` with compatibility metadata matching skill frontmatter
- Regenerate `registry.json` from split sources

## Test plan
- [x] Run `bun run registry:build`
- [x] Run `bun run registry:check`
- [x] Run `bun run standards:check`
- [x] Run `bun run check`

Refs #258
Closes #258

Made with [Cursor](https://cursor.com)