### PR TITLE
fix: improve npm metadata and version checks

### DIFF
--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -52,8 +52,20 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Install gitleaks CLI
+        env:
+          GITLEAKS_VERSION: '8.30.1'
+        run: |
+          curl -sSfL \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            -o "${RUNNER_TEMP}/gitleaks.tar.gz"
+          mkdir -p "${RUNNER_TEMP}/bin"
+          tar -xzf "${RUNNER_TEMP}/gitleaks.tar.gz" -C "${RUNNER_TEMP}/bin" gitleaks
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+          "${RUNNER_TEMP}/bin/gitleaks" version
+
       - name: Run gitleaks scan
-        uses: gitleaks/gitleaks-action@v2
+        run: gitleaks git --redact --verbose --no-banner --exit-code 1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/README.md
+++ b/README.md
@@ -60,7 +60,13 @@ ailib update
 ailib doctor
 ```
 
-4. Evolve your stack over time:
+4. Check installed CLI version:
+
+```bash
+ailib --version
+```
+
+5. Evolve your stack over time:
 
 ```bash
 ailib add prettier

--- a/docs/cli-usage-guide.md
+++ b/docs/cli-usage-guide.md
@@ -12,6 +12,7 @@ Core commands:
 - `ailib remove <module>`
 - `ailib doctor`
 - `ailib uninstall`
+- `ailib version` (or `ailib --version`)
 - `ailib slots list`
 - `ailib modules list`
 - `ailib modules explain <module>`

--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
   "name": "@alisya.ai/ailib",
   "version": "1.0.6",
   "description": "Universal AI context-injection engine CLI",
+  "homepage": "https://github.com/Alisya-AI/ai-lib#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Alisya-AI/ai-lib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Alisya-AI/ai-lib/issues"
+  },
   "type": "module",
   "main": "dist/runtime/cli.js",
   "exports": {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
 
 import { run } from './cli.ts';
 
@@ -33,4 +34,24 @@ test('run rejects unknown command', async () => {
     async () => run(['unknown-command'], { cwd: process.cwd(), packageRoot: process.cwd() }),
     /Unknown command: unknown-command/
   );
+});
+
+test('run prints package version for version aliases', async () => {
+  const pkg = JSON.parse(await fs.readFile('package.json', 'utf8')) as { version: string };
+  const expected = `${pkg.version}\n`;
+
+  const longFlagOutput = await captureStdout(async () => {
+    await run(['--version'], { cwd: process.cwd(), packageRoot: process.cwd() });
+  });
+  assert.equal(longFlagOutput, expected);
+
+  const shortFlagOutput = await captureStdout(async () => {
+    await run(['-v'], { cwd: process.cwd(), packageRoot: process.cwd() });
+  });
+  assert.equal(shortFlagOutput, expected);
+
+  const commandOutput = await captureStdout(async () => {
+    await run(['version'], { cwd: process.cwd(), packageRoot: process.cwd() });
+  });
+  assert.equal(commandOutput, expected);
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { executeCommand } from './cli/dispatch.ts';
 import { parseFlags } from './cli/flags.ts';
 import { printHelp } from './cli/help.ts';
 import { createCanonicalSlotResolver } from './cli/slot-resolver.ts';
+import { readJson } from './cli/utils.ts';
 import { createWorkspaceUpdateRunner } from './cli/workspace-update-runner.ts';
 import type { CommandContext, RunOptions } from './cli/types.ts';
 
@@ -21,6 +22,11 @@ const APPLY_WORKSPACE_UPDATE = createWorkspaceUpdateRunner({
 export async function run(argv: string[], options: RunOptions = {}) {
   const cwd = options.cwd ?? process.cwd();
   const packageRoot = options.packageRoot ?? path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+  const packageJson = await readJson<{ version?: string }>(path.join(packageRoot, 'package.json'));
+  const cliVersion = packageJson.version;
+  if (typeof cliVersion !== 'string' || !cliVersion.trim()) {
+    throw new Error(`Invalid package.json: missing version in ${path.join(packageRoot, 'package.json')}`);
+  }
 
   const [command, ...rest] = argv;
   const flags = parseFlags(rest);
@@ -37,6 +43,9 @@ export async function run(argv: string[], options: RunOptions = {}) {
       applyWorkspaceUpdate: async ({ packageRoot: rootPackage, rootDir, workspaceOverride, forceOnConflict }) =>
         APPLY_WORKSPACE_UPDATE({ packageRoot: rootPackage, rootDir, workspaceOverride, forceOnConflict })
     }),
-    printHelp
+    printHelp,
+    printVersion: () => {
+      process.stdout.write(`${cliVersion}\n`);
+    }
   });
 }

--- a/src/cli/dispatch.test.ts
+++ b/src/cli/dispatch.test.ts
@@ -23,7 +23,8 @@ test('executeCommand prints help when command is empty', async () => {
     handlers,
     printHelp: () => {
       printHelpCalls += 1;
-    }
+    },
+    printVersion: () => {}
   });
 
   assert.equal(printHelpCalls, 1);
