### PR TITLE
feat: split Jira and Notion delivery skills

### DIFF
--- a/docs/built-in-skills-catalog.md
+++ b/docs/built-in-skills-catalog.md
@@ -56,6 +56,18 @@ All built-in skills currently declare compatibility with:
 - Dependency notes: no required skills.
 - Recommended usage: use when cycle time, handoff friction, or rollout sequencing is slowing delivery.
 
+### `jira-delivery-practices`
+
+- Purpose: Apply Jira workflow best practices to keep software delivery planning, execution, and release traceability aligned.
+- Dependency notes: no required skills.
+- Recommended usage: use when teams need stronger ticket hygiene, strict flow states, and clear requirement-to-PR traceability.
+
+### `notion-delivery-practices`
+
+- Purpose: Apply Notion documentation best practices to keep software development context, decisions, and delivery playbooks current.
+- Dependency notes: no required skills.
+- Recommended usage: use when teams need reliable design notes, release playbooks, and cross-linking between docs, tickets, and PRs.
+
 ### `task-driven-gh-flow`
 
 - Purpose: Execute roadmap work through GitHub tasks with strict traceability across issue hierarchy, project status, and PR linkage.

--- a/registry.json
+++ b/registry.json
@@ -433,6 +433,54 @@
         ]
       }
     },
+    "jira-delivery-practices": {
+      "display": "Jira delivery practices",
+      "description": "Apply Jira workflow best practices to keep software delivery planning, execution, and release traceability aligned.",
+      "path": "skills/jira-delivery-practices.md",
+      "compatible": {
+        "languages": [
+          "typescript",
+          "python",
+          "go",
+          "java",
+          "rust",
+          "javascript"
+        ],
+        "targets": [
+          "cursor",
+          "claude-code",
+          "copilot",
+          "openai",
+          "gemini",
+          "windsurf",
+          "jetbrains"
+        ]
+      }
+    },
+    "notion-delivery-practices": {
+      "display": "Notion delivery practices",
+      "description": "Apply Notion documentation best practices to keep software development context, decisions, and delivery playbooks current.",
+      "path": "skills/notion-delivery-practices.md",
+      "compatible": {
+        "languages": [
+          "typescript",
+          "python",
+          "go",
+          "java",
+          "rust",
+          "javascript"
+        ],
+        "targets": [
+          "cursor",
+          "claude-code",
+          "copilot",
+          "openai",
+          "gemini",
+          "windsurf",
+          "jetbrains"
+        ]
+      }
+    },
     "task-driven-gh-flow": {
       "display": "Task-driven GH flow",
       "description": "Execute roadmap work through GitHub tasks with strict traceability. Use when implementing planned backlog items, creating small PRs, linking PRs to issues, updating GitHub Projects after merge, and splitting tasks into sub-issues when a single PR is not enough.",

--- a/registry/core.json
+++ b/registry/core.json
@@ -196,6 +196,24 @@
         "targets": ["cursor", "claude-code", "copilot", "openai", "gemini", "windsurf", "jetbrains"]
       }
     },
