### PR TITLE
fix: handle first publish and scope alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ### npm
 
 ```bash
-npm install -g @ailib/cli
+npm install -g @alisya.ai/ailib
 ```
 
 ### Homebrew

--- a/bun.lock
+++ b/bun.lock
@@ -2,7 +2,7 @@
   "lockfileVersion": 1,
   "workspaces": {
     "": {
-      "name": "@ailib/cli",
+      "name": "@alisya.ai/ailib",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/node": "^25.6.0",

--- a/docs/npm-publishing.md
+++ b/docs/npm-publishing.md
@@ -1,10 +1,10 @@
-# npm publishing for `@ailib/cli`
+# npm publishing for `@alisya.ai/ailib`
 
 This document defines the publish + verification flow for npm releases.
 
 ## Prerequisites
 
-- npm account with publish access to `@ailib/cli`
+- npm account with publish access to `@alisya.ai/ailib`
 - npm auth already configured (`npm whoami`)
 - repository on a clean release commit
 - for GitHub Actions publishing: repository secret `NPM_TOKEN` with npm automation token
@@ -35,8 +35,8 @@ The workflow performs:
 
 1. npm authentication check (`npm whoami`)
 2. `npm publish --access public`
-3. version resolution check (`npm view @ailib/cli version --json`)
-4. clean-directory install verification (`npm install @ailib/cli@<version>`)
+3. version resolution check (`npm view @alisya.ai/ailib version --json`)
+4. clean-directory install verification (`npm install @alisya.ai/ailib@<version>`)
 5. CLI smoke test (`npx ailib --help`)
 
 ## 3) Optional dry-run publish verification
@@ -90,7 +90,7 @@ The workflow runs:
 Set `NPM_TOKEN` in repository secrets:
 
 - npm type: Automation token (recommended for CI publish)
-- scope: minimal publish permissions for `@ailib/cli`
+- scope: minimal publish permissions for `@alisya.ai/ailib`
 
 ### Optional hardening: npm trusted publishing
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ailib/cli",
+  "name": "@alisya.ai/ailib",
   "version": "1.0.0",
   "description": "Universal AI context-injection engine CLI",
   "type": "module",

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -21,7 +21,7 @@ bun install --frozen-lockfile
 echo "Building TypeScript tooling outputs..."
 bun run tools:build
 
-echo "Installing @ailib/cli globally from local repository..."
+echo "Installing @alisya.ai/ailib globally from local repository..."
 npm install -g .
 
 echo "Validating installed CLI..."

--- a/tools/generate-npm-release-record.test.ts
+++ b/tools/generate-npm-release-record.test.ts
@@ -18,13 +18,13 @@ test('generate-npm-release-record creates markdown with evidence and release not
   const publishFile = path.join(dir, 'npm-publish-report.json');
   const outputFile = path.join(dir, 'npm-release-record.md');
 
-  await fs.writeFile(packageFile, JSON.stringify({ name: '@ailib/cli', version: '1.2.3' }), 'utf8');
+  await fs.writeFile(packageFile, JSON.stringify({ name: '@alisya.ai/ailib', version: '1.2.3' }), 'utf8');
   await fs.writeFile(
     preflightFile,
     JSON.stringify({
-      packageName: '@ailib/cli',
+      packageName: '@alisya.ai/ailib',
       version: '1.2.3',
-      tarball: 'ailib-cli-1.2.3.tgz',
+      tarball: 'alisya.ai-ailib-1.2.3.tgz',
       checkedAt: '2026-01-01T00:00:00.000Z'
     }),
     'utf8'
@@ -32,7 +32,7 @@ test('generate-npm-release-record creates markdown with evidence and release not
   await fs.writeFile(
     publishFile,
     JSON.stringify({
-      packageName: '@ailib/cli',
+      packageName: '@alisya.ai/ailib',
       version: '1.2.3',
       checkedAt: '2026-01-01T01:00:00.000Z'
     }),
@@ -56,8 +56,8 @@ test('generate-npm-release-record creates markdown with evidence and release not
   assert.match(result.stdout, /npm release record written/);
 
   const markdown = await fs.readFile(outputFile, 'utf8');
-  assert.match(markdown, /@ailib\/cli@1\.2\.3/);
-  assert.match(markdown, /ailib-cli-1\.2\.3\.tgz/);
+  assert.match(markdown, /@alisya\.ai\/ailib@1\.2\.3/);
+  assert.match(markdown, /alisya.ai-ailib-1\.2\.3\.tgz/);
   assert.match(markdown, /https:\/\/github\.com\/Alisya-AI\/ai-lib\/releases\/tag\/v1\.2\.3/);
 });
 
@@ -68,13 +68,13 @@ test('generate-npm-release-record fails when release-notes-url is missing', asyn
   const publishFile = path.join(dir, 'npm-publish-report.json');
   const outputFile = path.join(dir, 'npm-release-record.md');
 
-  await fs.writeFile(packageFile, JSON.stringify({ name: '@ailib/cli', version: '1.2.3' }), 'utf8');
+  await fs.writeFile(packageFile, JSON.stringify({ name: '@alisya.ai/ailib', version: '1.2.3' }), 'utf8');
   await fs.writeFile(
     preflightFile,
-    JSON.stringify({ packageName: '@ailib/cli', version: '1.2.3', tarball: 'ailib-cli-1.2.3.tgz' }),
+    JSON.stringify({ packageName: '@alisya.ai/ailib', version: '1.2.3', tarball: 'alisya.ai-ailib-1.2.3.tgz' }),
     'utf8'
   );
-  await fs.writeFile(publishFile, JSON.stringify({ packageName: '@ailib/cli', version: '1.2.3' }), 'utf8');
+  await fs.writeFile(publishFile, JSON.stringify({ packageName: '@alisya.ai/ailib', version: '1.2.3' }), 'utf8');
 
   const result = spawnSync(
     'bun',

--- a/tools/generate-npm-release-record.ts
+++ b/tools/generate-npm-release-record.ts
@@ -188,7 +188,7 @@ function buildRecordMarkdown({
     '',
     '- `bun run release:npm:preflight`',
     '- `bun run release:npm:publish`',
-    '- `npm view @ailib/cli version --json`',
+    '- `npm view @alisya.ai/ailib version --json`',
     '- `npx --yes ailib --help`',
     ''
   ].join('\n');

--- a/tools/npm-release-preflight.test.ts
+++ b/tools/npm-release-preflight.test.ts
@@ -11,7 +11,7 @@ async function tempDir() {
   return await fs.mkdtemp(path.join(os.tmpdir(), 'ailib-npm-preflight-'));
 }
 
-test('npm-release-preflight succeeds with fixture payloads', async () => {
+test('npm-release-preflight succeeds for first-time publish fixture payloads', async () => {
   const dir = await tempDir();
   const packageFile = path.join(dir, 'package.json');
   const versionsFile = path.join(dir, 'versions.json');
@@ -19,7 +19,7 @@ test('npm-release-preflight succeeds with fixture payloads', async () => {
   const reportFile = path.join(dir, 'report.json');
 
   await fs.writeFile(packageFile, JSON.stringify({ name: '@ailib/cli', version: '9.9.9' }), 'utf8');
-  await fs.writeFile(versionsFile, JSON.stringify(['1.0.0', '1.0.1']), 'utf8');
+  await fs.writeFile(versionsFile, JSON.stringify([]), 'utf8');
   await fs.writeFile(
     packFile,
     JSON.stringify([

--- a/tools/npm-release-preflight.test.ts
+++ b/tools/npm-release-preflight.test.ts
@@ -18,13 +18,13 @@ test('npm-release-preflight succeeds for first-time publish fixture payloads', a
   const packFile = path.join(dir, 'pack.json');
   const reportFile = path.join(dir, 'report.json');
 
-  await fs.writeFile(packageFile, JSON.stringify({ name: '@ailib/cli', version: '9.9.9' }), 'utf8');
+  await fs.writeFile(packageFile, JSON.stringify({ name: '@alisya.ai/ailib', version: '9.9.9' }), 'utf8');
   await fs.writeFile(versionsFile, JSON.stringify([]), 'utf8');
   await fs.writeFile(
     packFile,
     JSON.stringify([
       {
-        filename: 'ailib-cli-9.9.9.tgz',
+        filename: 'alisya.ai-ailib-9.9.9.tgz',
         files: [{ path: 'bin/ailib.js' }, { path: 'src/cli.ts' }, { path: 'registry.json' }]
       }
     ]),
@@ -47,9 +47,9 @@ test('npm-release-preflight succeeds for first-time publish fixture payloads', a
   assert.match(result.stdout, /npm release preflight passed/);
 
   const report = JSON.parse(await fs.readFile(reportFile, 'utf8')) as Record<string, unknown>;
-  assert.equal(report.packageName, '@ailib/cli');
+  assert.equal(report.packageName, '@alisya.ai/ailib');
   assert.equal(report.version, '9.9.9');
-  assert.equal(report.tarball, 'ailib-cli-9.9.9.tgz');
+  assert.equal(report.tarball, 'alisya.ai-ailib-9.9.9.tgz');
 });
 
 test('npm-release-preflight fails when target version is already published', async () => {
@@ -58,13 +58,13 @@ test('npm-release-preflight fails when target version is already published', asy
   const versionsFile = path.join(dir, 'versions.json');
   const packFile = path.join(dir, 'pack.json');
 
-  await fs.writeFile(packageFile, JSON.stringify({ name: '@ailib/cli', version: '1.0.0' }), 'utf8');
+  await fs.writeFile(packageFile, JSON.stringify({ name: '@alisya.ai/ailib', version: '1.0.0' }), 'utf8');
   await fs.writeFile(versionsFile, JSON.stringify(['0.9.0', '1.0.0']), 'utf8');
   await fs.writeFile(
     packFile,
     JSON.stringify([
       {
-        filename: 'ailib-cli-1.0.0.tgz',
+        filename: 'alisya.ai-ailib-1.0.0.tgz',
         files: [{ path: 'bin/ailib.js' }, { path: 'src/cli.ts' }, { path: 'registry.json' }]
       }
     ]),

--- a/tools/npm-release-preflight.ts
+++ b/tools/npm-release-preflight.ts
@@ -91,6 +91,15 @@ async function runCommand(command: string, args: string[]): Promise<string> {
   });
 }
 
+function isNpmPackageNotFoundError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return (
+    error.message.includes('npm error code E404') ||
+    error.message.includes('npm ERR! code E404') ||
+    error.message.includes('404 Not Found')
+  );
+}
+
 function parsePackageMetadata(data: unknown): PackageMetadata {
   if (!data || typeof data !== 'object') {
     throw new Error('Invalid package.json: expected object');
@@ -151,9 +160,21 @@ async function main() {
   const packageData = await readJsonFromFile(args.packageFile);
   const pkg = parsePackageMetadata(packageData);
 
-  const versionsPayload = args.versionsJsonFile
-    ? await readJsonFromFile(args.versionsJsonFile)
-    : JSON.parse(await runCommand('npm', ['view', pkg.name, 'versions', '--json']));
+  let versionsPayload: unknown;
+  if (args.versionsJsonFile) {
+    versionsPayload = await readJsonFromFile(args.versionsJsonFile);
+  } else {
+    try {
+      versionsPayload = JSON.parse(await runCommand('npm', ['view', pkg.name, 'versions', '--json']));
+    } catch (error: unknown) {
+      // First-time publish returns 404 because the package does not exist yet.
+      if (isNpmPackageNotFoundError(error)) {
+        versionsPayload = [];
+      } else {
+        throw error;
+      }
+    }
+  }
   const publishedVersions = parseVersions(versionsPayload);
 
   if (publishedVersions.includes(pkg.version)) {

--- a/tools/npm-release-publish.test.ts
+++ b/tools/npm-release-publish.test.ts
@@ -17,7 +17,7 @@ test('npm-release-publish supports dry-run verification with fixture version', a
   const publishedVersionFile = path.join(dir, 'published-version.json');
   const reportFile = path.join(dir, 'report.json');
 
-  await fs.writeFile(packageFile, JSON.stringify({ name: '@ailib/cli', version: '9.9.9' }), 'utf8');
+  await fs.writeFile(packageFile, JSON.stringify({ name: '@alisya.ai/ailib', version: '9.9.9' }), 'utf8');
   await fs.writeFile(publishedVersionFile, JSON.stringify('9.9.9'), 'utf8');
 
   const result = spawnSync(
@@ -36,7 +36,7 @@ test('npm-release-publish supports dry-run verification with fixture version', a
   assert.match(result.stdout, /npm publish verification passed/);
 
   const report = JSON.parse(await fs.readFile(reportFile, 'utf8')) as Record<string, unknown>;
-  assert.equal(report.packageName, '@ailib/cli');
+  assert.equal(report.packageName, '@alisya.ai/ailib');
   assert.equal(report.version, '9.9.9');
   assert.equal(report.dryRun, true);
 });
@@ -46,7 +46,7 @@ test('npm-release-publish fails dry-run when resolved version mismatches package
   const packageFile = path.join(dir, 'package.json');
   const publishedVersionFile = path.join(dir, 'published-version.json');
 
-  await fs.writeFile(packageFile, JSON.stringify({ name: '@ailib/cli', version: '1.2.3' }), 'utf8');
+  await fs.writeFile(packageFile, JSON.stringify({ name: '@alisya.ai/ailib', version: '1.2.3' }), 'utf8');
   await fs.writeFile(publishedVersionFile, JSON.stringify('1.2.4'), 'utf8');
 
   const result = spawnSync(


### PR DESCRIPTION
## Summary
- Handle first-time npm publish preflight by treating npm 404 version lookups as an unpublished-package path
- Align package scope/name references from `@ailib/cli` to `@alisya.ai/ailib` across package metadata, scripts, release tools, tests, and docs
- Keep release verification tooling and fixtures consistent with scoped package tarball naming

## Test plan
- [x] `bun test tools/npm-release-preflight.test.ts tools/npm-release-publish.test.ts tools/generate-npm-release-record.test.ts`
- [x] `bun run check`

Refs #299
Closes #299

Made with [Cursor](https://cursor.com)