### PR TITLE
infra: add npm publish verification flow

### DIFF
--- a/docs/npm-publishing.md
+++ b/docs/npm-publishing.md
@@ -1,0 +1,55 @@
+# npm publishing for `@ailib/cli`
+
+This document defines the publish + verification flow for npm releases.
+
+## Prerequisites
+
+- npm account with publish access to `@ailib/cli`
+- npm auth already configured (`npm whoami`)
+- repository on a clean release commit
+
+## 1) Preflight release validation
+
+Run artifact build + readiness checks:
+
+```bash
+bun run release:npm:preflight
+```
+
+This validates:
+
+- release artifacts are generated under `dist/release/`
+- target package version is not already published
+- npm pack output contains required release files
+
+## 2) Publish and verify npm install resolution
+
+Run the publish workflow:
+
+```bash
+bun run release:npm:publish
+```
+
+The workflow performs:
+
+1. npm authentication check (`npm whoami`)
+2. `npm publish --access public`
+3. version resolution check (`npm view @ailib/cli version --json`)
+4. clean-directory install verification (`npm install @ailib/cli@<version>`)
+5. CLI smoke test (`npx ailib --help`)
+
+## 3) Optional dry-run publish verification
+
+To exercise non-publish verification paths without uploading:
+
+```bash
+bun run release:npm:publish:dry-run
+```
+
+## 4) Release evidence artifact
+
+The publish verification command writes:
+
+- `dist/release/npm-publish-report.json`
+
+Keep that report linked in the release task/PR for traceability.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   "scripts": {
     "release:build": "bash scripts/build-release-artifacts.sh",
     "release:npm:preflight": "bun run release:build && bun tools/npm-release-preflight.ts",
+    "release:npm:publish": "bun run release:npm:preflight && bun tools/npm-release-publish.ts",
+    "release:npm:publish:dry-run": "bun run release:npm:preflight && bun tools/npm-release-publish.ts --dry-run",
     "local:install": "bash scripts/install-local.sh",
     "security:audit": "bun audit --audit-level=high",
     "format:check": "prettier --check \"**/*.{ts,js,json,md,yml,yaml}\" --ignore-unknown",

--- a/tools/npm-release-publish.test.ts
+++ b/tools/npm-release-publish.test.ts
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+
+async function tempDir() {
+  return await fs.mkdtemp(path.join(os.tmpdir(), 'ailib-npm-publish-'));
+}
+
+test('npm-release-publish supports dry-run verification with fixture version', async () => {
+  const dir = await tempDir();
+  const packageFile = path.join(dir, 'package.json');
+  const publishedVersionFile = path.join(dir, 'published-version.json');
+  const reportFile = path.join(dir, 'report.json');
+
+  await fs.writeFile(packageFile, JSON.stringify({ name: '@ailib/cli', version: '9.9.9' }), 'utf8');
+  await fs.writeFile(publishedVersionFile, JSON.stringify('9.9.9'), 'utf8');
+
+  const result = spawnSync(
+    'bun',
+    [
+      'tools/npm-release-publish.ts',
+      '--dry-run',
+      `--package-file=${packageFile}`,
+      `--published-version-json-file=${publishedVersionFile}`,
+      `--report-file=${reportFile}`
+    ],
+    { cwd: packageRoot, encoding: 'utf8' }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /npm publish verification passed/);
+
+  const report = JSON.parse(await fs.readFile(reportFile, 'utf8')) as Record<string, unknown>;
+  assert.equal(report.packageName, '@ailib/cli');
+  assert.equal(report.version, '9.9.9');
+  assert.equal(report.dryRun, true);
+});
+
+test('npm-release-publish fails dry-run when resolved version mismatches package version', async () => {
+  const dir = await tempDir();
+  const packageFile = path.join(dir, 'package.json');
+  const publishedVersionFile = path.join(dir, 'published-version.json');
+
+  await fs.writeFile(packageFile, JSON.stringify({ name: '@ailib/cli', version: '1.2.3' }), 'utf8');
+  await fs.writeFile(publishedVersionFile, JSON.stringify('1.2.4'), 'utf8');
+
+  const result = spawnSync(
+    'bun',
+    [
+      'tools/npm-release-publish.ts',
+      '--dry-run',
+      `--package-file=${packageFile}`,
+      `--published-version-json-file=${publishedVersionFile}`,
+      `--report-file=${path.join(dir, 'report.json')}`
+    ],
+    { cwd: packageRoot, encoding: 'utf8' }
+  );
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Published version mismatch/);
+});

