### PR TITLE
infra: extend npm tarball verification retries

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -130,6 +130,9 @@ jobs:
       - name: Publish and verify npm release
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # npm metadata can update before tarball CDN propagation; extend verification window.
+          AILIB_NPM_TARBALL_MAX_ATTEMPTS: '80'
+          AILIB_NPM_TARBALL_DELAY_MS: '3000'
         run: bun run release:npm:publish
 
       - name: Generate npm release record


### PR DESCRIPTION
## Summary
- increase npm tarball propagation retry window in `npm-publish` workflow by setting retry env vars
- avoid false release failures when npm metadata updates before CDN tarball availability

## Test plan
- [x] Run `bunx prettier --check .github/workflows/npm-publish.yml`
- [x] Inspect failing run `24951332663` logs to confirm tarball propagation timeout cause

Refs #317
Closes #317

Made with [Cursor](https://cursor.com)