### PR TITLE
feat: define target skill profile contract

### DIFF
--- a/docs/targets-guide.md
+++ b/docs/targets-guide.md
@@ -30,6 +30,26 @@ Optional fields:
 - `root_output`: additional output written at root workspace only (used by `windsurf`)
 - `mode`: special renderer mode (`copilot`)
 - `frontmatter`: object with `root`/`workspace` frontmatter variants (used by `cursor`)
+- `skill_profile`: target contract for skill rendering conventions (`format`, `required_sections`, `section_mapping`)
+
+`skill_profile` shape:
+
+```json
+"skill_profile": {
+  "format": "cursor",
+  "required_sections": ["When to Use", "Instructions"],
+  "section_mapping": {
+    "Purpose": "When to Use",
+    "Workflow": "Instructions"
+  }
+}
+```
+
+Profile guidance:
+
+- use `format: "cursor"` when skills should follow `When to Use` + `Instructions` sections.
+- use `format: "claude-code"` when skills should follow `Purpose` + `Workflow` sections.
+- use `section_mapping` to map canonical section names into target-facing section names.
 
 Use existing targets as references:
 

--- a/registry.json
+++ b/registry.json
@@ -219,12 +219,34 @@
     "claude-code": {
       "display": "Claude Code",
       "output": "CLAUDE.md",
-      "template": "targets/claude-code.md.tmpl"
+      "template": "targets/claude-code.md.tmpl",
+      "skill_profile": {
+        "format": "claude-code",
+        "required_sections": [
+          "Purpose",
+          "Workflow"
+        ],
+        "section_mapping": {
+          "Purpose": "Purpose",
+          "Workflow": "Workflow"
+        }
+      }
     },
     "cursor": {
       "display": "Cursor",
       "output": ".cursor/rules/ailib.mdc",
       "template": "targets/cursor.mdc.tmpl",
+      "skill_profile": {
+        "format": "cursor",
+        "required_sections": [
+          "When to Use",
+          "Instructions"
+        ],
+        "section_mapping": {
+          "Purpose": "When to Use",
+          "Workflow": "Instructions"
+        }
+      },
       "frontmatter": {
         "root": "---\ndescription: ailib context router\nalwaysApply: true\n---\n\n",
         "workspace": "---\ndescription: ailib context router\nglobs:\n  - \"./**\"\nalwaysApply: false\n---\n\n"
@@ -234,28 +256,83 @@
       "display": "Windsurf",
       "output": ".windsurf/rules/ailib.md",
       "template": "targets/windsurf.md.tmpl",
-      "root_output": ".windsurfrules"
+      "root_output": ".windsurfrules",
+      "skill_profile": {
+        "format": "claude-code",
+        "required_sections": [
+          "Purpose",
+          "Workflow"
+        ],
+        "section_mapping": {
+          "Purpose": "Purpose",
+          "Workflow": "Workflow"
+        }
+      }
     },
     "copilot": {
       "display": "GitHub Copilot",
       "output": ".github/copilot-instructions.md",
       "template": "targets/copilot.md.tmpl",
-      "mode": "copilot"
+      "mode": "copilot",
+      "skill_profile": {
+        "format": "claude-code",
+        "required_sections": [
+          "Purpose",
+          "Workflow"
+        ],
+        "section_mapping": {
+          "Purpose": "Purpose",
+          "Workflow": "Workflow"
+        }
+      }
     },
     "jetbrains": {
       "display": "JetBrains AI Assistant",
       "output": ".junie/guidelines.md",
-      "template": "targets/jetbrains.md.tmpl"
+      "template": "targets/jetbrains.md.tmpl",
+      "skill_profile": {
+        "format": "claude-code",
+        "required_sections": [
+          "Purpose",
+          "Workflow"
+        ],
+        "section_mapping": {
+          "Purpose": "Purpose",
+          "Workflow": "Workflow"
+        }
+      }
     },
     "openai": {
       "display": "OpenAI Codex",
       "output": "AGENTS.md",
-      "template": "targets/openai.md.tmpl"
+      "template": "targets/openai.md.tmpl",
+      "skill_profile": {
+        "format": "claude-code",
+        "required_sections": [
+          "Purpose",
+          "Workflow"
+        ],
+        "section_mapping": {
+          "Purpose": "Purpose",
+          "Workflow": "Workflow"
+        }
+      }
     },
     "gemini": {
       "display": "Gemini CLI",
       "output": "GEMINI.md",
-      "template": "targets/gemini.md.tmpl"
+      "template": "targets/gemini.md.tmpl",
+      "skill_profile": {
+        "format": "claude-code",
+        "required_sections": [
+          "Purpose",
+          "Workflow"
+        ],
+        "section_mapping": {
+          "Purpose": "Purpose",
+          "Workflow": "Workflow"
+        }
+      }
     }
   },
   "skills": {

--- a/registry/core.json
+++ b/registry/core.json
@@ -91,12 +91,28 @@
     "claude-code": {
       "display": "Claude Code",
       "output": "CLAUDE.md",
-      "template": "targets/claude-code.md.tmpl"
+      "template": "targets/claude-code.md.tmpl",
+      "skill_profile": {
+        "format": "claude-code",
+        "required_sections": ["Purpose", "Workflow"],
+        "section_mapping": {
+          "Purpose": "Purpose",
+          "Workflow": "Workflow"
+        }
+      }
     },
     "cursor": {
       "display": "Cursor",
       "output": ".cursor/rules/ailib.mdc",
       "template": "targets/cursor.mdc.tmpl",
+      "skill_profile": {
+        "format": "cursor",
+        "required_sections": ["When to Use", "Instructions"],
+        "section_mapping": {
+          "Purpose": "When to Use",
+          "Workflow": "Instructions"
+        }
+      },
       "frontmatter": {
         "root": "---\ndescription: ailib context router\nalwaysApply: true\n---\n\n",
         "workspace": "---\ndescription: ailib context router\nglobs:\n  - \"./**\"\nalwaysApply: false\n---\n\n"
@@ -106,28 +122,68 @@
       "display": "Windsurf",
       "output": ".windsurf/rules/ailib.md",
       "template": "targets/windsurf.md.tmpl",
-      "root_output": ".windsurfrules"
+      "root_output": ".windsurfrules",
+      "skill_profile": {
+        "format": "claude-code",
+        "required_sections": ["Purpose", "Workflow"],
+        "section_mapping": {
+          "Purpose": "Purpose",
+          "Workflow": "Workflow"
+        }
+      }
     },
     "copilot": {
       "display": "GitHub Copilot",
       "output": ".github/copilot-instructions.md",
       "template": "targets/copilot.md.tmpl",
-      "mode": "copilot"
+      "mode": "copilot",
+      "skill_profile": {
+        "format": "claude-code",
+        "required_sections": ["Purpose", "Workflow"],
+        "section_mapping": {
+          "Purpose": "Purpose",
+          "Workflow": "Workflow"
+        }
+      }
     },
     "jetbrains": {
       "display": "JetBrains AI Assistant",
       "output": ".junie/guidelines.md",
-      "template": "targets/jetbrains.md.tmpl"
+      "template": "targets/jetbrains.md.tmpl",
+      "skill_profile": {
+        "format": "claude-code",
+        "required_sections": ["Purpose", "Workflow"],
+        "section_mapping": {
+          "Purpose": "Purpose",
+          "Workflow": "Workflow"
+        }
+      }
     },
     "openai": {
       "display": "OpenAI Codex",
       "output": "AGENTS.md",
-      "template": "targets/openai.md.tmpl"
+      "template": "targets/openai.md.tmpl",
+      "skill_profile": {
+        "format": "claude-code",
+        "required_sections": ["Purpose", "Workflow"],
+        "section_mapping": {
+          "Purpose": "Purpose",
+          "Workflow": "Workflow"
+        }
+      }
     },
     "gemini": {
       "display": "Gemini CLI",
       "output": "GEMINI.md",
-      "template": "targets/gemini.md.tmpl"
+      "template": "targets/gemini.md.tmpl",
+      "skill_profile": {
+        "format": "claude-code",
+        "required_sections": ["Purpose", "Workflow"],
+        "section_mapping": {
+          "Purpose": "Purpose",
+          "Workflow": "Workflow"
+        }
+      }
     }
   },
   "skills": {

--- a/schema/registry.schema.json
+++ b/schema/registry.schema.json
@@ -87,7 +87,32 @@
         "required": ["output", "template"],
         "properties": {
           "output": { "type": "string" },
-          "template": { "type": "string" }
+          "template": { "type": "string" },
+          "display": { "type": "string" },
+          "root_output": { "type": "string" },
+          "mode": { "type": "string" },
+          "frontmatter": {
+            "type": "object",
+            "properties": {
+              "root": { "type": "string" },
+              "workspace": { "type": "string" }
+            }
+          },
+          "skill_profile": {
+            "type": "object",
+            "required": ["format"],
+            "properties": {
+              "format": { "type": "string", "enum": ["cursor", "claude-code"] },
+              "required_sections": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "section_mapping": {
+                "type": "object",
+                "additionalProperties": { "type": "string" }
+              }
+            }
+          }
         }
       }
     }