+    "jira-delivery-practices": {
+      "display": "Jira delivery practices",
+      "description": "Apply Jira workflow best practices to keep software delivery planning, execution, and release traceability aligned.",
+      "path": "skills/jira-delivery-practices.md",
+      "compatible": {
+        "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
+        "targets": ["cursor", "claude-code", "copilot", "openai", "gemini", "windsurf", "jetbrains"]
+      }
+    },
+    "notion-delivery-practices": {
+      "display": "Notion delivery practices",
+      "description": "Apply Notion documentation best practices to keep software development context, decisions, and delivery playbooks current.",
+      "path": "skills/notion-delivery-practices.md",
+      "compatible": {
+        "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
+        "targets": ["cursor", "claude-code", "copilot", "openai", "gemini", "windsurf", "jetbrains"]
+      }
+    },
     "task-driven-gh-flow": {
       "display": "Task-driven GH flow",
       "description": "Execute roadmap work through GitHub tasks with strict traceability. Use when implementing planned backlog items, creating small PRs, linking PRs to issues, updating GitHub Projects after merge, and splitting tasks into sub-issues when a single PR is not enough.",

--- a/skills/jira-delivery-practices.md
+++ b/skills/jira-delivery-practices.md
@@ -1,0 +1,23 @@
+---
+name: jira-delivery-practices
+description: Apply Jira workflow best practices to keep software delivery planning, execution, and release traceability aligned.
+compatible_languages: [typescript, python, go, java, rust, javascript]
+compatible_targets: [cursor, claude-code, copilot, openai, gemini, windsurf, jetbrains]
+---
+
+# jira-delivery-practices
+
+## Purpose
+
+- Keep execution traceable from ticket scope to PR merge and release outcomes.
+- Improve sprint flow with clear ticket states, ownership, and dependency visibility.
+- Reduce work-in-progress churn by enforcing actionable acceptance criteria.
+
+## Workflow
+
+- Use one Jira ticket as the implementation source of truth per delivery unit.
+- Define explicit acceptance criteria, dependencies, risk notes, and owner before moving to in-progress.
+- Keep status transitions strict (`Todo -> In Progress -> In Review -> Done`) and block transitions without required artifacts.
+- Link branch names and PRs back to ticket IDs for direct traceability.
+- Validate pull requests against ticket scope, acceptance criteria, and test evidence during review.
+- On merge, update ticket release fields and capture rollout outcomes/issues for follow-up work.

--- a/skills/notion-delivery-practices.md
+++ b/skills/notion-delivery-practices.md
@@ -1,0 +1,23 @@
+---
+name: notion-delivery-practices
+description: Apply Notion documentation best practices to keep software development context, decisions, and delivery playbooks current.
+compatible_languages: [typescript, python, go, java, rust, javascript]
+compatible_targets: [cursor, claude-code, copilot, openai, gemini, windsurf, jetbrains]
+---
+
+# notion-delivery-practices
+
+## Purpose
+
+- Keep engineering documentation usable during planning, implementation, and operations.
+- Ensure decisions, runbooks, and release notes stay current alongside code changes.
+- Reduce handoff friction with consistent templates and ownership for knowledge artifacts.
+
+## Workflow
+
+- Start each initiative with a Notion page linking scope, constraints, owners, and delivery milestones.
+- Capture design and decision records in structured sections (context, options, decision, consequences).
+- Link Jira tickets and PRs into the page timeline so documentation and execution remain synchronized.
+- Maintain concise implementation notes that explain non-obvious tradeoffs and rollout concerns.
+- Before release, verify playbooks include validation steps, rollback actions, and support contacts.
+- After release, append outcomes, incidents, and follow-up actions to keep team knowledge trustworthy.

--- a/skills/task-driven-gh-flow.md
+++ b/skills/task-driven-gh-flow.md
@@ -16,14 +16,15 @@ compatible_targets: [cursor, claude-code, copilot, openai, gemini, windsurf, jet
 ## Workflow
 
 1. Read the active task plus its parent Story/Epic context and acceptance criteria.
-2. Confirm the task is single-PR sized; if not, split into child tasks before coding.
-3. Branch from latest `main` with a scoped name that references phase/task context.
-4. Implement only task-required changes and validate with targeted checks plus full checks.
-5. Commit one logical change using concise commit title and bullet details.
-6. Open one PR per task with summary bullets, test checklist, assignee/label, and `Refs #<task>`.
-7. Immediately sync task issue body (`## Mapped PRs`) and add progress comment.
-8. After merge, close task, update parent checklist/mapped PRs, and move project fields to next state.
-9. Repeat the loop for the next task only after post-merge sync is complete.
+2. When creating or updating issues, always set `Issue Type` and `Team`; for every Story/Task, link the parent immediately (`Story -> Epic`, `Task -> Story`).
+3. Confirm the task is single-PR sized; if not, split into child tasks before coding.
+4. Branch from latest `main` with a scoped name that references phase/task context.
+5. Implement only task-required changes and validate with targeted checks plus full checks.
+6. Commit one logical change using concise commit title and bullet details.
+7. Open one PR per task with summary bullets, test checklist, assignee/label, and `Refs #<task>`.
+8. Immediately sync task issue body (`## Mapped PRs`) and add progress comment.
+9. After merge, close task, update parent checklist/mapped PRs, and move project fields to next state.
+10. Repeat the loop for the next task only after post-merge sync is complete.
 
 ## Non-Negotiable Rules
 
@@ -33,14 +34,15 @@ compatible_targets: [cursor, claude-code, copilot, openai, gemini, windsurf, jet
 4. Keep PRs small, scoped, and mergeable.
 5. After merge, sync issue + project state before starting the next task.
 6. For roadmap planning, always model hierarchy as `Epic -> Story -> Task` using native issue parent/sub-issue links.
-7. Set real GitHub Issue Types (`Epic`, `Story`, `Task`) on every created item; never rely only on title prefixes.
+7. Set real GitHub `Issue Type` (`Epic`, `Story`, `Task`) on every created item; never rely only on title prefixes.
 8. Keep `Phase XX` in Epic titles only. Story and Task titles must be clean, without `[Phase XX][Story]` or `[Phase XX][Task]` prefixes.
-9. Add all created items to the target GitHub Project and set required fields (at minimum `Status` and `Team` when configured).
-10. Every task issue must show its PR in the GitHub issue `Development` field (not only in comments/body links).
+9. Add all created items to the target GitHub Project and always set `Status` and `Team` fields.
+10. Every Story must be linked to its parent Epic, and every Task must be linked to its parent Story at creation time.
+11. Every task issue must show its PR in the GitHub issue `Development` field (not only in comments/body links).
 
 ## Default PR Metadata
 
-- Assignee: `silvamarcel`
+- Assignee: set to the task owner/requester for that workstream (do not hardcode usernames)
 - Label selection:
   - `maintenance` for refactor/chore/infra/docs/process updates
   - `feature` for new functionality

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,6 +1,8 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 
 import { run } from './cli.ts';
 
@@ -54,4 +56,17 @@ test('run prints package version for version aliases', async () => {
     await run(['version'], { cwd: process.cwd(), packageRoot: process.cwd() });
   });
   assert.equal(commandOutput, expected);
+});
+
+test('run throws when package.json is missing version', async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'ailib-cli-version-'));
+  try {
+    await fs.writeFile(path.join(root, 'package.json'), '{"name":"tmp"}\n', 'utf8');
+    await assert.rejects(
+      run(['--version'], { cwd: root, packageRoot: root }),
+      /Invalid package\.json: missing version/
+    );
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
 });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -205,6 +205,38 @@ test('skills list and explain include reliability skills', async () => {
   assert.match(explainMigration, /path: skills\/migration-planning\.md/);
 });
 
