### PR TITLE
infra: automate homebrew formula sync

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -33,6 +33,7 @@ concurrency:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   publish:
@@ -295,3 +296,86 @@ jobs:
         with:
           name: npm-release-evidence
           path: dist/release/
+
+  auto-recover:
+    if: |
+      needs.publish.result == 'failure' &&
+      github.event_name == 'push' &&
+      github.ref_name == 'main' &&
+      !contains(github.event.head_commit.message, 'chore: release recovery')
+    needs: publish
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+          ref: main
+
+      - name: Setup Node for recovery
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Attempt automatic recovery release dispatch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git pull --ff-only origin main
+
+          PACKAGE_NAME="$(node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));process.stdout.write(p.name);")"
+          CURRENT_VERSION="$(node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));process.stdout.write(p.version);")"
+          LATEST_VERSION="$(npm view "${PACKAGE_NAME}" version --json 2>/dev/null | tr -d '\" \n\r' || true)"
+          if [ -z "${LATEST_VERSION}" ] || [ "${LATEST_VERSION}" = "null" ]; then
+            echo "Skipping recovery: unable to resolve latest npm version."
+            exit 0
+          fi
+          if [ "${LATEST_VERSION}" != "${CURRENT_VERSION}" ]; then
+            echo "Skipping recovery: repo version ${CURRENT_VERSION} does not match npm latest ${LATEST_VERSION}."
+            exit 0
+          fi
+
+          TARBALL_URL="$(npm view "${PACKAGE_NAME}@${CURRENT_VERSION}" dist.tarball --json 2>/dev/null | tr -d '\" \n\r' || true)"
+          if [ -z "${TARBALL_URL}" ] || [ "${TARBALL_URL}" = "null" ]; then
+            echo "Skipping recovery: no tarball URL published for ${PACKAGE_NAME}@${CURRENT_VERSION}."
+            exit 0
+          fi
+
+          TARBALL_STATUS="$(curl -s -o /dev/null -w '%{http_code}' "${TARBALL_URL}" || true)"
+          if [ -n "${TARBALL_STATUS}" ] && [ "${TARBALL_STATUS}" -ge 200 ] && [ "${TARBALL_STATUS}" -lt 400 ]; then
+            echo "Skipping recovery: tarball is reachable (HTTP ${TARBALL_STATUS})."
+            exit 0
+          fi
+
+          NEXT_VERSION="$(CURRENT_VERSION="${CURRENT_VERSION}" node - <<'NODE'
+          const raw = process.env.CURRENT_VERSION || '';
+          const match = raw.match(/^(\d+)\.(\d+)\.(\d+)/u);
+          if (!match) throw new Error(`Invalid semver: ${raw}`);
+          process.stdout.write(`${match[1]}.${match[2]}.${Number(match[3]) + 1}`);
+          NODE
+          )"
+
+          npm pkg set version="${NEXT_VERSION}"
+          git add package.json
+
+          if git diff --cached --quiet; then
+            echo "No recovery version bump required."
+            exit 0
+          fi
+
+          export GIT_AUTHOR_NAME="github-actions[bot]"
+          export GIT_AUTHOR_EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
+          export GIT_COMMITTER_NAME="${GIT_AUTHOR_NAME}"
+          export GIT_COMMITTER_EMAIL="${GIT_AUTHOR_EMAIL}"
+          git commit -m "chore: release recovery ${PACKAGE_NAME}@${NEXT_VERSION}"
+          git push origin HEAD:main
+          RECOVERY_SHA="$(git rev-parse HEAD)"
+
+          gh workflow run npm-publish.yml \
+            --ref main \
+            -f release_notes_url="${{ github.server_url }}/${{ github.repository }}/commit/${RECOVERY_SHA}" \
+            -f ref=main

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -135,6 +135,158 @@ jobs:
           AILIB_NPM_TARBALL_DELAY_MS: '3000'
         run: bun run release:npm:publish
 
