### PR TITLE
infra: increase npm tarball propagation wait

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -130,9 +130,10 @@ jobs:
       - name: Publish and verify npm release
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          # npm metadata can update before tarball CDN propagation; extend verification window.
-          AILIB_NPM_TARBALL_MAX_ATTEMPTS: '80'
-          AILIB_NPM_TARBALL_DELAY_MS: '3000'
+          # npm metadata can update before tarball CDN propagation.
+          # Use a wider wait window (20 minutes) to avoid false failures from delayed artifact availability.
+          AILIB_NPM_TARBALL_MAX_ATTEMPTS: '240'
+          AILIB_NPM_TARBALL_DELAY_MS: '5000'
         run: bun run release:npm:publish
 
       - name: Resolve Homebrew formula release inputs

--- a/docs/npm-publishing.md
+++ b/docs/npm-publishing.md
@@ -44,6 +44,13 @@ The workflow performs:
 The publish verification step automatically retries npm version resolution when the registry
 returns transient `404` responses or a stale previous version immediately after publish.
 
+For tarball reachability, CI uses an extended propagation window to reduce false failures:
+
+- `AILIB_NPM_TARBALL_MAX_ATTEMPTS=240`
+- `AILIB_NPM_TARBALL_DELAY_MS=5000`
+
+This gives ~20 minutes of tarball-availability retries before the workflow marks the release as failed.
+
 ## 3) Optional dry-run publish verification
 
 To exercise non-publish verification paths without uploading:


### PR DESCRIPTION
## Summary
- increase npm publish tarball verification window in CI from ~4 minutes (`80 x 3s`) to ~20 minutes (`240 x 5s`) to absorb delayed npm CDN propagation
- keep strict verification semantics (workflow still fails if tarball remains unreachable after the extended window)
- document propagation retry settings in npm publishing docs

## Investigation notes
- failed run: https://github.com/Alisya-AI/ai-lib/actions/runs/24951849793
- `npm view` reflected `1.0.7`, but tarball URL returned `404` throughout the existing verification window and only became downloadable later
- this indicates external npm propagation latency, not a local code race in release scripts

## Test plan
- [x] Run `bun run check`

Refs #323
Closes #323

Made with [Cursor](https://cursor.com)