### PR TITLE
feat: add task-driven GH built-in skill

### DIFF
--- a/docs/built-in-skills-catalog.md
+++ b/docs/built-in-skills-catalog.md
@@ -56,6 +56,12 @@ All built-in skills currently declare compatibility with:
 - Dependency notes: no required skills.
 - Recommended usage: use when cycle time, handoff friction, or rollout sequencing is slowing delivery.
 
+### `task-driven-gh-flow`
+
+- Purpose: Execute roadmap work through GitHub tasks with strict traceability across issue hierarchy, project status, and PR linkage.
+- Dependency notes: no required skills.
+- Recommended usage: use for backlog implementation where each task should map cleanly to one PR and post-merge sync is mandatory.
+
 ### `release-readiness`
 
 - Purpose: Validate a change is safe to release with checklist-driven checks, rollback preparation, and post-merge verification.

--- a/registry.json
+++ b/registry.json
@@ -433,6 +433,30 @@
         ]
       }
     },
+    "task-driven-gh-flow": {
+      "display": "Task-driven GH flow",
+      "description": "Execute roadmap work through GitHub tasks with strict traceability. Use when implementing planned backlog items, creating small PRs, linking PRs to issues, updating GitHub Projects after merge, and splitting tasks into sub-issues when a single PR is not enough.",
+      "path": "skills/task-driven-gh-flow.md",
+      "compatible": {
+        "languages": [
+          "typescript",
+          "python",
+          "go",
+          "java",
+          "rust",
+          "javascript"
+        ],
+        "targets": [
+          "cursor",
+          "claude-code",
+          "copilot",
+          "openai",
+          "gemini",
+          "windsurf",
+          "jetbrains"
+        ]
+      }
+    },
     "release-readiness": {
       "display": "Release readiness",
       "description": "Validate a change is safe to release with checklist-driven checks, rollback preparation, and post-merge verification.",

--- a/registry/core.json
+++ b/registry/core.json
@@ -196,6 +196,15 @@
         "targets": ["cursor", "claude-code", "copilot", "openai", "gemini", "windsurf", "jetbrains"]
       }
     },
