### PR TITLE
infra: automate npm publish on main

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,6 +1,20 @@
 name: npm-publish
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - README.md
+      - src/**
+      - core/**
+      - languages/**
+      - targets/**
+      - registry/**
+      - scripts/**
+      - tools/**
+      - bin/**
+      - schema/**
   workflow_dispatch:
     inputs:
       release_notes_url:
@@ -14,21 +28,35 @@ on:
         type: string
 
 concurrency:
-  group: npm-publish-${{ github.ref }}
+  group: npm-publish-${{ github.ref_name }}
   cancel-in-progress: false
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve publish context
+        id: context
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "publish_ref=${{ inputs.ref }}" >> "$GITHUB_OUTPUT"
+            echo "release_notes_url=${{ inputs.release_notes_url }}" >> "$GITHUB_OUTPUT"
+            echo "auto_bump=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish_ref=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+            echo "release_notes_url=${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}" >> "$GITHUB_OUTPUT"
+            echo "auto_bump=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          persist-credentials: false
-          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+          persist-credentials: true
+          ref: ${{ steps.context.outputs.publish_ref }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -53,13 +81,57 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Auto-bump patch version on main pushes
+        if: steps.context.outputs.auto_bump == 'true'
+        run: |
+          PACKAGE_NAME="$(node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));process.stdout.write(p.name);")"
+          CURRENT_VERSION="$(node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));process.stdout.write(p.version);")"
+          LATEST_VERSION="$(npm view "${PACKAGE_NAME}" version --json 2>/dev/null | tr -d '\" \n\r' || true)"
+          if [ -z "${LATEST_VERSION}" ] || [ "${LATEST_VERSION}" = "null" ]; then
+            LATEST_VERSION="0.0.0"
+          fi
+
+          NEXT_VERSION="$(CURRENT_VERSION="${CURRENT_VERSION}" LATEST_VERSION="${LATEST_VERSION}" node - <<'NODE'
+          function parse(version) {
+            const match = version.match(/^(\d+)\.(\d+)\.(\d+)/u);
+            if (!match) throw new Error(`Invalid semver: ${version}`);
+            return [Number(match[1]), Number(match[2]), Number(match[3])];
+          }
+          function compare(a, b) {
+            for (let idx = 0; idx < 3; idx += 1) {
+              if (a[idx] > b[idx]) return 1;
+              if (a[idx] < b[idx]) return -1;
+            }
+            return 0;
+          }
+          const current = parse(process.env.CURRENT_VERSION || '0.0.0');
+          const latest = parse(process.env.LATEST_VERSION || '0.0.0');
+          const base = compare(current, latest) >= 0 ? current : latest;
+          process.stdout.write(`${base[0]}.${base[1]}.${base[2] + 1}`);
+          NODE
+          )"
+
+          npm pkg set version="${NEXT_VERSION}"
+          git add package.json
+
+          if git diff --cached --quiet; then
+            echo "No version update detected"
+          else
+            export GIT_AUTHOR_NAME="github-actions[bot]"
+            export GIT_AUTHOR_EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
+            export GIT_COMMITTER_NAME="${GIT_AUTHOR_NAME}"
+            export GIT_COMMITTER_EMAIL="${GIT_AUTHOR_EMAIL}"
+            git commit -m "chore: release ${PACKAGE_NAME}@${NEXT_VERSION}"
+            git push origin HEAD:main
+          fi
+
       - name: Publish and verify npm release
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: bun run release:npm:publish
 
       - name: Generate npm release record
-        run: bun run release:npm:record -- --release-notes-url="${{ inputs.release_notes_url }}"
+        run: bun run release:npm:record -- --release-notes-url="${{ steps.context.outputs.release_notes_url }}"
 
       - name: Upload release evidence artifacts
         uses: actions/upload-artifact@v4

--- a/docs/npm-publishing.md
+++ b/docs/npm-publishing.md
@@ -71,19 +71,44 @@ Keep these artifacts linked in the release task/PR for traceability.
 
 ## 6) GitHub Actions release workflow
 
-This repository includes a manual publish workflow:
+This repository supports both automatic and manual publishing:
+
+- Automatic trigger: push to `main` when README or code paths change
+- Manual trigger: `workflow_dispatch`
 
 - Workflow: `.github/workflows/npm-publish.yml`
-- Trigger: `workflow_dispatch`
+- Trigger:
+  - `push` on `main` for release-relevant paths
+  - `workflow_dispatch` for operators
 - Inputs:
   - `release_notes_url` (required)
   - `ref` (optional, default `main`)
 
 The workflow runs:
 
-1. `bun run release:npm:publish`
-2. `bun run release:npm:record -- --release-notes-url=<input>`
-3. Uploads `dist/release/` as `npm-release-evidence` artifact
+1. (auto mode) bump patch version and push release commit to `main`
+2. `bun run release:npm:publish`
+3. `bun run release:npm:record -- --release-notes-url=<input-or-generated>`
+4. Uploads `dist/release/` as `npm-release-evidence` artifact
+
+### Auto-release path filter
+
+Auto-publish on `main` only runs when changes include release-relevant paths:
+
+- `README.md`
+- `src/**`, `core/**`, `languages/**`, `targets/**`, `registry/**`
+- `scripts/**`, `tools/**`, `bin/**`, `schema/**`
+
+Version-bump commits only touch `package.json`, so they do not re-trigger auto release.
+
+### Manual workflow_dispatch
+
+For manual runs, provide:
+
+- `release_notes_url`
+- optional `ref`
+
+Manual mode does not auto-bump version; publish should target the version already set in `package.json`.
 
 ### Secret configuration
 
@@ -96,3 +121,10 @@ Set `NPM_TOKEN` in repository secrets:
 
 You can migrate from `NPM_TOKEN` to npm Trusted Publishing (OIDC) later.
 That removes long-lived token storage and uses GitHub-issued identity.
+
+### Legacy flow reference
+
+The direct manual command sequence remains valid for local release operators:
+
+1. `bun run release:npm:publish`
+2. `bun run release:npm:record -- --release-notes-url=<input>`

--- a/tools/npm-release-publish.ts
+++ b/tools/npm-release-publish.ts
@@ -131,6 +131,42 @@ function parseVersionPayload(data: unknown): string {
   throw new Error('Invalid npm version payload: expected string or non-empty string array');
 }
 
+function isNpmPackageNotFoundError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return (
+    error.message.includes('npm error code E404') ||
+    error.message.includes('npm ERR! code E404') ||
+    error.message.includes('404 Not Found')
+  );
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function resolvePublishedVersionWithRetry(packageName: string): Promise<unknown> {
+  const maxAttempts = 10;
+  const delayMs = 3000;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return JSON.parse((await runCommand('npm', ['view', packageName, 'version', '--json'])).stdout);
+    } catch (error: unknown) {
+      if (!isNpmPackageNotFoundError(error) || attempt === maxAttempts) {
+        throw error;
+      }
+      process.stdout.write(
+        `npm view retry ${attempt}/${String(maxAttempts)} for ${packageName} after registry 404; waiting ${String(delayMs / 1000)}s...\n`
+      );
+      await sleep(delayMs);
+    }
+  }
+
+  throw new Error(`Unable to resolve published version for ${packageName}`);
+}
+
 async function verifyInstalledCli(pkg: PackageMetadata): Promise<void> {
   const installDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ailib-npm-install-check-'));
   try {
@@ -178,7 +214,7 @@ async function main() {
 
   const publishedVersionPayload = args.publishedVersionJsonFile
     ? await readJsonFromFile(args.publishedVersionJsonFile)
-    : JSON.parse((await runCommand('npm', ['view', pkg.name, 'version', '--json'])).stdout);
+    : await resolvePublishedVersionWithRetry(pkg.name);
   const publishedVersion = parseVersionPayload(publishedVersionPayload);
   if (publishedVersion !== pkg.version) {
     throw new Error(


### PR DESCRIPTION
## Summary
- Add automatic npm publish workflow trigger on `main` pushes when README/code paths change
- Auto-bump patch version before publish to prevent republish collisions in CI
- Keep manual dispatch support and document trigger/secret behavior in npm publishing docs
- Include npm version-resolution retry after publish to tolerate transient registry 404 propagation

## Test plan
- [x] `bun run format:check`
- [x] `bun run check`

Refs #301
Closes #301

Made with [Cursor](https://cursor.com)