### PR TITLE
infra: enforce Homebrew tap sync

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -206,34 +206,24 @@ jobs:
             git push origin HEAD:main
           fi
 
-      - name: Resolve Homebrew tap sync context
-        id: tap_context
-        env:
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-        run: |
-          if [ -z "${HOMEBREW_TAP_TOKEN}" ]; then
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::Skipping Homebrew tap sync because HOMEBREW_TAP_TOKEN is not configured."
-          else
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Sync Homebrew tap formula (create PR)
-        if: steps.tap_context.outputs.enabled == 'true'
+      - name: Sync Homebrew tap formula
         env:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           PACKAGE_VERSION: ${{ steps.homebrew.outputs.package_version }}
           TARBALL_URL: ${{ steps.homebrew.outputs.tarball_url }}
           TARBALL_SHA: ${{ steps.homebrew.outputs.tarball_sha }}
         run: |
+          if [ -z "${HOMEBREW_TAP_TOKEN}" ]; then
+            echo "Missing required repository secret: HOMEBREW_TAP_TOKEN"
+            exit 1
+          fi
+
           TAP_REPO="Alisya-AI/homebrew-ailib"
           TAP_DIR="${RUNNER_TEMP}/homebrew-tap"
-          BRANCH_NAME="chore/ailib-${PACKAGE_VERSION}-${GITHUB_RUN_ID}"
 
           rm -rf "${TAP_DIR}"
           git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/${TAP_REPO}.git" "${TAP_DIR}"
           cd "${TAP_DIR}"
-          git checkout -b "${BRANCH_NAME}"
 
           cat > Formula/ailib.rb <<EOF
           class Ailib < Formula
@@ -269,24 +259,17 @@ jobs:
           export GIT_COMMITTER_NAME="${GIT_AUTHOR_NAME}"
           export GIT_COMMITTER_EMAIL="${GIT_AUTHOR_EMAIL}"
           git commit -m "chore: update ailib formula to ${PACKAGE_VERSION}"
-          git push -u origin "${BRANCH_NAME}"
-
-          export GH_TOKEN="${HOMEBREW_TAP_TOKEN}"
-          gh pr create \
-            --repo "${TAP_REPO}" \
-            --base main \
-            --head "${BRANCH_NAME}" \
-            --title "chore: update ailib formula to ${PACKAGE_VERSION}" \
-            --body "$(cat <<EOF
-          ## Summary
-          - update Homebrew formula to @alisya.ai/ailib@${PACKAGE_VERSION}
-          - set tarball url and sha256 to published npm artifact
-          - keep install/test blocks aligned with ai-lib formula
-
-          ## Verification
-          - Source release workflow: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
-          EOF
-          )"
+          for attempt in $(seq 1 3); do
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            if [ "${attempt}" -eq 3 ]; then
+              echo "Unable to push tap update after ${attempt} attempts."
+              exit 1
+            fi
+            git fetch origin main
+            git rebase origin/main
+          done
 
       - name: Generate npm release record
         run: bun run release:npm:record -- --release-notes-url="${{ steps.context.outputs.release_notes_url }}"

--- a/README.md
+++ b/README.md
@@ -21,17 +21,25 @@ npm install -g @alisya.ai/ailib
 
 ### Homebrew
 
-Current in-repo formula (stable):
+Direct install from this repository formula:
 
 ```bash
 brew install --formula https://raw.githubusercontent.com/Alisya-AI/ai-lib/main/Formula/ailib.rb
 ```
 
-Recommended user flow via tap:
+Recommended install flow via tap:
 
 ```bash
 brew tap Alisya-AI/ailib
-brew install ailib
+brew update
+brew install Alisya-AI/ailib/ailib
+```
+
+If you previously installed from a raw formula URL and are stuck on an older version, migrate to the tap formula:
+
+```bash
+brew uninstall ailib
+brew install Alisya-AI/ailib/ailib
 ```
 
 ### Local install from repository

