### PR TITLE
infra: add npm release record generator

### DIFF
--- a/docs/npm-publishing.md
+++ b/docs/npm-publishing.md
@@ -46,10 +46,24 @@ To exercise non-publish verification paths without uploading:
 bun run release:npm:publish:dry-run
 ```
 
-## 4) Release evidence artifact
+## 4) Generate release record
+
+After publish verification, generate a markdown release record with release notes linkage:
+
+```bash
+bun run release:npm:record -- --release-notes-url=https://github.com/Alisya-AI/ai-lib/releases/tag/vX.Y.Z
+```
+
+This writes:
+
+- `dist/release/npm-release-record.md`
+
+## 5) Release evidence artifacts
 
 The publish verification command writes:
 
 - `dist/release/npm-publish-report.json`
+- `dist/release/npm-preflight-report.json`
+- `dist/release/npm-release-record.md`
 
-Keep that report linked in the release task/PR for traceability.
+Keep these artifacts linked in the release task/PR for traceability.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "release:npm:preflight": "bun run release:build && bun tools/npm-release-preflight.ts",
     "release:npm:publish": "bun run release:npm:preflight && bun tools/npm-release-publish.ts",
     "release:npm:publish:dry-run": "bun run release:npm:preflight && bun tools/npm-release-publish.ts --dry-run",
+    "release:npm:record": "bun tools/generate-npm-release-record.ts",
     "local:install": "bash scripts/install-local.sh",
     "security:audit": "bun audit --audit-level=high",
     "format:check": "prettier --check \"**/*.{ts,js,json,md,yml,yaml}\" --ignore-unknown",

--- a/tools/generate-npm-release-record.test.ts
+++ b/tools/generate-npm-release-record.test.ts
@@ -1,0 +1,93 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+
+async function tempDir() {
+  return await fs.mkdtemp(path.join(os.tmpdir(), 'ailib-release-record-'));
+}
+
+test('generate-npm-release-record creates markdown with evidence and release notes', async () => {
+  const dir = await tempDir();
+  const packageFile = path.join(dir, 'package.json');
+  const preflightFile = path.join(dir, 'npm-preflight-report.json');
+  const publishFile = path.join(dir, 'npm-publish-report.json');
+  const outputFile = path.join(dir, 'npm-release-record.md');
+
+  await fs.writeFile(packageFile, JSON.stringify({ name: '@ailib/cli', version: '1.2.3' }), 'utf8');
+  await fs.writeFile(
+    preflightFile,
+    JSON.stringify({
+      packageName: '@ailib/cli',
+      version: '1.2.3',
+      tarball: 'ailib-cli-1.2.3.tgz',
+      checkedAt: '2026-01-01T00:00:00.000Z'
+    }),
+    'utf8'
+  );
+  await fs.writeFile(
+    publishFile,
+    JSON.stringify({
+      packageName: '@ailib/cli',
+      version: '1.2.3',
+      checkedAt: '2026-01-01T01:00:00.000Z'
+    }),
+    'utf8'
+  );
+
+  const result = spawnSync(
+    'bun',
+    [
+      'tools/generate-npm-release-record.ts',
+      `--package-file=${packageFile}`,
+      `--preflight-report-file=${preflightFile}`,
+      `--publish-report-file=${publishFile}`,
+      `--output-file=${outputFile}`,
+      '--release-notes-url=https://github.com/Alisya-AI/ai-lib/releases/tag/v1.2.3'
+    ],
+    { cwd: packageRoot, encoding: 'utf8' }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /npm release record written/);
+
+  const markdown = await fs.readFile(outputFile, 'utf8');
+  assert.match(markdown, /@ailib\/cli@1\.2\.3/);
+  assert.match(markdown, /ailib-cli-1\.2\.3\.tgz/);
+  assert.match(markdown, /https:\/\/github\.com\/Alisya-AI\/ai-lib\/releases\/tag\/v1\.2\.3/);
+});
+
+test('generate-npm-release-record fails when release-notes-url is missing', async () => {
+  const dir = await tempDir();
+  const packageFile = path.join(dir, 'package.json');
+  const preflightFile = path.join(dir, 'npm-preflight-report.json');
+  const publishFile = path.join(dir, 'npm-publish-report.json');
+  const outputFile = path.join(dir, 'npm-release-record.md');
+
+  await fs.writeFile(packageFile, JSON.stringify({ name: '@ailib/cli', version: '1.2.3' }), 'utf8');
+  await fs.writeFile(
+    preflightFile,
+    JSON.stringify({ packageName: '@ailib/cli', version: '1.2.3', tarball: 'ailib-cli-1.2.3.tgz' }),
+    'utf8'
+  );
+  await fs.writeFile(publishFile, JSON.stringify({ packageName: '@ailib/cli', version: '1.2.3' }), 'utf8');
+
+  const result = spawnSync(
+    'bun',
+    [
+      'tools/generate-npm-release-record.ts',
+      `--package-file=${packageFile}`,
+      `--preflight-report-file=${preflightFile}`,
+      `--publish-report-file=${publishFile}`,
+      `--output-file=${outputFile}`
+    ],
+    { cwd: packageRoot, encoding: 'utf8' }
+  );
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Missing required option: --release-notes-url/);
+});

--- a/tools/generate-npm-release-record.ts
+++ b/tools/generate-npm-release-record.ts
@@ -1,0 +1,227 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+
+type CliArgs = {
+  packageFile: string;
+  preflightReportFile: string;
+  publishReportFile: string;
+  outputFile: string;
+  releaseNotesUrl: string;
+};
+
+type PackageMetadata = {
+  name: string;
+  version: string;
+};
+
+type PreflightReport = {
+  packageName: string;
+  version: string;
+  tarball: string;
+  checkedAt?: string;
+};
+
+type PublishReport = {
+  packageName: string;
+  version: string;
+  checkedAt?: string;
+};
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = {
+    packageFile: 'package.json',
+    preflightReportFile: 'dist/release/npm-preflight-report.json',
+    publishReportFile: 'dist/release/npm-publish-report.json',
+    outputFile: 'dist/release/npm-release-record.md',
+    releaseNotesUrl: ''
+  };
+
+  for (const arg of argv) {
+    if (arg.startsWith('--package-file=')) {
+      args.packageFile = arg.slice('--package-file='.length);
+      continue;
+    }
+    if (arg.startsWith('--preflight-report-file=')) {
+      args.preflightReportFile = arg.slice('--preflight-report-file='.length);
+      continue;
+    }
+    if (arg.startsWith('--publish-report-file=')) {
+      args.publishReportFile = arg.slice('--publish-report-file='.length);
+      continue;
+    }
+    if (arg.startsWith('--output-file=')) {
+      args.outputFile = arg.slice('--output-file='.length);
+      continue;
+    }
+    if (arg.startsWith('--release-notes-url=')) {
+      args.releaseNotesUrl = arg.slice('--release-notes-url='.length);
+      continue;
+    }
+
+    throw new Error(
+      [
+        `Unknown option: ${arg}`,
+        'Usage: bun tools/generate-npm-release-record.ts',
+        '  --release-notes-url=<url>',
+        '  [--package-file=package.json]',
+        '  [--preflight-report-file=dist/release/npm-preflight-report.json]',
+        '  [--publish-report-file=dist/release/npm-publish-report.json]',
+        '  [--output-file=dist/release/npm-release-record.md]'
+      ].join('\n')
+    );
+  }
+
+  if (!args.releaseNotesUrl.trim()) {
+    throw new Error('Missing required option: --release-notes-url=<url>');
+  }
+
+  return args;
+}
+
+function resolveInputPath(inputPath: string): string {
+  return path.isAbsolute(inputPath) ? inputPath : path.join(root, inputPath);
+}
+
+async function readJsonFromFile(filePath: string): Promise<unknown> {
+  const raw = await fs.readFile(resolveInputPath(filePath), 'utf8');
+  return JSON.parse(raw);
+}
+
+function parsePackageMetadata(data: unknown): PackageMetadata {
+  if (!data || typeof data !== 'object') {
+    throw new Error('Invalid package.json: expected object');
+  }
+  const pkg = data as Record<string, unknown>;
+  if (typeof pkg.name !== 'string' || !pkg.name.trim()) {
+    throw new Error('Invalid package.json: missing package name');
+  }
+  if (typeof pkg.version !== 'string' || !pkg.version.trim()) {
+    throw new Error('Invalid package.json: missing package version');
+  }
+  return { name: pkg.name, version: pkg.version };
+}
+
+function parsePreflightReport(data: unknown): PreflightReport {
+  if (!data || typeof data !== 'object') {
+    throw new Error('Invalid npm preflight report: expected object');
+  }
+  const report = data as Record<string, unknown>;
+  if (
+    typeof report.packageName !== 'string' ||
+    typeof report.version !== 'string' ||
+    typeof report.tarball !== 'string'
+  ) {
+    throw new Error('Invalid npm preflight report: missing packageName/version/tarball');
+  }
+  return {
+    packageName: report.packageName,
+    version: report.version,
+    tarball: report.tarball,
+    checkedAt: typeof report.checkedAt === 'string' ? report.checkedAt : undefined
+  };
+}
+
+function parsePublishReport(data: unknown): PublishReport {
+  if (!data || typeof data !== 'object') {
+    throw new Error('Invalid npm publish report: expected object');
+  }
+  const report = data as Record<string, unknown>;
+  if (typeof report.packageName !== 'string' || typeof report.version !== 'string') {
+    throw new Error('Invalid npm publish report: missing packageName/version');
+  }
+  return {
+    packageName: report.packageName,
+    version: report.version,
+    checkedAt: typeof report.checkedAt === 'string' ? report.checkedAt : undefined
+  };
+}
+
+function ensureSamePackageAndVersion(pkg: PackageMetadata, preflight: PreflightReport, publish: PublishReport) {
+  if (pkg.name !== preflight.packageName || pkg.name !== publish.packageName) {
+    throw new Error('Release reports reference a different package than package.json');
+  }
+  if (pkg.version !== preflight.version || pkg.version !== publish.version) {
+    throw new Error('Release reports reference a different version than package.json');
+  }
+}
+
+function buildRecordMarkdown({
+  pkg,
+  preflight,
+  publish,
+  releaseNotesUrl,
+  generatedAt
+}: {
+  pkg: PackageMetadata;
+  preflight: PreflightReport;
+  publish: PublishReport;
+  releaseNotesUrl: string;
+  generatedAt: string;
+}) {
+  const npmPackageUrl = `https://www.npmjs.com/package/${pkg.name}/v/${pkg.version}`;
+  return [
+    `# npm release record: ${pkg.name}@${pkg.version}`,
+    '',
+    `Generated at: ${generatedAt}`,
+    '',
+    '## Published package',
+    '',
+    `- Package: \`${pkg.name}\``,
+    `- Version: \`${pkg.version}\``,
+    `- npm package URL: ${npmPackageUrl}`,
+    '',
+    '## Verification evidence',
+    '',
+    `- Preflight report: \`dist/release/npm-preflight-report.json\``,
+    `- Publish report: \`dist/release/npm-publish-report.json\``,
+    `- Packed tarball: \`${preflight.tarball}\``,
+    `- Preflight checked at: \`${preflight.checkedAt || 'n/a'}\``,
+    `- Publish checked at: \`${publish.checkedAt || 'n/a'}\``,
+    '',
+    '## Release notes',
+    '',
+    `- ${releaseNotesUrl}`,
+    '',
+    '## Verification commands run',
+    '',
+    '- `bun run release:npm:preflight`',
+    '- `bun run release:npm:publish`',
+    '- `npm view @ailib/cli version --json`',
+    '- `npx --yes ailib --help`',
+    ''
+  ].join('\n');
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const packageData = await readJsonFromFile(args.packageFile);
+  const preflightData = await readJsonFromFile(args.preflightReportFile);
+  const publishData = await readJsonFromFile(args.publishReportFile);
+
+  const pkg = parsePackageMetadata(packageData);
+  const preflight = parsePreflightReport(preflightData);
+  const publish = parsePublishReport(publishData);
+
+  ensureSamePackageAndVersion(pkg, preflight, publish);
+
+  const outputPath = resolveInputPath(args.outputFile);
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  const markdown = buildRecordMarkdown({
+    pkg,
+    preflight,
+    publish,
+    releaseNotesUrl: args.releaseNotesUrl,
+    generatedAt: new Date().toISOString()
+  });
+  await fs.writeFile(outputPath, markdown, 'utf8');
+
+  process.stdout.write(`npm release record written: ${path.relative(root, outputPath)}\n`);
+}
+
+main().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add `tools/generate-npm-release-record.ts` to produce markdown release records from npm preflight/publish evidence files
- Add tests covering successful record generation and required release-notes-link validation
- Add `release:npm:record` script and update npm publishing docs with release record workflow

## Test plan
- [x] `bun test tools/generate-npm-release-record.test.ts tools/npm-release-preflight.test.ts tools/npm-release-publish.test.ts`
- [x] `bun run check`

Refs #285
Closes #285

Made with [Cursor](https://cursor.com)