### PR TITLE
fix: align in-repo formula runtime wiring

### DIFF
--- a/Formula/ailib.rb
+++ b/Formula/ailib.rb
@@ -11,9 +11,10 @@ class Ailib < Formula
 
   def install
     system "npm", "install", "--omit=dev", *std_npm_args
+    bin.write_exec_script libexec/"bin/ailib"
   end
 
   test do
-    system bin/"ailib", "--help"
+    assert_match "ailib commands:", shell_output("#{bin}/ailib --help")
   end
 end


### PR DESCRIPTION
## Summary
- Align `Formula/ailib.rb` with the merged tap formula runtime behavior
- Add Homebrew exec wrapper for `ailib` binary installation in formula
- Update formula test to assert expected CLI help output text

## Test plan
- [x] `bun run format:check`
- [x] `bun run check`

Refs #307
Closes #307

Made with [Cursor](https://cursor.com)