### PR TITLE
infra: update formula release metadata

### DIFF
--- a/Formula/ailib.rb
+++ b/Formula/ailib.rb
@@ -1,6 +1,9 @@
 class Ailib < Formula
   desc "Universal AI context-injection engine CLI"
   homepage "https://github.com/Alisya-AI/ai-lib"
+  url "https://registry.npmjs.org/@alisya.ai/ailib/-/ailib-1.0.2.tgz"
+  sha256 "944c4617fdf801dd5f5d61e9e413579e508193a17320e71b37f60d3cda7da43c"
+  version "1.0.2"
   head "https://github.com/Alisya-AI/ai-lib.git", branch: "main"
   license "Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ npm install -g @alisya.ai/ailib
 
 ### Homebrew
 
-Current in-repo formula (HEAD):
+Current in-repo formula (stable):
 
 ```bash
-brew install --HEAD --formula https://raw.githubusercontent.com/Alisya-AI/ai-lib/main/Formula/ailib.rb
+brew install --formula https://raw.githubusercontent.com/Alisya-AI/ai-lib/main/Formula/ailib.rb
 ```
 
-Planned stable user flow via tap:
+Recommended user flow via tap:
 
 ```bash
 brew tap Alisya-AI/ailib

--- a/docs/homebrew-publishing.md
+++ b/docs/homebrew-publishing.md
@@ -4,11 +4,11 @@ This document explains exactly how to publish and update `ailib` for Homebrew us
 
 ## Current state
 
-- In this repo, `Formula/ailib.rb` is a HEAD formula.
+- In this repo, `Formula/ailib.rb` is a stable formula pinned to a published npm tarball (`url` + `sha256`).
 - Users can install directly from this repo:
 
 ```bash
-brew install --HEAD --formula https://raw.githubusercontent.com/Alisya-AI/ai-lib/main/Formula/ailib.rb
+brew install --formula https://raw.githubusercontent.com/Alisya-AI/ai-lib/main/Formula/ailib.rb
 ```
 
 ## Recommended distribution: dedicated tap
@@ -25,7 +25,7 @@ Outputs are written to `dist/release/`:
 
 - npm package tarball (`*.tgz`)
 - source tarball (`ailib-v<version>-<sha>-source.tar.gz`)
-- checksum manifest (`release-checksums.txt`)
+- checksum manifest (`release-checksums.txt`) with local + published npm checksum fields
 - formula snippet helper (`homebrew-formula-snippet.txt`)
 
 To run npm release readiness checks (artifact + unpublished-version validation):
@@ -46,7 +46,7 @@ Use a tap repo so users can run `brew install ailib` after one-time tap setup.
 
 1. Create tap repository: `Alisya-AI/homebrew-ailib`.
 2. Add `Formula/ailib.rb`.
-3. Start from the formula in this repository, then make it a stable formula (`url` + `sha256`).
+3. Start from the formula in this repository and update `url`, `sha256`, and `version` each release.
 
 Stable formula shape:
 
@@ -54,8 +54,9 @@ Stable formula shape:
 class Ailib < Formula
   desc "Universal AI context-injection engine CLI"
   homepage "https://github.com/Alisya-AI/ai-lib"
-  url "https://github.com/Alisya-AI/ai-lib/archive/refs/tags/vX.Y.Z.tar.gz"
+  url "https://registry.npmjs.org/@alisya.ai/ailib/-/ailib-X.Y.Z.tgz"
   sha256 "<REPLACE_WITH_SHA256>"
+  version "X.Y.Z"
   license "Apache-2.0"
 
   depends_on "node"
@@ -72,14 +73,20 @@ end
 
 ### Release workflow (every version)
 
-1. Tag and push a release in `Alisya-AI/ai-lib` (example: `v1.0.1`).
-2. Compute tarball SHA256:
+1. Publish npm version `X.Y.Z` for `@alisya.ai/ailib`.
+2. Generate release artifacts:
    ```bash