--- a/tools/npm-release-publish.ts
+++ b/tools/npm-release-publish.ts
@@ -1,0 +1,206 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+
+type CliArgs = {
+  packageFile: string;
+  publishedVersionJsonFile?: string;
+  reportFile: string;
+  dryRun: boolean;
+};
+
+type PackageMetadata = {
+  name: string;
+  version: string;
+};
+
+type PublishReport = {
+  packageName: string;
+  version: string;
+  dryRun: boolean;
+  checks: {
+    npmAuthVerified: boolean;
+    publishCommandExecuted: boolean;
+    npmVersionResolved: boolean;
+    installVerificationPassed: boolean;
+  };
+  checkedAt: string;
+};
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = {
+    packageFile: 'package.json',
+    reportFile: 'dist/release/npm-publish-report.json',
+    dryRun: false
+  };
+
+  for (const arg of argv) {
+    if (arg === '--dry-run') {
+      args.dryRun = true;
+      continue;
+    }
+    if (arg.startsWith('--package-file=')) {
+      args.packageFile = arg.slice('--package-file='.length);
+      continue;
+    }
+    if (arg.startsWith('--published-version-json-file=')) {
+      args.publishedVersionJsonFile = arg.slice('--published-version-json-file='.length);
+      continue;
+    }
+    if (arg.startsWith('--report-file=')) {
+      args.reportFile = arg.slice('--report-file='.length);
+      continue;
+    }
+
+    throw new Error(
+      [
+        `Unknown option: ${arg}`,
+        'Usage: bun tools/npm-release-publish.ts [--dry-run]',
+        '  [--package-file=package.json]',
+        '  [--published-version-json-file=<path>]',
+        '  [--report-file=dist/release/npm-publish-report.json]'
+      ].join('\n')
+    );
+  }
+
+  return args;
+}
+
+function resolveInputPath(inputPath: string): string {
+  return path.isAbsolute(inputPath) ? inputPath : path.join(root, inputPath);
+}
+
+async function readJsonFromFile(filePath: string): Promise<unknown> {
+  const raw = await fs.readFile(resolveInputPath(filePath), 'utf8');
+  return JSON.parse(raw);
+}
+
+async function runCommand(command: string, args: string[], cwd = root): Promise<{ stdout: string; stderr: string }> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+      reject(new Error(`${command} ${args.join(' ')} failed: ${stderr.trim() || `exit ${String(code)}`}`));
+    });
+  });
+}
+
+function parsePackageMetadata(data: unknown): PackageMetadata {
+  if (!data || typeof data !== 'object') {
+    throw new Error('Invalid package.json: expected object');
+  }
+  const pkg = data as Record<string, unknown>;
+  if (typeof pkg.name !== 'string' || !pkg.name.trim()) {
+    throw new Error('Invalid package.json: missing package name');
+  }
+  if (typeof pkg.version !== 'string' || !pkg.version.trim()) {
+    throw new Error('Invalid package.json: missing package version');
+  }
+  return { name: pkg.name, version: pkg.version };
+}
+
+function parseVersionPayload(data: unknown): string {
+  if (typeof data === 'string') {
+    return data;
+  }
+  if (Array.isArray(data)) {
+    const last = data[data.length - 1];
+    if (typeof last === 'string') {
+      return last;
+    }
+  }
+  throw new Error('Invalid npm version payload: expected string or non-empty string array');
+}
+
+async function verifyInstalledCli(pkg: PackageMetadata): Promise<void> {
+  const installDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ailib-npm-install-check-'));
+  try {
+    await runCommand('npm', ['init', '-y'], installDir);
+    await runCommand('npm', ['install', `${pkg.name}@${pkg.version}`], installDir);
+    const help = await runCommand('npx', ['--yes', 'ailib', '--help'], installDir);
+    if (!/ailib commands:/u.test(help.stdout)) {
+      throw new Error(`Installed CLI did not produce expected help output for ${pkg.name}@${pkg.version}`);
+    }
+  } finally {
+    await fs.rm(installDir, { recursive: true, force: true });
+  }
+}
+
+async function writeReport(reportPath: string, report: PublishReport): Promise<void> {
+  await fs.mkdir(path.dirname(reportPath), { recursive: true });
+  await fs.writeFile(reportPath, JSON.stringify(report, null, 2), 'utf8');
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const packageData = await readJsonFromFile(args.packageFile);
+  const pkg = parsePackageMetadata(packageData);
+
+  const report: PublishReport = {
+    packageName: pkg.name,
+    version: pkg.version,
+    dryRun: args.dryRun,
+    checks: {
+      npmAuthVerified: false,
+      publishCommandExecuted: false,
+      npmVersionResolved: false,
+      installVerificationPassed: false
+    },
+    checkedAt: new Date().toISOString()
+  };
+
+  if (!args.dryRun) {
+    await runCommand('npm', ['whoami']);
+    report.checks.npmAuthVerified = true;
+
+    await runCommand('npm', ['publish', '--access', 'public']);
+    report.checks.publishCommandExecuted = true;
+  }
+
+  const publishedVersionPayload = args.publishedVersionJsonFile
+    ? await readJsonFromFile(args.publishedVersionJsonFile)
+    : JSON.parse((await runCommand('npm', ['view', pkg.name, 'version', '--json'])).stdout);
+  const publishedVersion = parseVersionPayload(publishedVersionPayload);
+  if (publishedVersion !== pkg.version) {
+    throw new Error(
+      `Published version mismatch for ${pkg.name}: expected ${pkg.version}, received ${publishedVersion}`
+    );
+  }
+  report.checks.npmVersionResolved = true;
+
+  if (!args.dryRun) {
+    await verifyInstalledCli(pkg);
+    report.checks.installVerificationPassed = true;
+  }
+
+  const reportPath = resolveInputPath(args.reportFile);
+  await writeReport(reportPath, report);
+
+  process.stdout.write(`npm publish verification passed for ${pkg.name}@${pkg.version}\n`);
+  process.stdout.write(`report: ${path.relative(root, reportPath)}\n`);
+}
+
+main().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add `tools/npm-release-publish.ts` to run npm auth check, publish, version resolution check, and install smoke verification
- Add dry-run fixture tests for publish verification behavior and mismatch failure paths
- Add release scripts and docs for publish + verify workflow execution

## Test plan
- [x] `bun test tools/npm-release-preflight.test.ts tools/npm-release-publish.test.ts`
- [x] `bun run check`

Refs #284
Closes #284

Made with [Cursor](https://cursor.com)