+      - name: Resolve Homebrew formula release inputs
+        id: homebrew
+        run: |
+          PACKAGE_NAME="$(node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));process.stdout.write(p.name);")"
+          PACKAGE_VERSION="$(node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));process.stdout.write(p.version);")"
+          PACKAGE_BASENAME="$(node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));process.stdout.write(p.name.split('/').pop());")"
+          TARBALL_URL="$(npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" dist.tarball --json 2>/dev/null | tr -d '\" \n\r' || true)"
+          if [ -z "${TARBALL_URL}" ] || [ "${TARBALL_URL}" = "null" ]; then
+            TARBALL_URL="https://registry.npmjs.org/${PACKAGE_NAME}/-/$(printf '%s' "${PACKAGE_BASENAME}")-${PACKAGE_VERSION}.tgz"
+          fi
+
+          TARBALL_PATH="${RUNNER_TEMP}/${PACKAGE_BASENAME}-${PACKAGE_VERSION}.tgz"
+          for attempt in $(seq 1 20); do
+            if curl -fsSL "${TARBALL_URL}" -o "${TARBALL_PATH}"; then
+              break
+            fi
+            if [ "${attempt}" -eq 20 ]; then
+              echo "Unable to download npm tarball from ${TARBALL_URL}"
+              exit 1
+            fi
+            sleep 3
+          done
+          TARBALL_SHA="$(shasum -a 256 "${TARBALL_PATH}" | awk '{print $1}')"
+
+          echo "package_name=${PACKAGE_NAME}" >> "$GITHUB_OUTPUT"
+          echo "package_version=${PACKAGE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tarball_url=${TARBALL_URL}" >> "$GITHUB_OUTPUT"
+          echo "tarball_sha=${TARBALL_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Sync in-repo Homebrew formula
+        env:
+          PACKAGE_VERSION: ${{ steps.homebrew.outputs.package_version }}
+          TARBALL_URL: ${{ steps.homebrew.outputs.tarball_url }}
+          TARBALL_SHA: ${{ steps.homebrew.outputs.tarball_sha }}
+        run: |
+          cat > Formula/ailib.rb <<EOF
+          class Ailib < Formula
+            desc "Universal AI context-injection engine CLI"
+            homepage "https://github.com/Alisya-AI/ai-lib"
+            url "${TARBALL_URL}"
+            sha256 "${TARBALL_SHA}"
+            version "${PACKAGE_VERSION}"
+            head "https://github.com/Alisya-AI/ai-lib.git", branch: "main"
+            license "Apache-2.0"
+
+            depends_on "node"
+
+            def install
+              system "npm", "install", "--omit=dev", *std_npm_args
+              bin.write_exec_script libexec/"bin/ailib"
+            end
+
+            test do
+              assert_match "ailib commands:", shell_output("#{bin}/ailib --help")
+            end
+          end
+          EOF
+
+          git add Formula/ailib.rb
+          if git diff --cached --quiet; then
+            echo "In-repo Formula/ailib.rb already up to date"
+          else
+            export GIT_AUTHOR_NAME="github-actions[bot]"
+            export GIT_AUTHOR_EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
+            export GIT_COMMITTER_NAME="${GIT_AUTHOR_NAME}"
+            export GIT_COMMITTER_EMAIL="${GIT_AUTHOR_EMAIL}"
+            git commit -m "chore: sync homebrew formula ${PACKAGE_VERSION}"
+            git push origin HEAD:main
+          fi
+
+      - name: Resolve Homebrew tap sync context
+        id: tap_context
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [ -z "${HOMEBREW_TAP_TOKEN}" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Skipping Homebrew tap sync because HOMEBREW_TAP_TOKEN is not configured."
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Sync Homebrew tap formula (create PR)
+        if: steps.tap_context.outputs.enabled == 'true'
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          PACKAGE_VERSION: ${{ steps.homebrew.outputs.package_version }}
+          TARBALL_URL: ${{ steps.homebrew.outputs.tarball_url }}
+          TARBALL_SHA: ${{ steps.homebrew.outputs.tarball_sha }}
+        run: |
+          TAP_REPO="Alisya-AI/homebrew-ailib"
+          TAP_DIR="${RUNNER_TEMP}/homebrew-tap"
+          BRANCH_NAME="chore/ailib-${PACKAGE_VERSION}-${GITHUB_RUN_ID}"
+
+          rm -rf "${TAP_DIR}"
+          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/${TAP_REPO}.git" "${TAP_DIR}"
+          cd "${TAP_DIR}"
+          git checkout -b "${BRANCH_NAME}"
+
+          cat > Formula/ailib.rb <<EOF
+          class Ailib < Formula
+            desc "Universal AI context-injection engine CLI"
+            homepage "https://github.com/Alisya-AI/ai-lib"
+            url "${TARBALL_URL}"
+            sha256 "${TARBALL_SHA}"
+            version "${PACKAGE_VERSION}"
+            head "https://github.com/Alisya-AI/ai-lib.git", branch: "main"
+            license "Apache-2.0"
+
+            depends_on "node"
+
+            def install
+              system "npm", "install", "--omit=dev", *std_npm_args
+              bin.write_exec_script libexec/"bin/ailib"
+            end
+
+            test do
+              assert_match "ailib commands:", shell_output("#{bin}/ailib --help")
+            end
+          end
+          EOF
+
+          if git diff --quiet -- Formula/ailib.rb; then
+            echo "Homebrew tap formula already up to date"
+            exit 0
+          fi
+
+          git add Formula/ailib.rb
+          export GIT_AUTHOR_NAME="github-actions[bot]"
+          export GIT_AUTHOR_EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
+          export GIT_COMMITTER_NAME="${GIT_AUTHOR_NAME}"
+          export GIT_COMMITTER_EMAIL="${GIT_AUTHOR_EMAIL}"
+          git commit -m "chore: update ailib formula to ${PACKAGE_VERSION}"
+          git push -u origin "${BRANCH_NAME}"
+
+          export GH_TOKEN="${HOMEBREW_TAP_TOKEN}"
+          gh pr create \
+            --repo "${TAP_REPO}" \
+            --base main \
+            --head "${BRANCH_NAME}" \
+            --title "chore: update ailib formula to ${PACKAGE_VERSION}" \
+            --body "$(cat <<EOF
+          ## Summary
+          - update Homebrew formula to @alisya.ai/ailib@${PACKAGE_VERSION}
+          - set tarball url and sha256 to published npm artifact
+          - keep install/test blocks aligned with ai-lib formula
+
+          ## Verification
+          - Source release workflow: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+          EOF
+          )"
+
       - name: Generate npm release record
         run: bun run release:npm:record -- --release-notes-url="${{ steps.context.outputs.release_notes_url }}"
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -33,7 +33,6 @@ concurrency:
 
 permissions:
   contents: write
