### PR TITLE
fix: retry stale npm version verification

### DIFF
--- a/docs/npm-publishing.md
+++ b/docs/npm-publishing.md
@@ -39,6 +39,9 @@ The workflow performs:
 4. clean-directory install verification (`npm install @alisya.ai/ailib@<version>`)
 5. CLI smoke test (`npx ailib --help`)
 
+The publish verification step automatically retries npm version resolution when the registry
+returns transient `404` responses or a stale previous version immediately after publish.
+
 ## 3) Optional dry-run publish verification
 
 To exercise non-publish verification paths without uploading:

--- a/tools/npm-release-publish.test.ts
+++ b/tools/npm-release-publish.test.ts
@@ -64,3 +64,89 @@ test('npm-release-publish fails dry-run when resolved version mismatches package
   assert.equal(result.status, 1);
   assert.match(result.stderr, /Published version mismatch/);
 });
+
+test('npm-release-publish retries when npm view returns stale version', { timeout: 15_000 }, async () => {
+  const dir = await tempDir();
+  const packageFile = path.join(dir, 'package.json');
+  const reportFile = path.join(dir, 'report.json');
+  const fakeBin = path.join(dir, 'bin');
+  const stateFile = path.join(dir, 'npm-view-count.txt');
+  const fakeNpm = path.join(fakeBin, 'npm');
+  const fakeNpx = path.join(fakeBin, 'npx');
+
+  await fs.mkdir(fakeBin, { recursive: true });
+  await fs.writeFile(packageFile, JSON.stringify({ name: '@alisya.ai/ailib', version: '2.0.0' }), 'utf8');
+  await fs.writeFile(stateFile, '0', 'utf8');
+  await fs.writeFile(
+    fakeNpm,
+    `#!/usr/bin/env bash
+set -euo pipefail
+STATE_FILE="${stateFile}"
+COMMAND="$1"
+if [ "$COMMAND" = "whoami" ]; then
+  echo "ci-user"
+  exit 0
+fi
+if [ "$COMMAND" = "publish" ]; then
+  exit 0
+fi
+if [ "$COMMAND" = "view" ]; then
+  COUNT="$(cat "$STATE_FILE")"
+  NEXT_COUNT=$((COUNT + 1))
+  echo "$NEXT_COUNT" > "$STATE_FILE"
+  if [ "$NEXT_COUNT" -lt 3 ]; then
+    echo "\\"1.9.9\\""
+  else
+    echo "\\"2.0.0\\""
+  fi
+  exit 0
+fi
+if [ "$COMMAND" = "init" ]; then
+  exit 0
+fi
+if [ "$COMMAND" = "install" ]; then
+  exit 0
+fi
+echo "unsupported npm command: $*" >&2
+exit 1
+`,
+    'utf8'
+  );
+  await fs.writeFile(
+    fakeNpx,
+    `#!/usr/bin/env bash
+set -euo pipefail
+echo "ailib commands:"
+`,
+    'utf8'
+  );
+  await fs.chmod(fakeNpm, 0o755);
+  await fs.chmod(fakeNpx, 0o755);
+
+  const result = spawnSync(
+    'bun',
+    ['tools/npm-release-publish.ts', `--package-file=${packageFile}`, `--report-file=${reportFile}`],
+    {
+      cwd: packageRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        AILIB_NPM_VIEW_MAX_ATTEMPTS: '5',
+        AILIB_NPM_VIEW_DELAY_MS: '10',
+        PATH: `${fakeBin}:${process.env.PATH ?? ''}`
+      }
+    }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /npm view retry 1\/5/);
+  assert.match(result.stdout, /npm view retry 2\/5/);
+  assert.match(result.stdout, /npm publish verification passed/);
+
+  const report = JSON.parse(await fs.readFile(reportFile, 'utf8')) as Record<string, unknown>;
+  const checks = report.checks as Record<string, unknown>;
+  assert.equal(checks.npmAuthVerified, true);
+  assert.equal(checks.publishCommandExecuted, true);
+  assert.equal(checks.npmVersionResolved, true);
+  assert.equal(checks.installVerificationPassed, true);
+});

