### PR TITLE
fix: create backup on first write

### DIFF
--- a/src/cli/file-helpers.test.ts
+++ b/src/cli/file-helpers.test.ts
@@ -23,9 +23,11 @@ test('parseFrontmatter returns null when block missing', () => {
 test('writeManagedFile supports overwrite, skip, merge, and abort modes', async () => {
   const root = await tempDir();
   const target = path.join(root, 'rules.md');
+  const backup = `${target}.bak`;
 
   await writeManagedFile({ outPath: target, rendered: 'first', onConflict: 'overwrite' });
   assert.equal(await fs.readFile(target, 'utf8'), 'first\n');
+  assert.equal(await fs.readFile(backup, 'utf8'), 'first\n');
 
   await writeManagedFile({ outPath: target, rendered: 'second', onConflict: 'skip' });
   assert.equal(await fs.readFile(target, 'utf8'), 'first\n');
@@ -34,7 +36,7 @@ test('writeManagedFile supports overwrite, skip, merge, and abort modes', async 
   const merged = await fs.readFile(target, 'utf8');
   assert.match(merged, /<!-- ailib:start -->/);
   assert.match(merged, /merged-content/);
-  assert.equal(await fs.readFile(`${target}.bak`, 'utf8'), 'first\n');
+  assert.equal(await fs.readFile(backup, 'utf8'), 'first\n');
 
   await assert.rejects(
     writeManagedFile({ outPath: target, rendered: 'ignored', onConflict: 'abort' }),

--- a/src/cli/file-helpers.ts
+++ b/src/cli/file-helpers.ts
@@ -15,6 +15,8 @@ export async function writeManagedFile({
   onConflict: string;
 }) {
   await fs.mkdir(path.dirname(outPath), { recursive: true });
+  const backupPath = `${outPath}.bak`;
+  let wroteBackup = false;
 
   if (await exists(outPath)) {
     if (onConflict === 'skip') return;
@@ -27,14 +29,19 @@ export async function writeManagedFile({
         ? `${existing.slice(0, existing.indexOf(AILIB_BLOCK_START)).trimEnd()}\n`
         : `${existing.trimEnd()}\n`;
       const merged = `${withoutOld}\n${AILIB_BLOCK_START}\n${rendered.trim()}\n${AILIB_BLOCK_END}\n`;
-      await fs.copyFile(outPath, `${outPath}.bak`);
+      await fs.copyFile(outPath, backupPath);
+      wroteBackup = true;
       await fs.writeFile(outPath, merged, 'utf8');
       return;
     }
-    await fs.copyFile(outPath, `${outPath}.bak`);
+    await fs.copyFile(outPath, backupPath);
+    wroteBackup = true;
   }
 
   await fs.writeFile(outPath, `${rendered.trim()}\n`, 'utf8');
+  if (!wroteBackup && !(await exists(backupPath))) {
+    await fs.copyFile(outPath, backupPath);
+  }
 }
 
 export async function copySourceFile({


### PR DESCRIPTION
## Summary
- Create `.bak` files on first-write managed file generation when no backup exists yet
- Preserve existing overwrite/merge backup semantics for pre-existing files
- Extend `writeManagedFile` tests to cover first-run backup creation

## Test plan
- [x] `bun test src/cli/file-helpers.test.ts`
- [x] `bun run check`

Refs #278
Closes #278