### PR TITLE
fix: package runtime/docs for npm release

### DIFF
--- a/bin/ailib.js
+++ b/bin/ailib.js
@@ -1,7 +1,18 @@
 #!/usr/bin/env bun
-import { run } from '../src/cli.ts';
+import path from 'node:path';
 
-run(process.argv.slice(2)).catch((error) => {
+const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+
+async function resolveRun() {
+  try {
+    return (await import('../dist/runtime/cli.js')).run;
+  } catch {
+    return (await import('../src/cli.ts')).run;
+  }
+}
+
+const run = await resolveRun();
+run(process.argv.slice(2), { packageRoot }).catch((error) => {
   process.stderr.write(`${error.message}\n`);
   process.exit(1);
 });

--- a/package.json
+++ b/package.json
@@ -3,12 +3,18 @@
   "version": "1.0.3",
   "description": "Universal AI context-injection engine CLI",
   "type": "module",
+  "main": "dist/runtime/cli.js",
+  "exports": {
+    ".": "./dist/runtime/cli.js",
+    "./package.json": "./package.json"
+  },
   "bin": {
     "ailib": "bin/ailib.js"
   },
   "files": [
     "bin",
-    "src",
+    "dist/runtime",
+    "docs",
     "schema",
     "core",
     "languages",

--- a/scripts/build-release-artifacts.sh
+++ b/scripts/build-release-artifacts.sh
@@ -40,6 +40,9 @@ fi
 
 echo "Building TypeScript tooling outputs..."
 bun run tools:build
+mkdir -p "${ROOT_DIR}/dist/runtime"
+echo "Building bundled CLI runtime output..."
+bun build "${ROOT_DIR}/src/cli.ts" --target bun --outfile "${ROOT_DIR}/dist/runtime/cli.js"
 
 mkdir -p "${DIST_DIR}"
 rm -f "${DIST_DIR}"/*.tgz "${DIST_DIR}"/release-checksums.txt "${DIST_DIR}"/homebrew-formula-snippet.txt

--- a/test/bun-packaging.test.ts
+++ b/test/bun-packaging.test.ts
@@ -16,6 +16,15 @@ async function exists(filePath: string) {
   }
 }
 
+async function ensureRuntimeBundle() {
+  const runtimePath = path.join(packageRoot, 'dist', 'runtime', 'cli.js');
+  if (await exists(runtimePath)) {
+    return;
+  }
+  const result = await runBun(['build', 'src/cli.ts', '--target', 'bun', '--outfile', 'dist/runtime/cli.js']);
+  assert.equal(result.code, 0, result.stderr);
+}
+
 function runBun(args: string[], cwd = packageRoot): Promise<{ code: number | null; stdout: string; stderr: string }> {
   return new Promise((resolve) => {
     const child = spawn('bun', args, { cwd });
@@ -49,6 +58,7 @@ test('bin entrypoint reports CLI errors through stderr', async () => {
 });
 
 test('package files list points to existing release paths', async () => {
+  await ensureRuntimeBundle();
   const pkg = JSON.parse(await fs.readFile(path.join(packageRoot, 'package.json'), 'utf8'));
   const fileEntries = pkg.files || [];
   assert.ok(fileEntries.length > 0, 'package.json files array should not be empty');
@@ -59,17 +69,21 @@ test('package files list points to existing release paths', async () => {
 });
 
 test('release-critical entry files are present and executable', async () => {
+  await ensureRuntimeBundle();
   const binPath = path.join(packageRoot, 'bin', 'ailib.js');
-  const cliPath = path.join(packageRoot, 'src', 'cli.ts');
+  const runtimePath = path.join(packageRoot, 'dist', 'runtime', 'cli.js');
   const registryPath = path.join(packageRoot, 'registry.json');
+  const docsPath = path.join(packageRoot, 'docs', 'homebrew-publishing.md');
 
   assert.equal(await exists(binPath), true, 'missing bin/ailib.js');
-  assert.equal(await exists(cliPath), true, 'missing src/cli.ts');
+  assert.equal(await exists(runtimePath), true, 'missing dist/runtime/cli.js');
+  assert.equal(await exists(docsPath), true, 'missing docs/homebrew-publishing.md');
   assert.equal(await exists(registryPath), true, 'missing registry.json');
 
   const bin = await fs.readFile(binPath, 'utf8');
   const binStat = await fs.stat(binPath);
   assert.match(bin, /^#!\/usr\/bin\/env bun$/mu);
-  assert.match(bin, /from '\.\.\/src\/cli\.ts';/mu);
+  assert.match(bin, /'\.\.\/dist\/runtime\/cli\.js'/mu);
+  assert.match(bin, /'\.\.\/src\/cli\.ts'/mu);
   assert.ok((binStat.mode & 0o111) !== 0, 'bin/ailib.js should be executable');
 });

--- a/tools/npm-release-preflight.test.ts
+++ b/tools/npm-release-preflight.test.ts
@@ -25,7 +25,12 @@ test('npm-release-preflight succeeds for first-time publish fixture payloads', a
     JSON.stringify([
       {
         filename: 'alisya.ai-ailib-9.9.9.tgz',
-        files: [{ path: 'bin/ailib.js' }, { path: 'src/cli.ts' }, { path: 'registry.json' }]
+        files: [
+          { path: 'bin/ailib.js' },
+          { path: 'dist/runtime/cli.js' },
+          { path: 'docs/homebrew-publishing.md' },
+          { path: 'registry.json' }
+        ]
       }
     ]),
     'utf8'
@@ -65,7 +70,12 @@ test('npm-release-preflight fails when target version is already published', asy
     JSON.stringify([
       {
         filename: 'alisya.ai-ailib-1.0.0.tgz',
-        files: [{ path: 'bin/ailib.js' }, { path: 'src/cli.ts' }, { path: 'registry.json' }]
+        files: [
+          { path: 'bin/ailib.js' },
+          { path: 'dist/runtime/cli.js' },
+          { path: 'docs/homebrew-publishing.md' },
+          { path: 'registry.json' }
+        ]
       }
     ]),
     'utf8'

--- a/tools/npm-release-preflight.ts
+++ b/tools/npm-release-preflight.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { spawn } from 'node:child_process';
 
 const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
-const requiredPackEntries = ['bin/ailib.js', 'src/cli.ts', 'registry.json'];
+const requiredPackEntries = ['bin/ailib.js', 'dist/runtime/cli.js', 'docs/homebrew-publishing.md', 'registry.json'];
 
 type CliArgs = {
   packageFile: string;


### PR DESCRIPTION
## Summary
- Stop publishing raw `src/` runtime code by packaging bundled CLI runtime at `dist/runtime/cli.js`
- Include `docs/` in npm package contents and enforce docs/runtime presence in npm preflight checks
- Add package entrypoint metadata (`main`/`exports`) so Bundlephobia can resolve a valid entry file
- Keep local development behavior intact by falling back to `src/cli.ts` when bundled runtime is not present

## Test plan
- [x] `bun run format:check`
- [x] `bun run check`
- [x] `bash scripts/build-release-artifacts.sh --skip-check && npm pack --dry-run --json`
- [x] Verify `npm pack --dry-run` file list includes `docs/` and `dist/runtime/cli.js` and excludes `src/`

Refs #309
Closes #309

Made with [Cursor](https://cursor.com)