-   curl -L -o /tmp/ailib-v1.0.1.tar.gz https://github.com/Alisya-AI/ai-lib/archive/refs/tags/v1.0.1.tar.gz
-   shasum -a 256 /tmp/ailib-v1.0.1.tar.gz
+   bun run release:build
    ```
-3. Update tap formula `url` and `sha256`.
-4. Commit and push to `Alisya-AI/homebrew-ailib`.
+3. Read `dist/release/homebrew-formula-snippet.txt` and copy values into tap `Formula/ailib.rb`.
+   - If npm already has `@alisya.ai/ailib@X.Y.Z`, the snippet uses published tarball SHA256.
+   - If not yet published, it falls back to local `npm pack` SHA256 (rerun after publish).
+4. (optional verification) Compute npm tarball SHA256 directly:
+   ```bash
+   curl -L -o /tmp/ailib-X.Y.Z.tgz https://registry.npmjs.org/@alisya.ai/ailib/-/ailib-X.Y.Z.tgz
+   shasum -a 256 /tmp/ailib-X.Y.Z.tgz
+   ```
+5. Commit and push to `Alisya-AI/homebrew-ailib`.
 
 ### User install commands
 

--- a/scripts/build-release-artifacts.sh
+++ b/scripts/build-release-artifacts.sh
@@ -50,19 +50,40 @@ NPM_TARBALL="$(printf '%s' "${PACK_JSON}" | node -e "let input='';process.stdin.
 NPM_TARBALL_PATH="${DIST_DIR}/${NPM_TARBALL}"
 
 VERSION="$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('package.json','utf8')).version)")"
+PACKAGE_NAME="$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('package.json','utf8')).name)")"
+PACKAGE_BASENAME="$(node -e "const p=JSON.parse(require('fs').readFileSync('package.json','utf8')).name;process.stdout.write(p.split('/').pop())")"
 GIT_SHA="$(git rev-parse --short HEAD)"
 SOURCE_TARBALL="ailib-v${VERSION}-${GIT_SHA}-source.tar.gz"
 SOURCE_TARBALL_PATH="${DIST_DIR}/${SOURCE_TARBALL}"
+NPM_REGISTRY_TARBALL_URL="https://registry.npmjs.org/${PACKAGE_NAME}/-/${PACKAGE_BASENAME}-${VERSION}.tgz"
 
 echo "Packing source artifact for formula workflows..."
 git archive --format=tar.gz --output="${SOURCE_TARBALL_PATH}" HEAD
 
 NPM_SHA="$(shasum -a 256 "${NPM_TARBALL_PATH}" | awk '{print $1}')"
 SOURCE_SHA="$(shasum -a 256 "${SOURCE_TARBALL_PATH}" | awk '{print $1}')"
+NPM_REGISTRY_SHA=""
+NPM_REGISTRY_TARBALL_PATH="${DIST_DIR}/npm-registry-${PACKAGE_BASENAME}-${VERSION}.tgz"
+
+if command -v curl >/dev/null 2>&1 && curl -fsSL "${NPM_REGISTRY_TARBALL_URL}" -o "${NPM_REGISTRY_TARBALL_PATH}"; then
+  NPM_REGISTRY_SHA="$(shasum -a 256 "${NPM_REGISTRY_TARBALL_PATH}" | awk '{print $1}')"
+  rm -f "${NPM_REGISTRY_TARBALL_PATH}"
+else
+  rm -f "${NPM_REGISTRY_TARBALL_PATH}"
+  echo "Published npm tarball not yet available for ${PACKAGE_NAME}@${VERSION}; using local npm pack checksum in formula snippet."
+fi
+
+FORMULA_SHA="${NPM_SHA}"
+if [[ -n "${NPM_REGISTRY_SHA}" ]]; then
+  FORMULA_SHA="${NPM_REGISTRY_SHA}"
+fi
 
 {
   echo "npm_tarball=${NPM_TARBALL}"
-  echo "npm_sha256=${NPM_SHA}"
+  echo "npm_tarball_url=${NPM_REGISTRY_TARBALL_URL}"
+  echo "npm_sha256_local=${NPM_SHA}"
+  echo "npm_sha256_published=${NPM_REGISTRY_SHA}"
+  echo "npm_sha256=${FORMULA_SHA}"
   echo "source_tarball=${SOURCE_TARBALL}"
   echo "source_sha256=${SOURCE_SHA}"
   echo "version=${VERSION}"
@@ -70,9 +91,9 @@ SOURCE_SHA="$(shasum -a 256 "${SOURCE_TARBALL_PATH}" | awk '{print $1}')"
 } > "${DIST_DIR}/release-checksums.txt"
 
 {
-  echo "# Update this once the release tag exists"
-  echo "url \"https://github.com/Alisya-AI/ai-lib/archive/refs/tags/v${VERSION}.tar.gz\""
-  echo "sha256 \"${SOURCE_SHA}\""
+  echo "url \"${NPM_REGISTRY_TARBALL_URL}\""
+  echo "sha256 \"${FORMULA_SHA}\""
+  echo "version \"${VERSION}\""
 } > "${DIST_DIR}/homebrew-formula-snippet.txt"
 
 echo "Release artifacts generated:"


### PR DESCRIPTION
## Summary
- Pin `Formula/ailib.rb` to the published `@alisya.ai/ailib@1.0.2` npm tarball URL and SHA256
- Update release artifact generation to output Homebrew snippet metadata from npm registry tarball coordinates
- Prefer published tarball SHA256 when available, with local `npm pack` fallback during pre-publish runs
- Refresh Homebrew publishing documentation for stable formula update workflow

## Test plan
- [x] `bun run release:build -- --skip-check`
- [x] `bun run check`

Refs #288
Closes #288