-  actions: write
 
 jobs:
   publish:
@@ -296,86 +295,3 @@ jobs:
         with:
           name: npm-release-evidence
           path: dist/release/
-
-  auto-recover:
-    if: |
-      needs.publish.result == 'failure' &&
-      github.event_name == 'push' &&
-      github.ref_name == 'main' &&
-      !contains(github.event.head_commit.message, 'chore: release recovery')
-    needs: publish
-    runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: true
-          ref: main
-
-      - name: Setup Node for recovery
-        uses: actions/setup-node@v6.4.0
-        with:
-          node-version: 24
-          registry-url: https://registry.npmjs.org
-
-      - name: Attempt automatic recovery release dispatch
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          git pull --ff-only origin main
-
-          PACKAGE_NAME="$(node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));process.stdout.write(p.name);")"
-          CURRENT_VERSION="$(node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));process.stdout.write(p.version);")"
-          LATEST_VERSION="$(npm view "${PACKAGE_NAME}" version --json 2>/dev/null | tr -d '\" \n\r' || true)"
-          if [ -z "${LATEST_VERSION}" ] || [ "${LATEST_VERSION}" = "null" ]; then
-            echo "Skipping recovery: unable to resolve latest npm version."
-            exit 0
-          fi
-          if [ "${LATEST_VERSION}" != "${CURRENT_VERSION}" ]; then
-            echo "Skipping recovery: repo version ${CURRENT_VERSION} does not match npm latest ${LATEST_VERSION}."
-            exit 0
-          fi
-
-          TARBALL_URL="$(npm view "${PACKAGE_NAME}@${CURRENT_VERSION}" dist.tarball --json 2>/dev/null | tr -d '\" \n\r' || true)"
-          if [ -z "${TARBALL_URL}" ] || [ "${TARBALL_URL}" = "null" ]; then
-            echo "Skipping recovery: no tarball URL published for ${PACKAGE_NAME}@${CURRENT_VERSION}."
-            exit 0
-          fi
-
-          TARBALL_STATUS="$(curl -s -o /dev/null -w '%{http_code}' "${TARBALL_URL}" || true)"
-          if [ -n "${TARBALL_STATUS}" ] && [ "${TARBALL_STATUS}" -ge 200 ] && [ "${TARBALL_STATUS}" -lt 400 ]; then
-            echo "Skipping recovery: tarball is reachable (HTTP ${TARBALL_STATUS})."
-            exit 0
-          fi
-
-          NEXT_VERSION="$(CURRENT_VERSION="${CURRENT_VERSION}" node - <<'NODE'
-          const raw = process.env.CURRENT_VERSION || '';
-          const match = raw.match(/^(\d+)\.(\d+)\.(\d+)/u);
-          if (!match) throw new Error(`Invalid semver: ${raw}`);
-          process.stdout.write(`${match[1]}.${match[2]}.${Number(match[3]) + 1}`);
-          NODE
-          )"
-
-          npm pkg set version="${NEXT_VERSION}"
-          git add package.json
-
-          if git diff --cached --quiet; then
-            echo "No recovery version bump required."
-            exit 0
-          fi
-
-          export GIT_AUTHOR_NAME="github-actions[bot]"
-          export GIT_AUTHOR_EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
-          export GIT_COMMITTER_NAME="${GIT_AUTHOR_NAME}"
-          export GIT_COMMITTER_EMAIL="${GIT_AUTHOR_EMAIL}"
-          git commit -m "chore: release recovery ${PACKAGE_NAME}@${NEXT_VERSION}"
-          git push origin HEAD:main
-          RECOVERY_SHA="$(git rev-parse HEAD)"
-
-          gh workflow run npm-publish.yml \
-            --ref main \
-            -f release_notes_url="${{ github.server_url }}/${{ github.repository }}/commit/${RECOVERY_SHA}" \
-            -f ref=main