--- a/tools/npm-release-publish.ts
+++ b/tools/npm-release-publish.ts
@@ -146,13 +146,34 @@ async function sleep(ms: number): Promise<void> {
   });
 }
 
-async function resolvePublishedVersionWithRetry(packageName: string): Promise<unknown> {
-  const maxAttempts = 10;
-  const delayMs = 3000;
+function resolveRetryConfig(): { maxAttempts: number; delayMs: number } {
+  const maxAttemptsValue = Number.parseInt(process.env.AILIB_NPM_VIEW_MAX_ATTEMPTS ?? '10', 10);
+  const delayMsValue = Number.parseInt(process.env.AILIB_NPM_VIEW_DELAY_MS ?? '3000', 10);
+  return {
+    maxAttempts: Number.isFinite(maxAttemptsValue) && maxAttemptsValue > 0 ? maxAttemptsValue : 10,
+    delayMs: Number.isFinite(delayMsValue) && delayMsValue >= 0 ? delayMsValue : 3000
+  };
+}
+
+async function resolvePublishedVersionWithRetry(packageName: string, expectedVersion: string): Promise<string> {
+  const { maxAttempts, delayMs } = resolveRetryConfig();
+  let lastResolvedVersion: string | undefined;
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     try {
-      return JSON.parse((await runCommand('npm', ['view', packageName, 'version', '--json'])).stdout);
+      const payload = JSON.parse((await runCommand('npm', ['view', packageName, 'version', '--json'])).stdout);
+      const resolvedVersion = parseVersionPayload(payload);
+      lastResolvedVersion = resolvedVersion;
+      if (resolvedVersion === expectedVersion) {
+        return resolvedVersion;
+      }
+      if (attempt === maxAttempts) {
+        break;
+      }
+      process.stdout.write(
+        `npm view retry ${attempt}/${String(maxAttempts)} for ${packageName}; expected ${expectedVersion}, received ${resolvedVersion}; waiting ${String(delayMs / 1000)}s...\n`
+      );
+      await sleep(delayMs);
     } catch (error: unknown) {
       if (!isNpmPackageNotFoundError(error) || attempt === maxAttempts) {
         throw error;
@@ -164,7 +185,9 @@ async function resolvePublishedVersionWithRetry(packageName: string): Promise<un
     }
   }
 
-  throw new Error(`Unable to resolve published version for ${packageName}`);
+  throw new Error(
+    `Unable to resolve published version for ${packageName}; expected ${expectedVersion}, last received ${lastResolvedVersion ?? 'unknown'}`
+  );
 }
 
 async function verifyInstalledCli(pkg: PackageMetadata): Promise<void> {
@@ -212,10 +235,9 @@ async function main() {
     report.checks.publishCommandExecuted = true;
   }
 
-  const publishedVersionPayload = args.publishedVersionJsonFile
-    ? await readJsonFromFile(args.publishedVersionJsonFile)
-    : await resolvePublishedVersionWithRetry(pkg.name);
-  const publishedVersion = parseVersionPayload(publishedVersionPayload);
+  const publishedVersion = args.publishedVersionJsonFile
+    ? parseVersionPayload(await readJsonFromFile(args.publishedVersionJsonFile))
+    : await resolvePublishedVersionWithRetry(pkg.name, pkg.version);
   if (publishedVersion !== pkg.version) {
     throw new Error(
       `Published version mismatch for ${pkg.name}: expected ${pkg.version}, received ${publishedVersion}`


### PR DESCRIPTION
## Summary
- Fix npm publish verification to retry when `npm view` returns stale previous versions right after a successful publish
- Keep existing retry behavior for transient `404` propagation and improve failure details with expected/last-resolved versions
- Add deterministic regression coverage with mocked npm/npx commands and configurable retry timing env vars
- Document stale-version retry behavior in npm publishing guide

## Test plan
- [x] `bun run test tools/npm-release-publish.test.ts`
- [x] `bun run check`

Refs #303
Closes #303

Made with [Cursor](https://cursor.com)