### PR TITLE
feat: align skills add/remove commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ ailib skills explain release-readiness
 Author and validate custom skills in a workspace:
 
 ```bash
-ailib skills init release-manager --workspace=apps/web --description="Release orchestration workflow"
+ailib skills add release-manager --workspace=apps/web --description="Release orchestration workflow"
 ailib skills validate --workspace=apps/web
 ```
 

--- a/docs/cli-usage-guide.md
+++ b/docs/cli-usage-guide.md
@@ -18,7 +18,8 @@ Core commands:
 - `ailib modules explain <module>`
 - `ailib skills list`
 - `ailib skills explain <skill-id>`
-- `ailib skills init <skill-id>`
+- `ailib skills add <skill-id>` (supports `skills init` alias)
+- `ailib skills remove <skill-id>`
 - `ailib skills validate`
 
 ## Single-repo flow
@@ -454,10 +455,19 @@ ailib update
 Create a new skill file:
 
 ```bash
-ailib skills init release-manager --workspace=apps/web --description="Release orchestration workflow"
+ailib skills add release-manager --workspace=apps/web --description="Release orchestration workflow"
 ```
 
-This writes a scaffold to `.cursor/skills/release-manager/SKILL.md` in the target workspace (or a custom path when `--path` is provided).
+This writes a scaffold to `.cursor/skills/release-manager/SKILL.md` in the target workspace (or a custom path when `--path` is provided).  
+When the `skill-id` matches a built-in skill (for example `solid-principles-application`), `skills add` seeds the file with the built-in skill content instead of an empty TODO scaffold.
+If the target file already exists, built-in seeding will not overwrite that local skill file.
+`skills init` remains available as a compatibility alias for `skills add`.
+
+Remove a local skill scaffold:
+
+```bash
+ailib skills remove release-manager --workspace=apps/web
+```
 
 ### 4) Validate authored skills
 