--- a/Formula/ailib.rb
+++ b/Formula/ailib.rb
@@ -1,9 +1,9 @@
 class Ailib < Formula
   desc "Universal AI context-injection engine CLI"
   homepage "https://github.com/Alisya-AI/ai-lib"
-  url "https://registry.npmjs.org/@alisya.ai/ailib/-/ailib-1.0.2.tgz"
-  sha256 "944c4617fdf801dd5f5d61e9e413579e508193a17320e71b37f60d3cda7da43c"
-  version "1.0.2"
+  url "https://registry.npmjs.org/@alisya.ai/ailib/-/ailib-1.0.6.tgz"
+  sha256 "19eea3cb84cbccc969ecc4a79c1dc3955c29cae0881e0c3ef3921f1e9f73ac64"
+  version "1.0.6"
   head "https://github.com/Alisya-AI/ai-lib.git", branch: "main"
   license "Apache-2.0"
 

--- a/docs/homebrew-publishing.md
+++ b/docs/homebrew-publishing.md
@@ -1,6 +1,6 @@
 # Homebrew publishing for `ailib`
 
-This document explains exactly how to publish and update `ailib` for Homebrew users.
+This document explains exactly how `ailib` Homebrew formulas are synchronized to npm releases.
 
 ## Current state
 