@@ -39,7 +40,8 @@ test('executeCommand prints help for help aliases', async () => {
     handlers,
     printHelp: () => {
       printHelpCalls += 1;
-    }
+    },
+    printVersion: () => {}
   });
 
   await executeCommand({
@@ -48,7 +50,8 @@ test('executeCommand prints help for help aliases', async () => {
     handlers,
     printHelp: () => {
       printHelpCalls += 1;
-    }
+    },
+    printVersion: () => {}
   });
 
   assert.equal(printHelpCalls, 2);
@@ -68,7 +71,8 @@ test('executeCommand dispatches to registered handler', async () => {
     command: 'update',
     context: createContext(['service-a']),
     handlers,
-    printHelp: () => {}
+    printHelp: () => {},
+    printVersion: () => {}
   });
 
   assert.deepEqual(calls, ['/tmp/workspace', '/tmp/package', 'service-a']);
@@ -80,8 +84,46 @@ test('executeCommand rejects unknown commands', async () => {
       command: 'unknown',
       context: createContext([]),
       handlers: {},
-      printHelp: () => {}
+      printHelp: () => {},
+      printVersion: () => {}
     }),
     /Unknown command: unknown/
   );
+});
+
+test('executeCommand prints version for version aliases', async () => {
+  let printVersionCalls = 0;
+  const handlers: CommandHandlers = {};
+
+  await executeCommand({
+    command: '--version',
+    context: createContext([]),
+    handlers,
+    printHelp: () => {},
+    printVersion: () => {
+      printVersionCalls += 1;
+    }
+  });
+
+  await executeCommand({
+    command: '-v',
+    context: createContext([]),
+    handlers,
+    printHelp: () => {},
+    printVersion: () => {
+      printVersionCalls += 1;
+    }
+  });
+
+  await executeCommand({
+    command: 'version',
+    context: createContext([]),
+    handlers,
+    printHelp: () => {},
+    printVersion: () => {
+      printVersionCalls += 1;
+    }
+  });
+
+  assert.equal(printVersionCalls, 3);
 });

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -7,15 +7,21 @@ export async function executeCommand({
   command,
   context,
   handlers,
-  printHelp
+  printHelp,
+  printVersion
 }: {
   command: string | undefined;
   context: CommandContext;
   handlers: CommandHandlers;
   printHelp: () => void;
+  printVersion: () => void;
 }): Promise<void> {
   if (!command || command === '--help' || command === '-h') {
     printHelp();
+    return;
+  }
+  if (command === '--version' || command === '-v' || command === 'version') {
+    printVersion();
     return;
   }
 

--- a/src/cli/help.test.ts
+++ b/src/cli/help.test.ts
@@ -34,4 +34,6 @@ test('printHelp renders expected command listing', () => {
   assert.match(output, /ailib skills explain <skill-id>/);
   assert.match(output, /ailib skills init <skill-id>/);
   assert.match(output, /ailib skills validate/);
+  assert.match(output, /ailib version/);
+  assert.match(output, /--version\/-v/);
 });

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -7,12 +7,14 @@ export function printHelp() {
       '  ailib remove <module> [--workspace=<path>]\n' +
       '  ailib doctor [--workspace=<path>]\n' +
       '  ailib uninstall [--all]\n' +
+      '  ailib version\n' +
       '  ailib slots list\n' +
       '  ailib modules list [--language=<lang>]\n' +
       '  ailib modules explain <module> [--language=<lang>]\n' +
       '  ailib skills list\n' +
       '  ailib skills explain <skill-id>\n' +
       '  ailib skills init <skill-id> [--workspace=<path>] [--path=<path>] [--description=<text>] [--force]\n' +
-      '  ailib skills validate [--workspace=<path>] [--path=<path>]\n'
+      '  ailib skills validate [--workspace=<path>] [--path=<path>]\n' +
+      '  aliases: --help/-h, --version/-v\n'
   );
 }


### PR DESCRIPTION
## Summary
- add `repository`, `homepage`, and `bugs` metadata in `package.json` so npm can resolve README relative links against the GitHub repository instead of npmjs package paths
- add a CLI version check via `ailib version` and aliases `--version` / `-v`, wired through dispatcher handling with unit coverage
- replace `gitleaks/gitleaks-action@v2` with a pinned gitleaks CLI install + scan step in `security-scans.yml` to remove the Node 20 JS-action annotation
- update command help and CLI usage guide for the new version command

## Test plan
- [x] Run `bun test src/cli/dispatch.test.ts src/cli/help.test.ts src/cli.test.ts`
- [x] Run `bun run check`
- [x] Run `npm pack --dry-run --json` and verify no `.ts` files are packed

Refs #319
Closes #319

Made with [Cursor](https://cursor.com)