+test('skills list and explain include Jira delivery skill metadata', async () => {
+  const listOutput = await captureStdout(async () => {
+    await run(['skills', 'list'], { packageRoot });
+  });
+  assert.match(listOutput, /- jira-delivery-practices - Jira delivery practices/);
+
+  const explainJira = await captureStdout(async () => {
+    await run(['skills', 'explain', 'jira-delivery-practices'], { packageRoot });
+  });
+  assert.match(explainJira, /skill: jira-delivery-practices/);
+  assert.match(explainJira, /path: skills\/jira-delivery-practices\.md/);
+  assert.match(explainJira, /description: Apply Jira workflow best practices/);
+  assert.match(explainJira, /compatible.languages: .*typescript/);
+  assert.match(explainJira, /compatible.targets: .*claude-code/);
+});
+
+test('skills list and explain include Notion delivery skill metadata', async () => {
+  const listOutput = await captureStdout(async () => {
+    await run(['skills', 'list'], { packageRoot });
+  });
+  assert.match(listOutput, /- notion-delivery-practices - Notion delivery practices/);
+
+  const explainNotion = await captureStdout(async () => {
+    await run(['skills', 'explain', 'notion-delivery-practices'], { packageRoot });
+  });
+  assert.match(explainNotion, /skill: notion-delivery-practices/);
+  assert.match(explainNotion, /path: skills\/notion-delivery-practices\.md/);
+  assert.match(explainNotion, /description: Apply Notion documentation best practices/);
+  assert.match(explainNotion, /compatible.languages: .*typescript/);
+  assert.match(explainNotion, /compatible.targets: .*claude-code/);
+});
+
 test('skills list and explain include task-driven GH flow metadata', async () => {
   const listOutput = await captureStdout(async () => {
     await run(['skills', 'list'], { packageRoot });


### PR DESCRIPTION
## Summary
- split combined Jira/Notion skill into two standalone built-in skills
- update registry/catalog/CLI skill introspection coverage for the two separate skills
- tighten task-driven GH flow skill guidance to require Issue Type, Team, and Story/Task parent links
- add CLI test coverage for missing package version guard path

## Test plan
- [x] bun test test/cli.test.ts
- [x] bun test src/cli.test.ts test/cli.test.ts test/registry-governance.test.ts
- [x] bun run coverage:check
- [x] bun run check

Closes #325
Closes #326