### PR TITLE
feat: add target-aware skill profiles

### DIFF
--- a/docs/cli-usage-guide.md
+++ b/docs/cli-usage-guide.md
@@ -459,9 +459,16 @@ ailib skills add release-manager --workspace=apps/web --description="Release orc
 ```
 
 This writes a scaffold to `.cursor/skills/release-manager/SKILL.md` in the target workspace (or a custom path when `--path` is provided).  
-When the `skill-id` matches a built-in skill (for example `solid-principles-application`), `skills add` seeds the file with the built-in skill content instead of an empty TODO scaffold.
+By default, scaffolds use the Cursor-style skill format (`## When to Use` + `## Instructions`).
+When the `skill-id` matches a built-in skill (for example `solid-principles-application`), `skills add` seeds the file with built-in content and maps it to the selected format.
 If the target file already exists, built-in seeding will not overwrite that local skill file.
 `skills init` remains available as a compatibility alias for `skills add`.
+
+Use Claude-oriented scaffold layout when needed:
+
+```bash
+ailib skills add release-manager --path=.claude/skills/release-manager/SKILL.md --format=claude-code
+```
 
 Remove a local skill scaffold:
 

--- a/src/cli/help.test.ts
+++ b/src/cli/help.test.ts
@@ -33,6 +33,7 @@ test('printHelp renders expected command listing', () => {
   assert.match(output, /ailib skills list/);
   assert.match(output, /ailib skills explain <skill-id>/);
   assert.match(output, /ailib skills add <skill-id>/);
+  assert.match(output, /--format=cursor\|claude-code/);
   assert.match(output, /ailib skills remove <skill-id>/);
   assert.match(output, /ailib skills init <skill-id> \(alias of skills add\)/);
   assert.match(output, /ailib skills validate/);

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -13,7 +13,7 @@ export function printHelp() {
       '  ailib modules explain <module> [--language=<lang>]\n' +
       '  ailib skills list\n' +
       '  ailib skills explain <skill-id>\n' +
-      '  ailib skills add <skill-id> [--workspace=<path>] [--path=<path>] [--description=<text>] [--force]\n' +
+      '  ailib skills add <skill-id> [--workspace=<path>] [--path=<path>] [--description=<text>] [--format=cursor|claude-code] [--force]\n' +
       '  ailib skills remove <skill-id> [--workspace=<path>] [--path=<path>]\n' +
       '  ailib skills init <skill-id> (alias of skills add)\n' +
       '  ailib skills validate [--workspace=<path>] [--path=<path>]\n' +

--- a/src/cli/skill-template.test.ts
+++ b/src/cli/skill-template.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { DEFAULT_SKILL_DESCRIPTION, renderSkillTemplate } from './skill-template.ts';
 
-test('renderSkillTemplate builds expected default scaffold', () => {
+test('renderSkillTemplate builds expected default cursor scaffold', () => {
   const rendered = renderSkillTemplate({ skillId: 'task-driven-gh-flow' });
   assert.equal(
     rendered,
@@ -14,11 +14,17 @@ test('renderSkillTemplate builds expected default scaffold', () => {
       '',
       '# task-driven-gh-flow',
       '',
-      '## Purpose',
-      '- TODO: describe when to use this skill',
+      'Detailed instructions for the agent.',
       '',
-      '## Workflow',
-      '- TODO: add concrete implementation steps',
+      '## When to Use',
+      '- Use this skill when...',
+      '- This skill is helpful for...',
+      '',
+      '## Instructions',
+      '- Step-by-step guidance for the agent',
+      '- Domain-specific conventions',
+      '- Best practices and patterns',
+      '- Use the ask questions tool if you need to clarify requirements with the user',
       ''
     ].join('\n')
   );
@@ -31,4 +37,15 @@ test('renderSkillTemplate uses explicit description when provided', () => {
   });
   assert.match(rendered, /name: release-manager/);
   assert.match(rendered, /description: Automate release checklists/);
+});
+
+test('renderSkillTemplate supports claude-code profile', () => {
+  const rendered = renderSkillTemplate({
+    skillId: 'release-manager',
+    description: 'Automate release checklists',
+    format: 'claude-code'
+  });
+  assert.match(rendered, /## Purpose/);
+  assert.match(rendered, /## Workflow/);
+  assert.doesNotMatch(rendered, /## When to Use/);
 });

--- a/src/cli/skill-template.ts
+++ b/src/cli/skill-template.ts
@@ -1,7 +1,34 @@
 export const DEFAULT_SKILL_DESCRIPTION = 'TODO: describe this skill';
+export type SkillTemplateFormat = 'cursor' | 'claude-code';
 
-export function renderSkillTemplate({ skillId, description }: { skillId: string; description?: string }) {
+export function renderSkillTemplate({
+  skillId,
+  description,
+  format = 'cursor'
+}: {
+  skillId: string;
+  description?: string;
+  format?: SkillTemplateFormat;
+}) {
   const resolvedDescription = description || DEFAULT_SKILL_DESCRIPTION;
+  if (format === 'claude-code') {
+    return [
+      '---',
+      `name: ${skillId}`,
+      `description: ${resolvedDescription}`,
+      '---',
+      '',
+      `# ${skillId}`,
+      '',
+      '## Purpose',
+      '- TODO: describe when to use this skill',
+      '',
+      '## Workflow',
+      '- TODO: add concrete implementation steps',
+      ''
+    ].join('\n');
+  }
+
   return [
     '---',
     `name: ${skillId}`,
@@ -10,11 +37,17 @@ export function renderSkillTemplate({ skillId, description }: { skillId: string;
     '',
     `# ${skillId}`,
     '',
-    '## Purpose',
-    '- TODO: describe when to use this skill',
+    'Detailed instructions for the agent.',
     '',
-    '## Workflow',
-    '- TODO: add concrete implementation steps',
+    '## When to Use',
+    '- Use this skill when...',
+    '- This skill is helpful for...',
+    '',
+    '## Instructions',
+    '- Step-by-step guidance for the agent',
+    '- Domain-specific conventions',
+    '- Best practices and patterns',
+    '- Use the ask questions tool if you need to clarify requirements with the user',
     ''
   ].join('\n');
 }

--- a/src/cli/skills-validate.test.ts
+++ b/src/cli/skills-validate.test.ts
@@ -32,6 +32,28 @@ test('validateSkillFile accepts valid skill markdown', () => {
   assert.deepEqual(issues, []);
 });
 
+test('validateSkillFile accepts cursor-style section layout', () => {
+  const issues = validateSkillFile({
+    file: '/tmp/SKILL.md',
+    content: [
+      '---',
+      'name: delivery-flow-refinement',
+      'description: Improve delivery flow quality',
+      '---',
+      '',
+      '# delivery-flow-refinement',
+      '',
+      '## When to Use',
+      '- Use this skill when a workflow stalls.',
+      '',
+      '## Instructions',
+      '- Identify bottlenecks and prioritize constraints.',
+      ''
+    ].join('\n')
+  });
+  assert.deepEqual(issues, []);
+});
+
 test('validateSkillFile returns actionable errors for malformed content', () => {
   const issues = validateSkillFile({
     file: '/tmp/SKILL.md',
@@ -39,8 +61,7 @@ test('validateSkillFile returns actionable errors for malformed content', () => 
   });
   assert.match(issues.join('\n'), /frontmatter 'name' must be a non-empty string/);
   assert.match(issues.join('\n'), /frontmatter 'description' must be a non-empty string/);
-  assert.match(issues.join('\n'), /missing required section '## Purpose'/);
-  assert.match(issues.join('\n'), /missing required section '## Workflow'/);
+  assert.match(issues.join('\n'), /missing required sections/);
   assert.match(issues.join('\n'), /frontmatter 'compatible_targets' must be a list like \[a,b\]/);
 });
 

--- a/src/cli/skills-validate.ts
+++ b/src/cli/skills-validate.ts
@@ -6,7 +6,10 @@ import { getStringFlag } from './flags.ts';
 import { parseFrontmatter } from './file-helpers.ts';
 import type { CliFlags } from './types.ts';
 
-const REQUIRED_SECTIONS = ['Purpose', 'Workflow'] as const;
+const REQUIRED_SECTION_GROUPS = [
+  ['Purpose', 'Workflow'],
+  ['When to Use', 'Instructions']
+] as const;
 const COMPATIBILITY_KEYS = [
   'compatible_languages',
   'compatible_modules',
@@ -59,10 +62,16 @@ export function validateSkillFile({ file, content }: { file: string; content: st
     issues.push(`${file}: frontmatter 'description' must be a non-empty string`);
   }
 
-  for (const heading of REQUIRED_SECTIONS) {
-    if (!new RegExp(`^## ${heading}\\s*$`, 'm').test(content)) {
-      issues.push(`${file}: missing required section '## ${heading}'`);
-    }
+  const hasRequiredSectionGroup = REQUIRED_SECTION_GROUPS.some(([first, second]) => {
+    return (
+      new RegExp(`^## ${escapeHeading(first)}\\s*$`, 'm').test(content) &&
+      new RegExp(`^## ${escapeHeading(second)}\\s*$`, 'm').test(content)
+    );
+  });
+  if (!hasRequiredSectionGroup) {
+    issues.push(
+      `${file}: missing required sections ('## Purpose' + '## Workflow') or ('## When to Use' + '## Instructions')`
+    );
   }
 
   for (const key of COMPATIBILITY_KEYS) {
@@ -78,6 +87,10 @@ export function validateSkillFile({ file, content }: { file: string; content: st
   }
 
   return issues;
+}
+
+function escapeHeading(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 async function collectSkillFiles(targetPath: string): Promise<string[]> {

--- a/src/cli/skills.test.ts
+++ b/src/cli/skills.test.ts
@@ -30,7 +30,11 @@ test('skillsCommand copies built-in skill content when id matches', async () => 
   const content = await fs.readFile(path.join(cwd, '.cursor/skills/task-driven-gh-flow/SKILL.md'), 'utf8');
   assert.match(content, /name: task-driven-gh-flow/);
   assert.match(content, /description: Execute roadmap work through GitHub tasks with strict traceability/);
+  assert.match(content, /## When to Use/);
+  assert.match(content, /## Instructions/);
   assert.match(content, /## Non-Negotiable Rules/);
+  assert.doesNotMatch(content, /## Purpose/);
+  assert.doesNotMatch(content, /## Workflow/);
   assert.doesNotMatch(content, /TODO: describe this skill/);
 });
 
@@ -50,6 +54,8 @@ test('skillsCommand supports description override for built-in skill content', a
 
   const content = await fs.readFile(path.join(cwd, '.cursor/skills/task-driven-gh-flow/SKILL.md'), 'utf8');
   assert.match(content, /description: My localized task-driven guidance/);
+  assert.match(content, /## When to Use/);
+  assert.match(content, /## Instructions/);
   assert.match(content, /## Non-Negotiable Rules/);
 });
 
@@ -91,6 +97,8 @@ test('skillsCommand scaffolds using custom path and description', async () => {
   const content = await fs.readFile(path.join(cwd, '.cursor/skills/custom-release/SKILL.md'), 'utf8');
   assert.match(content, /name: release-manager/);
   assert.match(content, /description: Release workflow automation/);
+  assert.match(content, /## When to Use/);
+  assert.match(content, /## Instructions/);
 });
 
 test('skillsCommand rejects invalid skill id and existing files without force', async () => {
@@ -111,6 +119,38 @@ test('skillsCommand rejects invalid skill id and existing files without force', 
   });
   const content = await fs.readFile(path.join(cwd, '.cursor/skills/code-review/SKILL.md'), 'utf8');
   assert.match(content, /description: Overwritten content/);
+});
+
+test('skillsCommand supports claude-code format profile', async () => {
+  const cwd = await tempDir();
+  await fs.writeFile(path.join(cwd, 'package.json'), '{"name":"tmp"}\n', 'utf8');
+
+  await skillsCommand({
+    cwd,
+    flags: {
+      _: ['add', 'claude-planner'],
+      path: '.claude/skills/claude-planner',
+      format: 'claude-code'
+    }
+  });
+
+  const content = await fs.readFile(path.join(cwd, '.claude/skills/claude-planner/SKILL.md'), 'utf8');
+  assert.match(content, /## Purpose/);
+  assert.match(content, /## Workflow/);
+  assert.doesNotMatch(content, /## When to Use/);
+});
+
+test('skillsCommand rejects unsupported format profile', async () => {
+  const cwd = await tempDir();
+  await fs.writeFile(path.join(cwd, 'package.json'), '{"name":"tmp"}\n', 'utf8');
+
+  await assert.rejects(
+    skillsCommand({
+      cwd,
+      flags: { _: ['add', 'invalid-format'], format: 'copilot' }
+    }),
+    /Invalid skills format: copilot/
+  );
 });
 
 test('skillsCommand supports --workspace targeting and blocks path escapes', async () => {

--- a/src/cli/skills.ts
+++ b/src/cli/skills.ts
@@ -2,9 +2,10 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { ensure } from './assertions.ts';
 import { resolveContext, resolveDefaultWorkspaceForMutation } from './context-resolution.ts';
+import { parseFrontmatter } from './file-helpers.ts';
 import { getStringFlag } from './flags.ts';
 import { skillsCatalogCommand } from './introspection.ts';
-import { renderSkillTemplate } from './skill-template.ts';
+import { renderSkillTemplate, type SkillTemplateFormat } from './skill-template.ts';
 import { skillsValidateCommand } from './skills-validate.ts';
 import type { CliFlags } from './types.ts';
 
@@ -38,7 +39,7 @@ export async function skillsCommand({
     return;
   }
   throw new Error(
-    'Usage: ailib skills list | ailib skills explain <skill-id> | ailib skills add <skill-id> [--workspace=<path>] [--path=<path>] [--description=<text>] [--force] | ailib skills remove <skill-id> [--workspace=<path>] [--path=<path>] | ailib skills validate [--workspace=<path>] [--path=<path>]'
+    'Usage: ailib skills list | ailib skills explain <skill-id> | ailib skills add <skill-id> [--workspace=<path>] [--path=<path>] [--description=<text>] [--format=cursor|claude-code] [--force] | ailib skills remove <skill-id> [--workspace=<path>] [--path=<path>] | ailib skills validate [--workspace=<path>] [--path=<path>]'
   );
 }
 
@@ -54,7 +55,7 @@ export async function skillsAddCommand({
   const skillId = flags._[1];
   ensure(
     skillId,
-    'Usage: ailib skills add <skill-id> [--workspace=<path>] [--path=<path>] [--description=<text>] [--force]'
+    'Usage: ailib skills add <skill-id> [--workspace=<path>] [--path=<path>] [--description=<text>] [--format=cursor|claude-code] [--force]'
   );
   ensure(SKILL_ID_RE.test(skillId), `Invalid skill id: ${skillId}`);
 
@@ -63,12 +64,16 @@ export async function skillsAddCommand({
   const targetWorkspace = resolveDefaultWorkspaceForMutation(context, workspaceFlag);
   const pathFlag = getStringFlag(flags, 'path');
   const description = getStringFlag(flags, 'description');
+  const format = resolveSkillTemplateFormat({
+    formatFlag: getStringFlag(flags, 'format'),
+    pathFlag
+  });
   const force = flags.force === true;
 
   const target = resolveSkillFilePath({ targetWorkspace, skillId, pathFlag });
   assertPathUnderWorkspace({ targetWorkspace, target });
 
-  const builtInSkillContent = await resolveBuiltInSkillContent({ packageRoot, skillId, description });
+  const builtInSkillContent = await resolveBuiltInSkillContent({ packageRoot, skillId, description, format });
 
   await fs.mkdir(path.dirname(target), { recursive: true });
 
@@ -92,7 +97,7 @@ export async function skillsAddCommand({
     }
   }
 
-  const scaffoldContent = builtInSkillContent ?? renderSkillTemplate({ skillId, description });
+  const scaffoldContent = builtInSkillContent ?? renderSkillTemplate({ skillId, description, format });
   await fs.writeFile(target, scaffoldContent, 'utf8');
   process.stdout.write(`skill scaffolded: ${skillId} -> ${target}\n`);
 }
@@ -158,19 +163,21 @@ function assertPathUnderWorkspace({ targetWorkspace, target }: { targetWorkspace
 async function resolveBuiltInSkillContent({
   packageRoot,
   skillId,
-  description
+  description,
+  format
 }: {
   packageRoot?: string;
   skillId: string;
   description: string | undefined;
+  format: SkillTemplateFormat;
 }): Promise<string | null> {
   if (!packageRoot) return null;
 
   const builtInPath = path.join(packageRoot, 'skills', `${skillId}.md`);
   try {
     const source = await fs.readFile(builtInPath, 'utf8');
-    if (!description) return source;
-    return applyDescriptionOverride(source, description);
+    const maybeDescribed = description ? applyDescriptionOverride(source, description) : source;
+    return formatBuiltInSkillForTarget({ source: maybeDescribed, skillId, format });
   } catch (error) {
     if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return null;
     throw error;
@@ -195,4 +202,78 @@ function applyDescriptionOverride(markdown: string, description: string): string
   if (descriptionLine >= 0) lines[descriptionLine] = `description: ${description}`;
   else lines.splice(frontmatterEnd, 0, `description: ${description}`);
   return lines.join('\n');
+}
+
+function resolveSkillTemplateFormat({
+  formatFlag,
+  pathFlag
+}: {
+  formatFlag: string | undefined;
+  pathFlag: string | undefined;
+}): SkillTemplateFormat {
+  if (formatFlag) {
+    if (formatFlag === 'cursor' || formatFlag === 'claude-code') return formatFlag;
+    throw new Error(`Invalid skills format: ${formatFlag}. Expected cursor or claude-code.`);
+  }
+  if (!pathFlag) return 'cursor';
+
+  const normalized = pathFlag.replaceAll('\\', '/').toLowerCase();
+  if (normalized.includes('/.claude/') || normalized.startsWith('.claude/')) return 'claude-code';
+  return 'cursor';
+}
+
+function formatBuiltInSkillForTarget({
+  source,
+  skillId,
+  format
+}: {
+  source: string;
+  skillId: string;
+  format: SkillTemplateFormat;
+}): string {
+  if (format === 'claude-code') return source;
+
+  const frontmatter = parseFrontmatter(source) || {};
+  const name = typeof frontmatter.name === 'string' && frontmatter.name.trim() ? frontmatter.name : skillId;
+  const description =
+    typeof frontmatter.description === 'string' && frontmatter.description.trim()
+      ? frontmatter.description
+      : DEFAULT_BUILTIN_DESCRIPTION;
+  const body = extractBodyWithoutFrontmatter(source);
+  const withCursorSections = body
+    .replace(/^##\s+Purpose\s*$/m, '## When to Use')
+    .replace(/^##\s+Workflow\s*$/m, '## Instructions');
+  const withInstructionLead = ensureInstructionLeadParagraph(withCursorSections);
+
+  return ['---', `name: ${name}`, `description: ${description}`, '---', '', withInstructionLead].join('\n');
+}
+
+const DEFAULT_BUILTIN_DESCRIPTION = 'Skill guidance for AI agent execution.';
+
+function extractBodyWithoutFrontmatter(source: string): string {
+  const lines = source.split('\n');
+  if (lines[0] !== '---') return source;
+  for (let i = 1; i < lines.length; i += 1) {
+    if (lines[i] === '---') {
+      return lines
+        .slice(i + 1)
+        .join('\n')
+        .trimStart();
+    }
+  }
+  return source;
+}
+
+function ensureInstructionLeadParagraph(content: string): string {
+  const trimmed = content.trimStart();
+  const headingMatch = trimmed.match(/^(#\s+.+)$/m);
+  if (!headingMatch) return content;
+  if (trimmed.includes('Detailed instructions for the agent.')) return content;
+
+  const heading = headingMatch[1];
+  const index = content.indexOf(heading);
+  if (index < 0) return content;
+  const before = content.slice(0, index + heading.length);
+  const after = content.slice(index + heading.length).trimStart();
+  return `${before}\n\nDetailed instructions for the agent.\n\n${after}`;
 }


### PR DESCRIPTION
## Summary
- add target-aware skill scaffold profiles so Cursor and Claude-style formats can coexist
- default `skills add` to Cursor profile and support `--format=cursor|claude-code`
- map built-in skill sections to target profile conventions while preserving local overwrite safety
- extend `skills validate` to accept both section pairs (`Purpose/Workflow` and `When to Use/Instructions`)
- update help/docs and regression tests for multi-target skill authoring flow

## Test plan
- [x] bun test src/cli/skill-template.test.ts src/cli/skills.test.ts src/cli/skills-validate.test.ts src/cli/help.test.ts test/cli.test.ts
- [x] bun run check

Closes #338
Refs #337
Refs #336

Made with [Cursor](https://cursor.com)