--- a/src/cli/types.test.ts
+++ b/src/cli/types.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import type { CliFlags, CommandContext, RunOptions, WorkspaceConfig } from './types.ts';
+import type { CliFlags, CommandContext, RunOptions, TargetDefinition, WorkspaceConfig } from './types.ts';
 
 test('types module supports expected shape usage', () => {
   const runOptions: RunOptions = { cwd: '/tmp/project', packageRoot: '/tmp/pkg' };
@@ -12,10 +12,23 @@ test('types module supports expected shape usage', () => {
     targets: ['claude-code'],
     skills: ['task-driven-gh-flow']
   };
+  const target: TargetDefinition = {
+    output: 'CLAUDE.md',
+    template: 'targets/claude-code.md.tmpl',
+    skill_profile: {
+      format: 'claude-code',
+      required_sections: ['Purpose', 'Workflow'],
+      section_mapping: {
+        Purpose: 'Purpose',
+        Workflow: 'Workflow'
+      }
+    }
+  };
   const context: CommandContext = { cwd: '/tmp/project', packageRoot: '/tmp/pkg', flags };
 
   assert.equal(runOptions.cwd, '/tmp/project');
   assert.equal(context.flags._[0], 'init');
   assert.equal(config.modules?.[0], 'eslint');
   assert.equal(config.skills?.[0], 'task-driven-gh-flow');
+  assert.equal(target.skill_profile?.format, 'claude-code');
 });

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -17,13 +17,21 @@ export interface LanguageDefinition {
 
 export interface TargetDefinition {
   output: string;
+  template?: string;
   root_output?: string;
   mode?: string;
   display?: string;
+  skill_profile?: TargetSkillProfile;
   frontmatter?: {
     root?: string;
     workspace?: string;
   };
+}
+
+export interface TargetSkillProfile {
+  format: 'cursor' | 'claude-code';
+  required_sections?: string[];
+  section_mapping?: Record<string, string>;
 }
 
 export interface SkillCompatibility {


### PR DESCRIPTION
## Summary
- add target-level `skill_profile` metadata to the core registry so each target declares its skill format contract
- extend `registry.schema.json` and CLI target types with `format`, `required_sections`, and `section_mapping`
- document the new target profile contract and guidance in the targets guide

## Traceability
- Closes #340
- Refs #339
- Refs #336

## Test plan
- [x] bun run registry:build
- [x] bun run check

Made with [Cursor](https://cursor.com)