--- a/src/cli/help.test.ts
+++ b/src/cli/help.test.ts
@@ -32,7 +32,9 @@ test('printHelp renders expected command listing', () => {
   assert.match(output, /ailib modules explain <module>/);
   assert.match(output, /ailib skills list/);
   assert.match(output, /ailib skills explain <skill-id>/);
-  assert.match(output, /ailib skills init <skill-id>/);
+  assert.match(output, /ailib skills add <skill-id>/);
+  assert.match(output, /ailib skills remove <skill-id>/);
+  assert.match(output, /ailib skills init <skill-id> \(alias of skills add\)/);
   assert.match(output, /ailib skills validate/);
   assert.match(output, /ailib version/);
   assert.match(output, /--version\/-v/);

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -13,7 +13,9 @@ export function printHelp() {
       '  ailib modules explain <module> [--language=<lang>]\n' +
       '  ailib skills list\n' +
       '  ailib skills explain <skill-id>\n' +
-      '  ailib skills init <skill-id> [--workspace=<path>] [--path=<path>] [--description=<text>] [--force]\n' +
+      '  ailib skills add <skill-id> [--workspace=<path>] [--path=<path>] [--description=<text>] [--force]\n' +
+      '  ailib skills remove <skill-id> [--workspace=<path>] [--path=<path>]\n' +
+      '  ailib skills init <skill-id> (alias of skills add)\n' +
       '  ailib skills validate [--workspace=<path>] [--path=<path>]\n' +
       '  aliases: --help/-h, --version/-v\n'
   );

--- a/src/cli/skills.test.ts
+++ b/src/cli/skills.test.ts
@@ -12,22 +12,67 @@ async function tempDir() {
 test('skillsCommand rejects unsupported subcommands', async () => {
   await assert.rejects(
     skillsCommand({ cwd: process.cwd(), flags: { _: ['unknown'] } }),
-    /Usage: ailib skills list.*ailib skills validate/s
+    /Usage: ailib skills list.*ailib skills remove.*ailib skills validate/s
   );
 });
 
-test('skillsCommand scaffolds default skill path', async () => {
+test('skillsCommand copies built-in skill content when id matches', async () => {
   const cwd = await tempDir();
   await fs.writeFile(path.join(cwd, 'package.json'), '{"name":"tmp"}\n', 'utf8');
+  const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..');
 
   await skillsCommand({
     cwd,
-    flags: { _: ['init', 'task-driven-gh-flow'] }
+    packageRoot,
+    flags: { _: ['add', 'task-driven-gh-flow'] }
   });
 
   const content = await fs.readFile(path.join(cwd, '.cursor/skills/task-driven-gh-flow/SKILL.md'), 'utf8');
   assert.match(content, /name: task-driven-gh-flow/);
-  assert.match(content, /description: TODO: describe this skill/);
+  assert.match(content, /description: Execute roadmap work through GitHub tasks with strict traceability/);
+  assert.match(content, /## Non-Negotiable Rules/);
+  assert.doesNotMatch(content, /TODO: describe this skill/);
+});
+
+test('skillsCommand supports description override for built-in skill content', async () => {
+  const cwd = await tempDir();
+  await fs.writeFile(path.join(cwd, 'package.json'), '{"name":"tmp"}\n', 'utf8');
+  const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..');
+
+  await skillsCommand({
+    cwd,
+    packageRoot,
+    flags: {
+      _: ['add', 'task-driven-gh-flow'],
+      description: 'My localized task-driven guidance'
+    }
+  });
+
+  const content = await fs.readFile(path.join(cwd, '.cursor/skills/task-driven-gh-flow/SKILL.md'), 'utf8');
+  assert.match(content, /description: My localized task-driven guidance/);
+  assert.match(content, /## Non-Negotiable Rules/);
+});
+
+test('skillsCommand does not overwrite existing local skill file for built-in id', async () => {
+  const cwd = await tempDir();
+  await fs.writeFile(path.join(cwd, 'package.json'), '{"name":"tmp"}\n', 'utf8');
+  const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..');
+  const target = path.join(cwd, '.cursor/skills/task-driven-gh-flow/SKILL.md');
+
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  await fs.writeFile(target, 'custom local skill content\n', 'utf8');
+
+  await assert.rejects(
+    skillsCommand({
+      cwd,
+      packageRoot,
+      flags: { _: ['add', 'task-driven-gh-flow'], force: true }
+    }),
+    /Built-in seeding will not overwrite existing local skill files/
+  );
+
+  const content = await fs.readFile(target, 'utf8');
+  assert.equal(content, 'custom local skill content\n');
 });
 
 test('skillsCommand scaffolds using custom path and description', async () => {
@@ -37,7 +82,7 @@ test('skillsCommand scaffolds using custom path and description', async () => {
   await skillsCommand({
     cwd,
     flags: {
-      _: ['init', 'release-manager'],
+      _: ['add', 'release-manager'],
       path: '.cursor/skills/custom-release',
       description: 'Release workflow automation'
     }
@@ -54,15 +99,15 @@ test('skillsCommand rejects invalid skill id and existing files without force', 
 
   await assert.rejects(skillsCommand({ cwd, flags: { _: ['init', 'BadId'] } }), /Invalid skill id: BadId/);
 
-  await skillsCommand({ cwd, flags: { _: ['init', 'code-review'] } });
+  await skillsCommand({ cwd, flags: { _: ['add', 'code-review'] } });
   await assert.rejects(
-    skillsCommand({ cwd, flags: { _: ['init', 'code-review'] } }),
+    skillsCommand({ cwd, flags: { _: ['add', 'code-review'] } }),
     /Skill file already exists: .*Re-run with --force to overwrite/
   );
 
   await skillsCommand({
     cwd,
-    flags: { _: ['init', 'code-review'], force: true, description: 'Overwritten content' }
+    flags: { _: ['add', 'code-review'], force: true, description: 'Overwritten content' }
   });
   const content = await fs.readFile(path.join(cwd, '.cursor/skills/code-review/SKILL.md'), 'utf8');
   assert.match(content, /description: Overwritten content/);
@@ -77,7 +122,7 @@ test('skillsCommand supports --workspace targeting and blocks path escapes', asy
 
   await skillsCommand({
     cwd: root,
-    flags: { _: ['init', 'triage'], workspace: 'apps/web' }
+    flags: { _: ['add', 'triage'], workspace: 'apps/web' }
   });
 
   const scaffoldPath = path.join(workspace, '.cursor/skills/triage/SKILL.md');
@@ -87,8 +132,35 @@ test('skillsCommand supports --workspace targeting and blocks path escapes', asy
   await assert.rejects(
     skillsCommand({
       cwd: root,
-      flags: { _: ['init', 'escape-test'], workspace: 'apps/web', path: '../outside' }
+      flags: { _: ['add', 'escape-test'], workspace: 'apps/web', path: '../outside' }
     }),
     /Skill path must be within workspace/
+  );
+});
+
+test('skillsCommand supports init alias and remove command', async () => {
+  const cwd = await tempDir();
+  await fs.writeFile(path.join(cwd, 'package.json'), '{"name":"tmp"}\n', 'utf8');
+
+  await skillsCommand({
+    cwd,
+    flags: { _: ['init', 'cleanup-me'], description: 'Temp skill' }
+  });
+
+  const skillPath = path.join(cwd, '.cursor/skills/cleanup-me/SKILL.md');
+  assert.match(await fs.readFile(skillPath, 'utf8'), /description: Temp skill/);
+
+  await skillsCommand({
+    cwd,
+    flags: { _: ['remove', 'cleanup-me'] }
+  });
+
+  await assert.rejects(fs.access(skillPath), /ENOENT/);
+  await assert.rejects(
+    skillsCommand({
+      cwd,
+      flags: { _: ['remove', 'cleanup-me'] }
+    }),
+    /Skill file does not exist:/
   );
 });

--- a/src/cli/skills.ts
+++ b/src/cli/skills.ts
@@ -25,8 +25,12 @@ export async function skillsCommand({
     await skillsCatalogCommand({ packageRoot, flags });
     return;
   }
-  if (sub === 'init') {
-    await skillsInitCommand({ cwd, flags });
+  if (sub === 'add' || sub === 'init') {
+    await skillsAddCommand({ cwd, packageRoot, flags });
+    return;
+  }
+  if (sub === 'remove') {
+    await skillsRemoveCommand({ cwd, flags });
     return;
   }
   if (sub === 'validate') {
@@ -34,15 +38,23 @@ export async function skillsCommand({
     return;
   }
   throw new Error(
-    'Usage: ailib skills list | ailib skills explain <skill-id> | ailib skills init <skill-id> [--workspace=<path>] [--path=<path>] [--description=<text>] [--force] | ailib skills validate [--workspace=<path>] [--path=<path>]'
+    'Usage: ailib skills list | ailib skills explain <skill-id> | ailib skills add <skill-id> [--workspace=<path>] [--path=<path>] [--description=<text>] [--force] | ailib skills remove <skill-id> [--workspace=<path>] [--path=<path>] | ailib skills validate [--workspace=<path>] [--path=<path>]'
   );
 }
 
-export async function skillsInitCommand({ cwd, flags }: { cwd: string; flags: CliFlags }) {
+export async function skillsAddCommand({
+  cwd,
+  packageRoot,
+  flags
+}: {
+  cwd: string;
+  packageRoot?: string;
+  flags: CliFlags;
+}) {
   const skillId = flags._[1];
   ensure(
     skillId,
-    'Usage: ailib skills init <skill-id> [--workspace=<path>] [--path=<path>] [--description=<text>] [--force]'
+    'Usage: ailib skills add <skill-id> [--workspace=<path>] [--path=<path>] [--description=<text>] [--force]'
   );
   ensure(SKILL_ID_RE.test(skillId), `Invalid skill id: ${skillId}`);
 
@@ -56,19 +68,70 @@ export async function skillsInitCommand({ cwd, flags }: { cwd: string; flags: Cl
   const target = resolveSkillFilePath({ targetWorkspace, skillId, pathFlag });
   assertPathUnderWorkspace({ targetWorkspace, target });
 
+  const builtInSkillContent = await resolveBuiltInSkillContent({ packageRoot, skillId, description });
+
   await fs.mkdir(path.dirname(target), { recursive: true });
 
-  if (!force) {
-    try {
-      await fs.access(target);
+  let targetExists = false;
+  try {
+    await fs.access(target);
+    targetExists = true;
+  } catch (error) {
+    if (!(error instanceof Error) || !('code' in error) || error.code !== 'ENOENT') throw error;
+  }
+
+  if (targetExists) {
+    if (builtInSkillContent !== null) {
+      throw new Error(
+        `Skill file already exists: ${target}. Built-in seeding will not overwrite existing local skill files. Remove the file first or use a different --path.`
+      );
+    }
+
+    if (!force) {
       throw new Error(`Skill file already exists: ${target}. Re-run with --force to overwrite.`);
-    } catch (error) {
-      if (!(error instanceof Error) || !('code' in error) || error.code !== 'ENOENT') throw error;
     }
   }
 
-  await fs.writeFile(target, renderSkillTemplate({ skillId, description }), 'utf8');
+  const scaffoldContent = builtInSkillContent ?? renderSkillTemplate({ skillId, description });
+  await fs.writeFile(target, scaffoldContent, 'utf8');
   process.stdout.write(`skill scaffolded: ${skillId} -> ${target}\n`);
+}
+
+export async function skillsInitCommand({
+  cwd,
+  packageRoot,
+  flags
+}: {
+  cwd: string;
+  packageRoot?: string;
+  flags: CliFlags;
+}) {
+  await skillsAddCommand({ cwd, packageRoot, flags });
+}
+
+export async function skillsRemoveCommand({ cwd, flags }: { cwd: string; flags: CliFlags }) {
+  const skillId = flags._[1];
+  ensure(skillId, 'Usage: ailib skills remove <skill-id> [--workspace=<path>] [--path=<path>]');
+  ensure(SKILL_ID_RE.test(skillId), `Invalid skill id: ${skillId}`);
+
+  const context = await resolveContext(cwd);
+  const workspaceFlag = getStringFlag(flags, 'workspace');
+  const targetWorkspace = resolveDefaultWorkspaceForMutation(context, workspaceFlag);
+  const pathFlag = getStringFlag(flags, 'path');
+
+  const target = resolveSkillFilePath({ targetWorkspace, skillId, pathFlag });
+  assertPathUnderWorkspace({ targetWorkspace, target });
+
+  try {
+    await fs.rm(target);
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      throw new Error(`Skill file does not exist: ${target}`);
+    }
+    throw error;
+  }
+
+  process.stdout.write(`skill removed: ${skillId} -> ${target}\n`);
 }
 
 export function resolveSkillFilePath({
@@ -90,4 +153,46 @@ export function resolveSkillFilePath({
 function assertPathUnderWorkspace({ targetWorkspace, target }: { targetWorkspace: string; target: string }) {
   const rel = path.relative(path.resolve(targetWorkspace), path.resolve(target));
   ensure(!rel.startsWith('..') && !path.isAbsolute(rel), `Skill path must be within workspace: ${targetWorkspace}`);
+}
+
+async function resolveBuiltInSkillContent({
+  packageRoot,
+  skillId,
+  description
+}: {
+  packageRoot?: string;
+  skillId: string;
+  description: string | undefined;
+}): Promise<string | null> {
+  if (!packageRoot) return null;
+
+  const builtInPath = path.join(packageRoot, 'skills', `${skillId}.md`);
+  try {
+    const source = await fs.readFile(builtInPath, 'utf8');
+    if (!description) return source;
+    return applyDescriptionOverride(source, description);
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
+function applyDescriptionOverride(markdown: string, description: string): string {
+  const lines = markdown.split('\n');
+  if (lines[0] !== '---') return markdown;
+
+  let frontmatterEnd = -1;
+  let descriptionLine = -1;
+  for (let i = 1; i < lines.length; i += 1) {
+    if (lines[i] === '---') {
+      frontmatterEnd = i;
+      break;
+    }
+    if (lines[i].startsWith('description:')) descriptionLine = i;
+  }
+  if (frontmatterEnd < 0) return markdown;
+
+  if (descriptionLine >= 0) lines[descriptionLine] = `description: ${description}`;
+  else lines.splice(frontmatterEnd, 0, `description: ${description}`);
+  return lines.join('\n');
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -444,7 +444,7 @@ test('add and remove enforce module argument', async () => {
   await assert.rejects(run(['remove'], { cwd: root, packageRoot }), /Usage: ailib remove <module>/);
 });
 
-test('skills init scaffolds skill file in target workspace', async () => {
+test('skills add scaffolds skill file in target workspace', async () => {
   const root = await makeMonorepo();
   await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code', '--on-conflict=overwrite'], {
     cwd: root,
@@ -456,7 +456,7 @@ test('skills init scaffolds skill file in target workspace', async () => {
   });
 
   await run(
-    ['skills', 'init', 'release-manager', '--workspace=apps/web', '--description=Release orchestration workflow'],
+    ['skills', 'add', 'release-manager', '--workspace=apps/web', '--description=Release orchestration workflow'],
     {
       cwd: root,
       packageRoot
@@ -470,6 +470,65 @@ test('skills init scaffolds skill file in target workspace', async () => {
   assert.match(content, /description: Release orchestration workflow/);
 });
 
+test('skills add seeds built-in skill details when id matches catalog', async () => {
+  const root = await makeMonorepo();
+  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code', '--on-conflict=overwrite'], {
+    cwd: root,
+    packageRoot
+  });
+  await run(['init', '--language=typescript', '--modules=biome', '--targets=claude-code'], {
+    cwd: path.join(root, 'apps', 'web'),
+    packageRoot
+  });
+
+  await run(['skills', 'add', 'solid-principles-application', '--workspace=apps/web'], {
+    cwd: root,
+    packageRoot
+  });
+
+  const skillPath = path.join(root, 'apps', 'web', '.cursor', 'skills', 'solid-principles-application', 'SKILL.md');
+  assert.equal(await exists(skillPath), true);
+  const content = await fs.readFile(skillPath, 'utf8');
+  assert.match(content, /name: solid-principles-application/);
+  assert.match(content, /description: Apply SRP, OCP, LSP, ISP, and DIP/);
+  assert.match(content, /Apply SRP by splitting modules/);
+  assert.doesNotMatch(content, /TODO: add concrete implementation steps/);
+});
+
+test('skills init remains an alias of skills add', async () => {
+  const root = await makeMonorepo();
+  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code', '--on-conflict=overwrite'], {
+    cwd: root,
+    packageRoot
+  });
+
+  await run(['skills', 'init', 'release-manager', '--description=Alias path'], { cwd: root, packageRoot });
+
+  const skillPath = path.join(root, '.cursor', 'skills', 'release-manager', 'SKILL.md');
+  assert.equal(await exists(skillPath), true);
+  assert.match(await fs.readFile(skillPath, 'utf8'), /description: Alias path/);
+});
+
+test('skills remove deletes local skill files', async () => {
+  const root = await makeMonorepo();
+  await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code', '--on-conflict=overwrite'], {
+    cwd: root,
+    packageRoot
+  });
+
+  await run(['skills', 'add', 'release-manager', '--description=To remove'], { cwd: root, packageRoot });
+  const skillPath = path.join(root, '.cursor', 'skills', 'release-manager', 'SKILL.md');
+  assert.equal(await exists(skillPath), true);
+
+  await run(['skills', 'remove', 'release-manager'], { cwd: root, packageRoot });
+  assert.equal(await exists(skillPath), false);
+
+  await assert.rejects(
+    run(['skills', 'remove', 'release-manager'], { cwd: root, packageRoot }),
+    /Skill file does not exist:/
+  );
+});
+
 test('skills validate reports workspace skill quality issues', async () => {
   const root = await makeMonorepo();
   await run(['init', '--language=typescript', '--modules=eslint', '--targets=claude-code', '--on-conflict=overwrite'], {
@@ -480,7 +539,7 @@ test('skills validate reports workspace skill quality issues', async () => {
     cwd: path.join(root, 'apps', 'web'),
     packageRoot
   });
-  await run(['skills', 'init', 'release-manager', '--workspace=apps/web'], { cwd: root, packageRoot });
+  await run(['skills', 'add', 'release-manager', '--workspace=apps/web'], { cwd: root, packageRoot });
 
   await run(['skills', 'validate', '--workspace=apps/web'], { cwd: root, packageRoot });
 


### PR DESCRIPTION
## Summary
- add `ailib skills add` and `ailib skills remove` so skills follow module-style mutation commands
- keep `ailib skills init` as a compatibility alias of `skills add`
- seed built-in skill content on add, and block overwriting existing local skill files
- update help/docs plus unit/integration coverage for add/remove/alias behavior

## Test plan
- [x] bun test src/cli/skills.test.ts src/cli/help.test.ts test/cli.test.ts
- [x] bun run check

Closes #331
Closes #330

Made with [Cursor](https://cursor.com)