--- a/docs/homebrew-publishing.md
+++ b/docs/homebrew-publishing.md
@@ -40,7 +40,7 @@ For a quicker local run that skips full checks:
 bun run release:build -- --skip-check
 ```
 
-Use a tap repo so users can run `brew install ailib` after one-time tap setup.
+Use a tap repo so users can install a stable named formula after one-time tap setup.
 
 ### One-time setup
 
@@ -48,6 +48,7 @@ Use a tap repo so users can run `brew install ailib` after one-time tap setup.
 2. Add `Formula/ailib.rb`.
 3. Add repository secret `HOMEBREW_TAP_TOKEN` in `Alisya-AI/ai-lib` with write access to `Alisya-AI/homebrew-ailib` (fine-grained PAT scoped to the tap repo is recommended).
 4. Start from the formula in this repository.
+5. Ensure `main` in `Alisya-AI/homebrew-ailib` accepts pushes from the token identity used by `HOMEBREW_TAP_TOKEN`.
 
 Stable formula shape:
 
@@ -79,9 +80,9 @@ On each successful npm publish workflow run:
 
 1. The release pipeline resolves the published tarball URL + SHA256 for `@alisya.ai/ailib@X.Y.Z`.
 2. It updates `Formula/ailib.rb` in this repository and pushes the change to `main` when needed.
-3. It clones `Alisya-AI/homebrew-ailib`, updates tap `Formula/ailib.rb`, and opens a PR automatically.
+3. It clones `Alisya-AI/homebrew-ailib`, updates tap `Formula/ailib.rb`, commits the change, and pushes directly to `main`.
 
-If `HOMEBREW_TAP_TOKEN` is missing, tap sync is skipped with a workflow warning.
+If `HOMEBREW_TAP_TOKEN` is missing, the release workflow fails so tap sync cannot drift silently.
 
 ### Optional verification
 
@@ -100,8 +101,7 @@ Legacy manual flow (fallback only):
    bun run release:build
    ```
 2. Read `dist/release/homebrew-formula-snippet.txt` and copy values into tap `Formula/ailib.rb`.
-3. Commit and push to `Alisya-AI/homebrew-ailib`.
-4. Open a PR in `Alisya-AI/homebrew-ailib`.
+3. Commit and push `Formula/ailib.rb` to `main` in `Alisya-AI/homebrew-ailib`.
 
 Previous checksum verification command:
 
@@ -143,7 +143,8 @@ ailib commands:
 
 ```bash
 brew tap Alisya-AI/ailib
-brew install ailib
+brew update
+brew install Alisya-AI/ailib/ailib
 ```
 
 Equivalent explicit form:

--- a/docs/npm-publishing.md
+++ b/docs/npm-publishing.md
@@ -101,7 +101,7 @@ The workflow runs:
 1. (auto mode) bump patch version and push release commit to `main`
 2. `bun run release:npm:publish`
 3. sync in-repo `Formula/ailib.rb` to the published npm tarball URL + SHA256
-4. create/update Homebrew tap formula PR in `Alisya-AI/homebrew-ailib` (when `HOMEBREW_TAP_TOKEN` is configured)
+4. update Homebrew tap formula in `Alisya-AI/homebrew-ailib` by committing directly to `main`
 5. `bun run release:npm:record -- --release-notes-url=<input-or-generated>`
 6. Uploads `dist/release/` as `npm-release-evidence` artifact
 
@@ -131,10 +131,11 @@ Set `NPM_TOKEN` in repository secrets:
 - npm type: Automation token (recommended for CI publish)
 - scope: minimal publish permissions for `@alisya.ai/ailib`
 
-Set `HOMEBREW_TAP_TOKEN` in repository secrets to enable tap PR automation:
+Set `HOMEBREW_TAP_TOKEN` in repository secrets to enable tap sync automation:
 
 - token type: fine-grained PAT (recommended)
-- repository access: `Alisya-AI/homebrew-ailib` (contents + pull requests write)
+- repository access: `Alisya-AI/homebrew-ailib` (contents write)
+- ensure the token identity can push to `main` in `Alisya-AI/homebrew-ailib`
 
 ### Optional hardening: npm trusted publishing
 


### PR DESCRIPTION
## Summary
- make Homebrew tap sync mandatory in npm publish workflow
- update tap sync to push formula updates directly to `main` with retry handling
- align README and release docs with the enforced tap sync behavior

## Test plan
- [x] Run `bun run check`

Refs #328

Made with [Cursor](https://cursor.com)