### PR TITLE
fix: include built-in skills in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "schema",
     "core",
     "languages",
+    "skills",
     "registry",
     "targets",
     "registry.json"

--- a/tools/npm-release-preflight.test.ts
+++ b/tools/npm-release-preflight.test.ts
@@ -29,6 +29,7 @@ test('npm-release-preflight succeeds for first-time publish fixture payloads', a
           { path: 'bin/ailib.js' },
           { path: 'dist/runtime/cli.js' },
           { path: 'docs/homebrew-publishing.md' },
+          { path: 'skills/task-driven-gh-flow.md' },
           { path: 'registry.json' }
         ]
       }
@@ -74,6 +75,7 @@ test('npm-release-preflight fails when target version is already published', asy
           { path: 'bin/ailib.js' },
           { path: 'dist/runtime/cli.js' },
           { path: 'docs/homebrew-publishing.md' },
+          { path: 'skills/task-driven-gh-flow.md' },
           { path: 'registry.json' }
         ]
       }
@@ -114,6 +116,7 @@ test('npm-release-preflight fails when npm pack payload includes TypeScript file
           { path: 'bin/ailib.js' },
           { path: 'dist/runtime/cli.js' },
           { path: 'docs/homebrew-publishing.md' },
+          { path: 'skills/task-driven-gh-flow.md' },
           { path: 'registry.json' },
           { path: 'tools/npm-release-publish.ts' }
         ]

--- a/tools/npm-release-preflight.ts
+++ b/tools/npm-release-preflight.ts
@@ -3,7 +3,13 @@ import path from 'node:path';
 import { spawn } from 'node:child_process';
 
 const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
-const requiredPackEntries = ['bin/ailib.js', 'dist/runtime/cli.js', 'docs/homebrew-publishing.md', 'registry.json'];
+const requiredPackEntries = [
+  'bin/ailib.js',
+  'dist/runtime/cli.js',
+  'docs/homebrew-publishing.md',
+  'skills/task-driven-gh-flow.md',
+  'registry.json'
+];
 
 type CliArgs = {
   packageFile: string;


### PR DESCRIPTION
## Summary
- include the `skills` directory in the npm package files allowlist so installed CLI builds can seed built-in skill content
- add npm preflight required-pack guard for a built-in skill asset to prevent future packaging regressions
- update npm preflight fixtures to assert built-in skill files are part of expected pack payload

## Test plan
- [x] bun test tools/npm-release-preflight.test.ts src/cli/skills.test.ts test/cli.test.ts
- [x] npm pack --dry-run --json
- [x] bun run check

Closes #334
Closes #333

Made with [Cursor](https://cursor.com)