### PR TITLE
infra: add gha npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,68 @@
+name: npm-publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_notes_url:
+        description: Release notes URL (for npm release record)
+        required: true
+        type: string
+      ref:
+        description: Git ref to publish from
+        required: false
+        default: main
+        type: string
+
+concurrency:
+  group: npm-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node for npm publishing
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Validate npm token secret
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "${NPM_TOKEN}" ]; then
+            echo "Missing required repository secret: NPM_TOKEN"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Publish and verify npm release
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: bun run release:npm:publish
+
+      - name: Generate npm release record
+        run: bun run release:npm:record -- --release-notes-url="${{ inputs.release_notes_url }}"
+
+      - name: Upload release evidence artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-release-evidence
+          path: dist/release/

--- a/docs/npm-publishing.md
+++ b/docs/npm-publishing.md
@@ -7,6 +7,7 @@ This document defines the publish + verification flow for npm releases.
 - npm account with publish access to `@ailib/cli`
 - npm auth already configured (`npm whoami`)
 - repository on a clean release commit
+- for GitHub Actions publishing: repository secret `NPM_TOKEN` with npm automation token
 
 ## 1) Preflight release validation
 
@@ -67,3 +68,31 @@ The publish verification command writes:
 - `dist/release/npm-release-record.md`
 
 Keep these artifacts linked in the release task/PR for traceability.
+
+## 6) GitHub Actions release workflow
+
+This repository includes a manual publish workflow:
+
+- Workflow: `.github/workflows/npm-publish.yml`
+- Trigger: `workflow_dispatch`
+- Inputs:
+  - `release_notes_url` (required)
+  - `ref` (optional, default `main`)
+
+The workflow runs:
+
+1. `bun run release:npm:publish`
+2. `bun run release:npm:record -- --release-notes-url=<input>`
+3. Uploads `dist/release/` as `npm-release-evidence` artifact
+
+### Secret configuration
+
+Set `NPM_TOKEN` in repository secrets:
+
+- npm type: Automation token (recommended for CI publish)
+- scope: minimal publish permissions for `@ailib/cli`
+
+### Optional hardening: npm trusted publishing
+
+You can migrate from `NPM_TOKEN` to npm Trusted Publishing (OIDC) later.
+That removes long-lived token storage and uses GitHub-issued identity.


### PR DESCRIPTION
## Summary
- Add a manual GitHub Actions workflow to publish `@ailib/cli` from CI using `NPM_TOKEN`
- Run existing publish + verification + release-record scripts in the workflow
- Upload `dist/release/` artifacts and document secret/workflow setup in npm publishing docs

## Test plan
- [x] `bun run format:check`
- [x] `bun run check`

Refs #297
Closes #297

Made with [Cursor](https://cursor.com)