### PR TITLE
test: add first-run backup edge coverage

### DIFF
--- a/src/cli/file-helpers.test.ts
+++ b/src/cli/file-helpers.test.ts
@@ -44,6 +44,27 @@ test('writeManagedFile supports overwrite, skip, merge, and abort modes', async 
   );
 });
 
+test('writeManagedFile creates .bak for first-run nested paths', async () => {
+  const root = await tempDir();
+  const target = path.join(root, 'nested', 'configs', 'rules.md');
+  const backup = `${target}.bak`;
+
+  await writeManagedFile({ outPath: target, rendered: 'first-run', onConflict: 'overwrite' });
+  assert.equal(await fs.readFile(target, 'utf8'), 'first-run\n');
+  assert.equal(await fs.readFile(backup, 'utf8'), 'first-run\n');
+});
+
+test('writeManagedFile preserves existing backup on first write', async () => {
+  const root = await tempDir();
+  const target = path.join(root, 'rules.md');
+  const backup = `${target}.bak`;
+  await fs.writeFile(backup, 'existing-backup\n', 'utf8');
+
+  await writeManagedFile({ outPath: target, rendered: 'first-run', onConflict: 'overwrite' });
+  assert.equal(await fs.readFile(target, 'utf8'), 'first-run\n');
+  assert.equal(await fs.readFile(backup, 'utf8'), 'existing-backup\n');
+});
+
 test('copySourceFile copies from package source and validates existence', async () => {
   const root = await tempDir();
   const packageRoot = path.join(root, 'pkg');


### PR DESCRIPTION
## Summary
- Add first-run backup coverage for nested managed-file output paths
- Add regression coverage to preserve an already-existing `.bak` on first write
- Keep scope test-only to validate backup behavior introduced by #278

## Test plan
- [x] `bun test src/cli/file-helpers.test.ts`
- [x] `bun run check`

Refs #279
Closes #279

Made with [Cursor](https://cursor.com)