### PR TITLE
style: format task-driven skill markdown

### DIFF
--- a/skills/task-driven-gh-flow.md
+++ b/skills/task-driven-gh-flow.md
@@ -52,10 +52,12 @@ If uncertain, prefer `maintenance` and note why in PR summary.
 
 ```md
 ## Summary
+
 - <change 1>
 - <change 2>
 
 ## Test plan
+
 - [x] Run `<command>`
 - [x] Run `<command>`
 


### PR DESCRIPTION
## Summary
- fix markdown formatting in `skills/task-driven-gh-flow.md` that breaks release preflight `format:check`
- keep change scoped to formatting-only whitespace so release logic remains unchanged

## Test plan
- [x] Run `bun run format:check`
- [x] Run `bun run release:npm:preflight`

Refs #315
Closes #315

Made with [Cursor](https://cursor.com)