@@ -46,7 +46,8 @@ Use a tap repo so users can run `brew install ailib` after one-time tap setup.
 
 1. Create tap repository: `Alisya-AI/homebrew-ailib`.
 2. Add `Formula/ailib.rb`.
-3. Start from the formula in this repository and update `url`, `sha256`, and `version` each release.
+3. Add repository secret `HOMEBREW_TAP_TOKEN` in `Alisya-AI/ai-lib` with write access to `Alisya-AI/homebrew-ailib` (fine-grained PAT scoped to the tap repo is recommended).
+4. Start from the formula in this repository.
 
 Stable formula shape:
 
@@ -72,22 +73,42 @@ class Ailib < Formula
 end
 ```
 
-### Release workflow (every version)
+### Release workflow (automated)
 
-1. Publish npm version `X.Y.Z` for `@alisya.ai/ailib`.
-2. Generate release artifacts:
+On each successful npm publish workflow run:
+
+1. The release pipeline resolves the published tarball URL + SHA256 for `@alisya.ai/ailib@X.Y.Z`.
+2. It updates `Formula/ailib.rb` in this repository and pushes the change to `main` when needed.
+3. It clones `Alisya-AI/homebrew-ailib`, updates tap `Formula/ailib.rb`, and opens a PR automatically.
+
+If `HOMEBREW_TAP_TOKEN` is missing, tap sync is skipped with a workflow warning.
+
+### Optional verification
+
+You can still verify a tarball checksum manually:
+
+```bash
+VERSION="X.Y.Z"
+curl -L -o "/tmp/ailib-${VERSION}.tgz" "https://registry.npmjs.org/@alisya.ai/ailib/-/ailib-${VERSION}.tgz"
+shasum -a 256 "/tmp/ailib-${VERSION}.tgz"
+```
+
+Legacy manual flow (fallback only):
+
+1. Generate release artifacts:
    ```bash
    bun run release:build
    ```
-3. Read `dist/release/homebrew-formula-snippet.txt` and copy values into tap `Formula/ailib.rb`.
-   - If npm already has `@alisya.ai/ailib@X.Y.Z`, the snippet uses published tarball SHA256.
-   - If not yet published, it falls back to local `npm pack` SHA256 (rerun after publish).
-4. (optional verification) Compute npm tarball SHA256 directly:
-   ```bash
-   curl -L -o /tmp/ailib-X.Y.Z.tgz https://registry.npmjs.org/@alisya.ai/ailib/-/ailib-X.Y.Z.tgz
-   shasum -a 256 /tmp/ailib-X.Y.Z.tgz
-   ```
-5. Commit and push to `Alisya-AI/homebrew-ailib`.
+2. Read `dist/release/homebrew-formula-snippet.txt` and copy values into tap `Formula/ailib.rb`.
+3. Commit and push to `Alisya-AI/homebrew-ailib`.
+4. Open a PR in `Alisya-AI/homebrew-ailib`.
+
+Previous checksum verification command:
+
+```bash
+curl -L -o /tmp/ailib-X.Y.Z.tgz https://registry.npmjs.org/@alisya.ai/ailib/-/ailib-X.Y.Z.tgz
+shasum -a 256 /tmp/ailib-X.Y.Z.tgz
+```
 
 ## Release verification record (v1.0.2)
 

--- a/docs/npm-publishing.md
+++ b/docs/npm-publishing.md
@@ -93,8 +93,10 @@ The workflow runs:
 
 1. (auto mode) bump patch version and push release commit to `main`
 2. `bun run release:npm:publish`
-3. `bun run release:npm:record -- --release-notes-url=<input-or-generated>`
-4. Uploads `dist/release/` as `npm-release-evidence` artifact
+3. sync in-repo `Formula/ailib.rb` to the published npm tarball URL + SHA256
+4. create/update Homebrew tap formula PR in `Alisya-AI/homebrew-ailib` (when `HOMEBREW_TAP_TOKEN` is configured)
+5. `bun run release:npm:record -- --release-notes-url=<input-or-generated>`
+6. Uploads `dist/release/` as `npm-release-evidence` artifact
 
 ### Auto-release path filter
 
@@ -121,6 +123,11 @@ Set `NPM_TOKEN` in repository secrets:
 
 - npm type: Automation token (recommended for CI publish)
 - scope: minimal publish permissions for `@alisya.ai/ailib`
+
+Set `HOMEBREW_TAP_TOKEN` in repository secrets to enable tap PR automation:
+
+- token type: fine-grained PAT (recommended)
+- repository access: `Alisya-AI/homebrew-ailib` (contents + pull requests write)
 
 ### Optional hardening: npm trusted publishing
 

--- a/docs/npm-publishing.md
+++ b/docs/npm-publishing.md
@@ -97,6 +97,7 @@ The workflow runs:
 4. create/update Homebrew tap formula PR in `Alisya-AI/homebrew-ailib` (when `HOMEBREW_TAP_TOKEN` is configured)
 5. `bun run release:npm:record -- --release-notes-url=<input-or-generated>`
 6. Uploads `dist/release/` as `npm-release-evidence` artifact
+7. on failed `push` runs where npm metadata updated but tarball remains unreachable, performs one automatic recovery bump + redispatch
 
 ### Auto-release path filter
 
@@ -107,6 +108,7 @@ Auto-publish on `main` only runs when changes include release-relevant paths:
 - `scripts/**`, `tools/**`, `bin/**`, `schema/**`
 
 Version-bump commits only touch `package.json`, so they do not re-trigger auto release.
+Recovery commits are redispatched through `workflow_dispatch` automatically by the same workflow.
 
 ### Manual workflow_dispatch
 

--- a/docs/npm-publishing.md
+++ b/docs/npm-publishing.md
@@ -97,7 +97,6 @@ The workflow runs:
 4. create/update Homebrew tap formula PR in `Alisya-AI/homebrew-ailib` (when `HOMEBREW_TAP_TOKEN` is configured)
 5. `bun run release:npm:record -- --release-notes-url=<input-or-generated>`
 6. Uploads `dist/release/` as `npm-release-evidence` artifact
-7. on failed `push` runs where npm metadata updated but tarball remains unreachable, performs one automatic recovery bump + redispatch
 
 ### Auto-release path filter
 
@@ -108,7 +107,6 @@ Auto-publish on `main` only runs when changes include release-relevant paths:
 - `scripts/**`, `tools/**`, `bin/**`, `schema/**`
 
 Version-bump commits only touch `package.json`, so they do not re-trigger auto release.
-Recovery commits are redispatched through `workflow_dispatch` automatically by the same workflow.
 
 ### Manual workflow_dispatch
 


### PR DESCRIPTION
## Summary
- extend `npm-publish` workflow to resolve released npm tarball URL/SHA and sync in-repo `Formula/ailib.rb` automatically after successful npm publish
- add tap automation that clones `Alisya-AI/homebrew-ailib`, updates `Formula/ailib.rb`, and opens a PR per release when `HOMEBREW_TAP_TOKEN` is configured
- document Homebrew sync automation and required secret wiring in publishing docs
- align in-repo `Formula/ailib.rb` with current published release `1.0.6`

## Test plan
- [x] Run `bun run check`

Refs #321
Closes #321