+    "task-driven-gh-flow": {
+      "display": "Task-driven GH flow",
+      "description": "Execute roadmap work through GitHub tasks with strict traceability. Use when implementing planned backlog items, creating small PRs, linking PRs to issues, updating GitHub Projects after merge, and splitting tasks into sub-issues when a single PR is not enough.",
+      "path": "skills/task-driven-gh-flow.md",
+      "compatible": {
+        "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
+        "targets": ["cursor", "claude-code", "copilot", "openai", "gemini", "windsurf", "jetbrains"]
+      }
+    },
     "release-readiness": {
       "display": "Release readiness",
       "description": "Validate a change is safe to release with checklist-driven checks, rollback preparation, and post-merge verification.",

--- a/skills/task-driven-gh-flow.md
+++ b/skills/task-driven-gh-flow.md
@@ -1,0 +1,74 @@
+---
+name: task-driven-gh-flow
+description: Execute roadmap work through GitHub tasks with strict traceability. Use when implementing planned backlog items, creating small PRs, linking PRs to issues, updating GitHub Projects after merge, and splitting tasks into sub-issues when a single PR is not enough.
+compatible_languages: [typescript, python, go, java, rust, javascript]
+compatible_targets: [cursor, claude-code, copilot, openai, gemini, windsurf, jetbrains]
+---
+
+# task-driven-gh-flow
+
+## Purpose
+
+- Execute roadmap and backlog delivery with strict one-task/one-PR traceability.
+- Keep planning hierarchy clear using native `Epic -> Story -> Task` issue relationships.
+- Ensure project tracking, issue state, and PR linkage stay in sync throughout delivery.
+
+## Workflow
+
+1. Read the active task plus its parent Story/Epic context and acceptance criteria.
+2. Confirm the task is single-PR sized; if not, split into child tasks before coding.
+3. Branch from latest `main` with a scoped name that references phase/task context.
+4. Implement only task-required changes and validate with targeted checks plus full checks.
+5. Commit one logical change using concise commit title and bullet details.
+6. Open one PR per task with summary bullets, test checklist, assignee/label, and `Refs #<task>`.
+7. Immediately sync task issue body (`## Mapped PRs`) and add progress comment.
+8. After merge, close task, update parent checklist/mapped PRs, and move project fields to next state.
+9. Repeat the loop for the next task only after post-merge sync is complete.
+
+## Non-Negotiable Rules
+
+1. Every PR must link to exactly one task issue via `Refs #<issue>`.
+2. Every task should be completed by one PR when possible.
+3. If work requires more than one PR, split the task into child tasks in GitHub first, then map one PR per child task.
+4. Keep PRs small, scoped, and mergeable.
+5. After merge, sync issue + project state before starting the next task.
+6. For roadmap planning, always model hierarchy as `Epic -> Story -> Task` using native issue parent/sub-issue links.
+7. Set real GitHub Issue Types (`Epic`, `Story`, `Task`) on every created item; never rely only on title prefixes.
+8. Keep `Phase XX` in Epic titles only. Story and Task titles must be clean, without `[Phase XX][Story]` or `[Phase XX][Task]` prefixes.
+9. Add all created items to the target GitHub Project and set required fields (at minimum `Status` and `Team` when configured).
+10. Every task issue must show its PR in the GitHub issue `Development` field (not only in comments/body links).
+
+## Default PR Metadata
+
+- Assignee: `silvamarcel`
+- Label selection:
+  - `maintenance` for refactor/chore/infra/docs/process updates
+  - `feature` for new functionality
+  - `bug` for defect fixes
+
+If uncertain, prefer `maintenance` and note why in PR summary.
+
+## PR Body Template
+
+```md
+## Summary
+- <change 1>
+- <change 2>
+
+## Test plan
+- [x] Run `<command>`
+- [x] Run `<command>`
+
+Refs #<issue>
+```
+
+## Issue Body Pattern
+
+Ensure task issues include:
+
+- `## Goal`
+- `## Tasks` (checkboxes)
+- `## Acceptance criteria` (checkboxes)
+- `## Mapped PRs` (append-only log)
+
+For multi-PR work, replace one task with child tasks and keep each child mapped to one PR.

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -205,6 +205,22 @@ test('skills list and explain include reliability skills', async () => {
   assert.match(explainMigration, /path: skills\/migration-planning\.md/);
 });
 
+test('skills list and explain include task-driven GH flow metadata', async () => {
+  const listOutput = await captureStdout(async () => {
+    await run(['skills', 'list'], { packageRoot });
+  });
+  assert.match(listOutput, /- task-driven-gh-flow - Task-driven GH flow/);
+
+  const explainTaskDriven = await captureStdout(async () => {
+    await run(['skills', 'explain', 'task-driven-gh-flow'], { packageRoot });
+  });
+  assert.match(explainTaskDriven, /skill: task-driven-gh-flow/);
+  assert.match(explainTaskDriven, /path: skills\/task-driven-gh-flow\.md/);
+  assert.match(explainTaskDriven, /description: Execute roadmap work through GitHub tasks with strict traceability/);
+  assert.match(explainTaskDriven, /compatible.languages: .*typescript/);
+  assert.match(explainTaskDriven, /compatible.targets: .*claude-code/);
+});
+
 test('skills list and explain include tdd workflow skill metadata', async () => {
   const listOutput = await captureStdout(async () => {
     await run(['skills', 'list'], { packageRoot });


### PR DESCRIPTION
## Summary
- add `task-driven-gh-flow` as a built-in published skill under `skills/`
- register the skill in `registry/core.json` and sync `registry.json` so consumers can discover it
- add catalog docs and CLI discovery test coverage for list/explain behavior

## Test plan
- [x] Run `bun run registry:check`
- [x] Run `bun test test/cli.test.ts`
- [x] Run `bun test test/registry-governance.test.ts src/cli/introspection.test.ts`

Refs #313

Made with [Cursor](https://cursor.com)

Closes #313
