### PR TITLE
test: add solid skill discovery coverage

### DIFF
--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -221,6 +221,22 @@ test('skills list and explain include tdd workflow skill metadata', async () => 
   assert.match(explainTdd, /compatible.targets: .*claude-code/);
 });
 
+test('skills list and explain include solid principles skill metadata', async () => {
+  const listOutput = await captureStdout(async () => {
+    await run(['skills', 'list'], { packageRoot });
+  });
+  assert.match(listOutput, /- solid-principles-application - SOLID principles application/);
+
+  const explainSolid = await captureStdout(async () => {
+    await run(['skills', 'explain', 'solid-principles-application'], { packageRoot });
+  });
+  assert.match(explainSolid, /skill: solid-principles-application/);
+  assert.match(explainSolid, /path: skills\/solid-principles-application\.md/);
+  assert.match(explainSolid, /description: Apply SRP, OCP, LSP, ISP, and DIP with practical design checks/);
+  assert.match(explainSolid, /compatible.languages: .*typescript/);
+  assert.match(explainSolid, /compatible.targets: .*claude-code/);
+});
+
 test('skills explain rejects unknown skill id', async () => {
   await assert.rejects(run(['skills', 'explain', 'missing-skill'], { packageRoot }), /Unknown skill: missing-skill/);
 });


### PR DESCRIPTION
## Summary
- Add CLI discovery assertions for `solid-principles-application` in `skills list`
- Add `skills explain solid-principles-application` assertions for path, description, and compatibility metadata

## Test plan
- [x] `bun test test/cli.test.ts`
- [x] `bun run check`

Refs #259
Closes #259