### PR TITLE
fix: harden npm publish release checks

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -37,6 +37,8 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - name: Resolve publish context
         id: context
@@ -52,21 +54,21 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: true
           ref: ${{ steps.context.outputs.publish_ref }}
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: latest
 
       - name: Setup Node for npm publishing
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Validate npm token secret
@@ -134,7 +136,7 @@ jobs:
         run: bun run release:npm:record -- --release-notes-url="${{ steps.context.outputs.release_notes_url }}"
 
       - name: Upload release evidence artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: npm-release-evidence
           path: dist/release/

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -13,12 +13,15 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
 
@@ -37,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
 
@@ -56,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
 
@@ -75,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
 
@@ -97,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -15,13 +15,16 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   dependency-audit:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
 
@@ -44,7 +47,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -65,7 +68,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
 

--- a/docs/npm-publishing.md
+++ b/docs/npm-publishing.md
@@ -36,8 +36,9 @@ The workflow performs:
 1. npm authentication check (`npm whoami`)
 2. `npm publish --access public`
 3. version resolution check (`npm view @alisya.ai/ailib version --json`)
-4. clean-directory install verification (`npm install @alisya.ai/ailib@<version>`)
-5. CLI smoke test (`npx ailib --help`)
+4. published tarball reachability check (`npm view @alisya.ai/ailib@<version> dist.tarball --json` + HTTP probe)
+5. clean-directory install verification (`npm install @alisya.ai/ailib@<version>`)
+6. CLI smoke test (`npx ailib --help`)
 
 The publish verification step automatically retries npm version resolution when the registry
 returns transient `404` responses or a stale previous version immediately after publish.

--- a/docs/npm-publishing.md
+++ b/docs/npm-publishing.md
@@ -22,6 +22,7 @@ This validates:
 - release artifacts are generated under `dist/release/`
 - target package version is not already published
 - npm pack output contains required release files
+- npm pack output excludes `.ts` source files
 
 ## 2) Publish and verify npm install resolution
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "languages",
     "registry",
     "targets",
