### PR TITLE
test: add tdd skill discovery coverage

### DIFF
--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -205,6 +205,22 @@ test('skills list and explain include reliability skills', async () => {
   assert.match(explainMigration, /path: skills\/migration-planning\.md/);
 });
 
+test('skills list and explain include tdd workflow skill metadata', async () => {
+  const listOutput = await captureStdout(async () => {
+    await run(['skills', 'list'], { packageRoot });
+  });
+  assert.match(listOutput, /- tdd-cycle-workflow - TDD cycle workflow/);
+
+  const explainTdd = await captureStdout(async () => {
+    await run(['skills', 'explain', 'tdd-cycle-workflow'], { packageRoot });
+  });
+  assert.match(explainTdd, /skill: tdd-cycle-workflow/);
+  assert.match(explainTdd, /path: skills\/tdd-cycle-workflow\.md/);
+  assert.match(explainTdd, /description: Drive implementation with red-green-refactor loops/);
+  assert.match(explainTdd, /compatible.languages: .*typescript/);
+  assert.match(explainTdd, /compatible.targets: .*claude-code/);
+});
+
 test('skills explain rejects unknown skill id', async () => {
   await assert.rejects(run(['skills', 'explain', 'missing-skill'], { packageRoot }), /Unknown skill: missing-skill/);
 });


### PR DESCRIPTION
## Summary
- Add CLI test coverage to assert `tdd-cycle-workflow` appears in `skills list` output.
- Add `skills explain tdd-cycle-workflow` assertions for path, description, and compatibility metadata.

## Test plan
- [x] bun test test/cli.test.ts
- [x] bun run check

Refs #255
Closes #255

Made with [Cursor](https://cursor.com)