-    "tools",
     "registry.json"
   ],
   "scripts": {

--- a/src/cli/workspace-discovery.test.ts
+++ b/src/cli/workspace-discovery.test.ts
@@ -124,6 +124,34 @@ test('listWorkspaceDirs supports double-star workspace patterns', async () => {
   assert.equal(dirs.includes(path.resolve(nestedApp)), true);
 });
 
+test('listWorkspaceDirs treats regex-like characters in workspace patterns as literals', async () => {
+  const root = await makeRoot();
+  await writeConfig(root, {
+    language: 'typescript',
+    modules: ['eslint'],
+    targets: ['claude-code'],
+    workspaces: ['apps/foo.+']
+  });
+
+  const literalMatch = path.join(root, 'apps', 'foo.+');
+  const wildcardMiss = path.join(root, 'apps', 'foobar');
+  await writeConfig(literalMatch, { language: 'typescript', modules: ['biome'], targets: ['claude-code'] });
+  await writeConfig(wildcardMiss, { language: 'typescript', modules: ['eslint'], targets: ['claude-code'] });
+
+  const dirs = await listWorkspaceDirs({
+    rootDir: root,
+    rootConfig: {
+      language: 'typescript',
+      modules: ['eslint'],
+      targets: ['claude-code'],
+      workspaces: ['apps/foo.+']
+    }
+  });
+
+  assert.equal(dirs.includes(path.resolve(literalMatch)), true);
+  assert.equal(dirs.includes(path.resolve(wildcardMiss)), false);
+});
+
 test('listWorkspaceDirs supports slash and basename gitignore rules', async () => {
   const root = await makeRoot();
   await writeConfig(root, {

--- a/src/cli/workspace-discovery.ts
+++ b/src/cli/workspace-discovery.ts
@@ -129,29 +129,41 @@ async function loadGitignoreMatchers(rootDir: string) {
 }
 
 function globMatch(relPath: string, pattern: string) {
-  const regex = globToRegex(pattern);
-  return regex.test(toPosix(relPath));
-}
+  const normalizedPattern = toPosix(pattern);
+  const normalizedPath = toPosix(relPath);
+  const memo = new Map<string, boolean>();
 
-function globToRegex(pattern: string) {
-  const normalized = toPosix(pattern);
-  let out = '^';
-  for (let i = 0; i < normalized.length; i += 1) {
-    const c = normalized[i];
-    if (c === '*') {
-      if (normalized[i + 1] === '*') {
-        out += '.*';
-        i += 1;
+  function matches(pathIdx: number, patternIdx: number): boolean {
+    const key = `${pathIdx}:${patternIdx}`;
+    const cached = memo.get(key);
+    if (cached !== undefined) return cached;
+
+    let result = false;
+    if (patternIdx === normalizedPattern.length) {
+      result = pathIdx === normalizedPath.length;
+    } else if (normalizedPattern[patternIdx] === '*') {
+      if (normalizedPattern[patternIdx + 1] === '*') {
+        // Double-star matches any character sequence, including path separators.
+        result =
+          matches(pathIdx, patternIdx + 2) || (pathIdx < normalizedPath.length && matches(pathIdx + 1, patternIdx));
       } else {
-        out += '[^/]*';
+        // Single-star matches zero or more non-separator characters.
+        result =
+          matches(pathIdx, patternIdx + 1) ||
+          (pathIdx < normalizedPath.length && normalizedPath[pathIdx] !== '/' && matches(pathIdx + 1, patternIdx));
       }
-      continue;
+    } else {
+      result =
+        pathIdx < normalizedPath.length &&
+        normalizedPath[pathIdx] === normalizedPattern[patternIdx] &&
+        matches(pathIdx + 1, patternIdx + 1);
     }
-    if ('\\^$+?.()|{}[]'.includes(c)) out += `\\${c}`;
-    else out += c;
+
+    memo.set(key, result);
+    return result;
   }
-  out += '$';
-  return new RegExp(out);
+
+  return matches(0, 0);
 }
 
 function resolveWorkspacePath(rootDir: string, value: string) {

--- a/tools/npm-release-preflight.test.ts
+++ b/tools/npm-release-preflight.test.ts
@@ -96,3 +96,44 @@ test('npm-release-preflight fails when target version is already published', asy
   assert.equal(result.status, 1);
   assert.match(result.stderr, /already published/);
 });
+
+test('npm-release-preflight fails when npm pack payload includes TypeScript files', async () => {
+  const dir = await tempDir();
+  const packageFile = path.join(dir, 'package.json');
+  const versionsFile = path.join(dir, 'versions.json');
+  const packFile = path.join(dir, 'pack.json');
+
+  await fs.writeFile(packageFile, JSON.stringify({ name: '@alisya.ai/ailib', version: '2.0.0' }), 'utf8');
+  await fs.writeFile(versionsFile, JSON.stringify([]), 'utf8');
+  await fs.writeFile(
+    packFile,
+    JSON.stringify([
+      {
+        filename: 'alisya.ai-ailib-2.0.0.tgz',
+        files: [
+          { path: 'bin/ailib.js' },
+          { path: 'dist/runtime/cli.js' },
+          { path: 'docs/homebrew-publishing.md' },
+          { path: 'registry.json' },
+          { path: 'tools/npm-release-publish.ts' }
+        ]
+      }
+    ]),
+    'utf8'
+  );
+
+  const result = spawnSync(
+    'bun',
+    [
+      'tools/npm-release-preflight.ts',
+      `--package-file=${packageFile}`,
+      `--versions-json-file=${versionsFile}`,
+      `--pack-json-file=${packFile}`,
+      `--report-file=${path.join(dir, 'report.json')}`
+    ],
+    { cwd: packageRoot, encoding: 'utf8' }
+  );
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /must not include TypeScript sources/);
+});

--- a/tools/npm-release-preflight.ts
+++ b/tools/npm-release-preflight.ts
@@ -155,6 +155,13 @@ function assertRequiredPackEntries(filePaths: string[]) {
   }
 }
 
+function assertNoTypeScriptEntries(filePaths: string[]) {
+  const tsEntries = filePaths.filter((relPath) => /\.ts$/u.test(relPath));
+  if (tsEntries.length > 0) {
+    throw new Error(`npm pack output must not include TypeScript sources: ${tsEntries.join(', ')}`);
+  }
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const packageData = await readJsonFromFile(args.packageFile);
@@ -186,6 +193,7 @@ async function main() {
     : JSON.parse(await runCommand('npm', ['pack', '--dry-run', '--json']));
   const packSummary = parsePackFiles(packPayload);
   assertRequiredPackEntries(packSummary.filePaths);
+  assertNoTypeScriptEntries(packSummary.filePaths);
 
   const reportPath = resolveInputPath(args.reportFile);
   await fs.mkdir(path.dirname(reportPath), { recursive: true });
@@ -200,7 +208,8 @@ async function main() {
         requiredPackEntries,
         checks: {
           versionUnpublished: true,
-          packContainsRequiredEntries: true
+          packContainsRequiredEntries: true,
+          packExcludesTypeScriptSources: true
         },
         checkedAt: new Date().toISOString()
       },

--- a/tools/npm-release-publish.test.ts
+++ b/tools/npm-release-publish.test.ts
@@ -4,11 +4,48 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
+import http from 'node:http';
 
 const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
 
 async function tempDir() {
   return await fs.mkdtemp(path.join(os.tmpdir(), 'ailib-npm-publish-'));
+}
+
+async function createTarballServer() {
+  let requestCount = 0;
+  const server = http.createServer((req, res) => {
+    requestCount += 1;
+    if (requestCount < 3) {
+      res.statusCode = 404;
+      res.end('not-ready');
+      return;
+    }
+    res.statusCode = 200;
+    res.setHeader('content-type', 'application/octet-stream');
+    if (req.method === 'HEAD') {
+      res.end();
+      return;
+    }
+    res.end('tgz-content');
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const addr = server.address();
+  if (!addr || typeof addr === 'string') {
+    throw new Error('unable to resolve tarball server address');
+  }
+  return {
+    tarballUrl: `http://127.0.0.1:${String(addr.port)}/ailib-2.0.0.tgz`,
+    close: async () =>
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      })
+  };
 }
 
 test('npm-release-publish supports dry-run verification with fixture version', async () => {
@@ -73,13 +110,15 @@ test('npm-release-publish retries when npm view returns stale version', { timeou
   const stateFile = path.join(dir, 'npm-view-count.txt');
   const fakeNpm = path.join(fakeBin, 'npm');
   const fakeNpx = path.join(fakeBin, 'npx');
+  const tarballServer = await createTarballServer();
 
-  await fs.mkdir(fakeBin, { recursive: true });
-  await fs.writeFile(packageFile, JSON.stringify({ name: '@alisya.ai/ailib', version: '2.0.0' }), 'utf8');
-  await fs.writeFile(stateFile, '0', 'utf8');
-  await fs.writeFile(
-    fakeNpm,
-    `#!/usr/bin/env bash
+  try {
+    await fs.mkdir(fakeBin, { recursive: true });
+    await fs.writeFile(packageFile, JSON.stringify({ name: '@alisya.ai/ailib', version: '2.0.0' }), 'utf8');
+    await fs.writeFile(stateFile, '0', 'utf8');
+    await fs.writeFile(
+      fakeNpm,
+      `#!/usr/bin/env bash
 set -euo pipefail
 STATE_FILE="${stateFile}"
 COMMAND="$1"
@@ -91,15 +130,21 @@ if [ "$COMMAND" = "publish" ]; then
   exit 0
 fi
 if [ "$COMMAND" = "view" ]; then
-  COUNT="$(cat "$STATE_FILE")"
-  NEXT_COUNT=$((COUNT + 1))
-  echo "$NEXT_COUNT" > "$STATE_FILE"
-  if [ "$NEXT_COUNT" -lt 3 ]; then
-    echo "\\"1.9.9\\""
-  else
-    echo "\\"2.0.0\\""
+  if [ "$3" = "version" ]; then
+    COUNT="$(cat "$STATE_FILE")"
+    NEXT_COUNT=$((COUNT + 1))
+    echo "$NEXT_COUNT" > "$STATE_FILE"
+    if [ "$NEXT_COUNT" -lt 3 ]; then
+      echo "\\"1.9.9\\""
+    else
+      echo "\\"2.0.0\\""
+    fi
+    exit 0
   fi
-  exit 0
+  if [ "$3" = "dist.tarball" ]; then
+    echo "\\"$TARBALL_URL\\""
+    exit 0
+  fi
 fi
 if [ "$COMMAND" = "init" ]; then
   exit 0
@@ -110,43 +155,52 @@ fi
 echo "unsupported npm command: $*" >&2
 exit 1
 `,
-    'utf8'
-  );
-  await fs.writeFile(
-    fakeNpx,
-    `#!/usr/bin/env bash
+      'utf8'
+    );
+    await fs.writeFile(
+      fakeNpx,
+      `#!/usr/bin/env bash
 set -euo pipefail
 echo "ailib commands:"
 `,
-    'utf8'
-  );
-  await fs.chmod(fakeNpm, 0o755);
-  await fs.chmod(fakeNpx, 0o755);
+      'utf8'
+    );
+    await fs.chmod(fakeNpm, 0o755);
+    await fs.chmod(fakeNpx, 0o755);
 
-  const result = spawnSync(
-    'bun',
-    ['tools/npm-release-publish.ts', `--package-file=${packageFile}`, `--report-file=${reportFile}`],
-    {
-      cwd: packageRoot,
-      encoding: 'utf8',
-      env: {
-        ...process.env,
-        AILIB_NPM_VIEW_MAX_ATTEMPTS: '5',
-        AILIB_NPM_VIEW_DELAY_MS: '10',
-        PATH: `${fakeBin}:${process.env.PATH ?? ''}`
+    const result = spawnSync(
+      'bun',
+      ['tools/npm-release-publish.ts', `--package-file=${packageFile}`, `--report-file=${reportFile}`],
+      {
+        cwd: packageRoot,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          TARBALL_URL: tarballServer.tarballUrl,
+          AILIB_NPM_VIEW_MAX_ATTEMPTS: '5',
+          AILIB_NPM_VIEW_DELAY_MS: '10',
+          AILIB_NPM_TARBALL_MAX_ATTEMPTS: '5',
+          AILIB_NPM_TARBALL_DELAY_MS: '10',
+          PATH: `${fakeBin}:${process.env.PATH ?? ''}`
+        }
       }
-    }
-  );
+    );
 
-  assert.equal(result.status, 0, result.stderr);
-  assert.match(result.stdout, /npm view retry 1\/5/);
-  assert.match(result.stdout, /npm view retry 2\/5/);
-  assert.match(result.stdout, /npm publish verification passed/);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /npm view retry 1\/5/);
+    assert.match(result.stdout, /npm view retry 2\/5/);
+    assert.match(result.stdout, /tarball reachability retry 1\/5/);
+    assert.match(result.stdout, /tarball reachability retry 2\/5/);
+    assert.match(result.stdout, /npm publish verification passed/);
 
-  const report = JSON.parse(await fs.readFile(reportFile, 'utf8')) as Record<string, unknown>;
-  const checks = report.checks as Record<string, unknown>;
-  assert.equal(checks.npmAuthVerified, true);
-  assert.equal(checks.publishCommandExecuted, true);
-  assert.equal(checks.npmVersionResolved, true);
-  assert.equal(checks.installVerificationPassed, true);
+    const report = JSON.parse(await fs.readFile(reportFile, 'utf8')) as Record<string, unknown>;
+    const checks = report.checks as Record<string, unknown>;
+    assert.equal(checks.npmAuthVerified, true);
+    assert.equal(checks.publishCommandExecuted, true);
+    assert.equal(checks.npmVersionResolved, true);
+    assert.equal(checks.publishedTarballReachable, true);
+    assert.equal(checks.installVerificationPassed, true);
+  } finally {
+    await tarballServer.close();
+  }
 });

--- a/tools/npm-release-publish.test.ts
+++ b/tools/npm-release-publish.test.ts
@@ -3,13 +3,36 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import http from 'node:http';
 
 const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
 
 async function tempDir() {
   return await fs.mkdtemp(path.join(os.tmpdir(), 'ailib-npm-publish-'));
+}
+
+async function spawnBun(
+  args: string[],
+  options: {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+  }
+): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  return await new Promise((resolve) => {
+    const child = spawn('bun', args, options);
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on('close', (status) => {
+      resolve({ status, stdout, stderr });
+    });
+  });
 }
 
 async function createTarballServer() {
@@ -102,7 +125,7 @@ test('npm-release-publish fails dry-run when resolved version mismatches package
   assert.match(result.stderr, /Published version mismatch/);
 });
 
-test('npm-release-publish retries when npm view returns stale version', { timeout: 15_000 }, async () => {
+test('npm-release-publish retries when npm view returns stale version', { timeout: 30_000 }, async () => {
   const dir = await tempDir();
   const packageFile = path.join(dir, 'package.json');
   const reportFile = path.join(dir, 'report.json');
@@ -168,12 +191,10 @@ echo "ailib commands:"
     await fs.chmod(fakeNpm, 0o755);
     await fs.chmod(fakeNpx, 0o755);
 
-    const result = spawnSync(
-      'bun',
+    const result = await spawnBun(
       ['tools/npm-release-publish.ts', `--package-file=${packageFile}`, `--report-file=${reportFile}`],
       {
         cwd: packageRoot,
-        encoding: 'utf8',
         env: {
           ...process.env,
           TARBALL_URL: tarballServer.tarballUrl,

--- a/tools/npm-release-publish.ts
+++ b/tools/npm-release-publish.ts
@@ -25,6 +25,7 @@ type PublishReport = {
     npmAuthVerified: boolean;
     publishCommandExecuted: boolean;
     npmVersionResolved: boolean;
+    publishedTarballReachable: boolean;
     installVerificationPassed: boolean;
   };
   checkedAt: string;
@@ -131,6 +132,13 @@ function parseVersionPayload(data: unknown): string {
   throw new Error('Invalid npm version payload: expected string or non-empty string array');
 }
 
+function parseTarballUrlPayload(data: unknown): string {
+  if (typeof data !== 'string' || !/^https?:\/\/\S+/u.test(data)) {
+    throw new Error('Invalid npm tarball payload: expected tarball URL string');
+  }
+  return data;
+}
+
 function isNpmPackageNotFoundError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   return (
@@ -146,17 +154,27 @@ async function sleep(ms: number): Promise<void> {
   });
 }
 
-function resolveRetryConfig(): { maxAttempts: number; delayMs: number } {
-  const maxAttemptsValue = Number.parseInt(process.env.AILIB_NPM_VIEW_MAX_ATTEMPTS ?? '10', 10);
-  const delayMsValue = Number.parseInt(process.env.AILIB_NPM_VIEW_DELAY_MS ?? '3000', 10);
+function resolveRetryConfig(): {
+  viewMaxAttempts: number;
+  viewDelayMs: number;
+  tarballMaxAttempts: number;
+  tarballDelayMs: number;
+} {
+  const viewMaxAttemptsValue = Number.parseInt(process.env.AILIB_NPM_VIEW_MAX_ATTEMPTS ?? '10', 10);
+  const viewDelayMsValue = Number.parseInt(process.env.AILIB_NPM_VIEW_DELAY_MS ?? '3000', 10);
+  const tarballMaxAttemptsValue = Number.parseInt(process.env.AILIB_NPM_TARBALL_MAX_ATTEMPTS ?? '20', 10);
+  const tarballDelayMsValue = Number.parseInt(process.env.AILIB_NPM_TARBALL_DELAY_MS ?? '3000', 10);
   return {
-    maxAttempts: Number.isFinite(maxAttemptsValue) && maxAttemptsValue > 0 ? maxAttemptsValue : 10,
-    delayMs: Number.isFinite(delayMsValue) && delayMsValue >= 0 ? delayMsValue : 3000
+    viewMaxAttempts: Number.isFinite(viewMaxAttemptsValue) && viewMaxAttemptsValue > 0 ? viewMaxAttemptsValue : 10,
+    viewDelayMs: Number.isFinite(viewDelayMsValue) && viewDelayMsValue >= 0 ? viewDelayMsValue : 3000,
+    tarballMaxAttempts:
+      Number.isFinite(tarballMaxAttemptsValue) && tarballMaxAttemptsValue > 0 ? tarballMaxAttemptsValue : 20,
+    tarballDelayMs: Number.isFinite(tarballDelayMsValue) && tarballDelayMsValue >= 0 ? tarballDelayMsValue : 3000
   };
 }
 
 async function resolvePublishedVersionWithRetry(packageName: string, expectedVersion: string): Promise<string> {
-  const { maxAttempts, delayMs } = resolveRetryConfig();
+  const { viewMaxAttempts: maxAttempts, viewDelayMs: delayMs } = resolveRetryConfig();
   let lastResolvedVersion: string | undefined;
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
@@ -187,6 +205,71 @@ async function resolvePublishedVersionWithRetry(packageName: string, expectedVer
 
   throw new Error(
     `Unable to resolve published version for ${packageName}; expected ${expectedVersion}, last received ${lastResolvedVersion ?? 'unknown'}`
+  );
+}
+
+async function resolvePublishedTarballUrlWithRetry(packageName: string, expectedVersion: string): Promise<string> {
+  const { tarballMaxAttempts: maxAttempts, tarballDelayMs: delayMs } = resolveRetryConfig();
+  let lastFailure: string | undefined;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const payload = JSON.parse(
+        (await runCommand('npm', ['view', `${packageName}@${expectedVersion}`, 'dist.tarball', '--json'])).stdout
+      );
+      return parseTarballUrlPayload(payload);
+    } catch (error: unknown) {
+      const reason = error instanceof Error ? error.message : String(error);
+      lastFailure = reason;
+      if (attempt === maxAttempts) {
+        break;
+      }
+      process.stdout.write(
+        `npm view tarball retry ${attempt}/${String(maxAttempts)} for ${packageName}@${expectedVersion}; reason: ${reason}; waiting ${String(delayMs / 1000)}s...\n`
+      );
+      await sleep(delayMs);
+    }
+  }
+  throw new Error(
+    `Unable to resolve tarball URL for ${packageName}@${expectedVersion}; last failure: ${lastFailure ?? 'unknown'}`
+  );
+}
+
+async function fetchUrlStatus(url: string): Promise<number> {
+  const head = await fetch(url, { method: 'HEAD', redirect: 'follow' });
+  if (head.status === 405 || head.status === 501) {
+    const get = await fetch(url, { method: 'GET', redirect: 'follow' });
+    return get.status;
+  }
+  return head.status;
+}
+
+async function assertPublishedTarballReachableWithRetry(
+  tarballUrl: string,
+  packageName: string,
+  expectedVersion: string
+) {
+  const { tarballMaxAttempts: maxAttempts, tarballDelayMs: delayMs } = resolveRetryConfig();
+  let lastStatusOrError = 'unknown';
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const status = await fetchUrlStatus(tarballUrl);
+      if (status >= 200 && status < 400) {
+        return;
+      }
+      lastStatusOrError = `HTTP ${String(status)}`;
+    } catch (error: unknown) {
+      lastStatusOrError = error instanceof Error ? error.message : String(error);
+    }
+    if (attempt === maxAttempts) {
+      break;
+    }
+    process.stdout.write(
+      `tarball reachability retry ${attempt}/${String(maxAttempts)} for ${packageName}@${expectedVersion}; last result: ${lastStatusOrError}; waiting ${String(delayMs / 1000)}s...\n`
+    );
+    await sleep(delayMs);
+  }
+  throw new Error(
+    `Published tarball not reachable for ${packageName}@${expectedVersion}: ${lastStatusOrError} (${tarballUrl})`
   );
 }
 
@@ -222,6 +305,7 @@ async function main() {
       npmAuthVerified: false,
       publishCommandExecuted: false,
       npmVersionResolved: false,
+      publishedTarballReachable: false,
       installVerificationPassed: false
     },
     checkedAt: new Date().toISOString()
@@ -246,6 +330,10 @@ async function main() {
   report.checks.npmVersionResolved = true;
 
   if (!args.dryRun) {
+    const tarballUrl = await resolvePublishedTarballUrlWithRetry(pkg.name, pkg.version);
+    await assertPublishedTarballReachableWithRetry(tarballUrl, pkg.name, pkg.version);
+    report.checks.publishedTarballReachable = true;
+
     await verifyInstalledCli(pkg);
     report.checks.installVerificationPassed = true;
   }


### PR DESCRIPTION
## Summary
- add tarball URL resolution + reachability retries to `tools/npm-release-publish.ts` so publish verification fails when npm metadata exists but the tarball is unavailable
- replace regex-based glob evaluation in workspace discovery with a memoized wildcard matcher to remove the ReDoS path reported in Snyk
- upgrade npm publish workflow actions to Node 24-compatible versions, set runner opt-in to Node 24 JS action runtime, and switch publish Node runtime to 24
- exclude TypeScript source files from the npm tarball by removing `tools/` from package publish entries and enforcing this in preflight validation
- update publish docs and tests for tarball verification and TypeScript exclusion

## Test plan
- [x] Run `bun test src/cli/workspace-discovery.test.ts`
- [x] Run `bun test tools/npm-release-publish.test.ts`
- [x] Run `bun test tools/npm-release-preflight.test.ts`
- [x] Run `npm pack --dry-run --json`
- [x] Run `bun run check`

Refs #311
Closes #311