### PR TITLE
feat: render target-scoped skill artifacts

### DIFF
--- a/src/cli/router-generation.test.ts
+++ b/src/cli/router-generation.test.ts
@@ -71,7 +71,7 @@ test('renderRouterDoc renders root and service docs with correct references', ()
   assert.match(rootDoc, /Act as the AI Agent defined in @\.ailib\/behavior\.md/);
   assert.match(rootDoc, /- @\.ailib\/modules\/pytest\.md/);
   assert.match(rootDoc, /# SKILLS/);
-  assert.match(rootDoc, /- @\.ailib\/skills\/task-driven-gh-flow\.md/);
+  assert.match(rootDoc, /- @\.ailib\/skills\/cursor\/task-driven-gh-flow\.md/);
 
   const serviceDoc = renderRouterDoc({
     label: 'Cursor',
@@ -81,8 +81,8 @@ test('renderRouterDoc renders root and service docs with correct references', ()
   });
   assert.match(serviceDoc, /@\.\.\/\.\.\/\.ailib\/behavior\.md/);
   assert.match(serviceDoc, /consult @\.\.\/\.\.\/docs\//);
-  assert.match(serviceDoc, /- @\.\.\/\.\.\/\.ailib\/skills\/task-driven-gh-flow\.md/);
-  assert.match(serviceDoc, /- @\.ailib\/skills\/local-skill\.md/);
+  assert.match(serviceDoc, /- @\.\.\/\.\.\/\.ailib\/skills\/cursor\/task-driven-gh-flow\.md/);
+  assert.match(serviceDoc, /- @\.ailib\/skills\/cursor\/local-skill\.md/);
 });
 
 test('renderRouterDoc snapshot includes skill pointer layout', () => {
@@ -107,7 +107,7 @@ test('renderRouterDoc snapshot includes skill pointer layout', () => {
     '- @.ailib/modules/pytest.md',
     '',
     '# SKILLS',
-    '- @.ailib/skills/task-driven-gh-flow.md',
+    '- @.ailib/skills/cursor/task-driven-gh-flow.md',
     '',
     '# PROJECT-SPECIFIC CONTEXT',
     'Prioritize project context in @./docs/.',
@@ -135,8 +135,8 @@ test('renderRouterDoc snapshot includes skill pointer layout', () => {
     '- @.ailib/modules/pytest.md',
     '',
     '# SKILLS',
-    '- @../../.ailib/skills/task-driven-gh-flow.md',
-    '- @.ailib/skills/local-skill.md',
+    '- @../../.ailib/skills/cursor/task-driven-gh-flow.md',
+    '- @.ailib/skills/cursor/local-skill.md',
     '',
     '# PROJECT-SPECIFIC CONTEXT',
     'Prioritize service-local business logic in @./docs/.',

--- a/src/cli/router-generation.ts
+++ b/src/cli/router-generation.ts
@@ -55,7 +55,7 @@ async function writeStandardTargetRouters({
         ? targetDef.frontmatter.root
         : targetDef.frontmatter.workspace
       : '';
-    const rendered = `${frontmatter || ''}${renderRouterDoc({ label, workspaceDir, rootDir, state })}`;
+    const rendered = `${frontmatter || ''}${renderRouterDoc({ label, workspaceDir, rootDir, state, targetId })}`;
     await writeManagedFile({ outPath: path.join(workspaceDir, targetDef.output), rendered, onConflict });
     if (atRoot && targetDef.root_output) {
       await writeManagedFile({ outPath: path.join(workspaceDir, targetDef.root_output), rendered, onConflict });
@@ -79,7 +79,7 @@ async function writeCopilotRouters({
   const sections = scopedStates
     .map(([dir, state]) => {
       const label = workspaceLabelFor(rootDir, dir);
-      return `## Workspace: ${label}\n\n${renderRouterDoc({ label: copilotLabel, workspaceDir: dir, rootDir, state }).trim()}\n`;
+      return `## Workspace: ${label}\n\n${renderRouterDoc({ label: copilotLabel, workspaceDir: dir, rootDir, state, targetId: 'copilot' }).trim()}\n`;
     })
     .join('\n');
 
@@ -116,7 +116,7 @@ async function writeCopilotWorkspaceInstruction({
   const rel = workspaceLabelFor(rootDir, workspaceDir);
   const applyTo = rel === '.' ? '**' : `${toPosix(rel)}/**`;
   const fileName = rel === '.' ? 'root.instructions.md' : `${sanitizeForFilename(rel)}.instructions.md`;
-  const content = `---\napplyTo: "${applyTo}"\n---\n\n${renderRouterDoc({ label: copilotLabel, workspaceDir, rootDir, state })}`;
+  const content = `---\napplyTo: "${applyTo}"\n---\n\n${renderRouterDoc({ label: copilotLabel, workspaceDir, rootDir, state, targetId: 'copilot' })}`;
   await writeManagedFile({
     outPath: path.join(rootDir, '.github/instructions', fileName),
     rendered: content,
@@ -128,12 +128,14 @@ export function renderRouterDoc({
   label,
   workspaceDir,
   rootDir,
-  state
+  state,
+  targetId = 'cursor'
 }: {
   label: string;
   workspaceDir: string;
   rootDir: string;
   state: WorkspaceState;
+  targetId?: string;
 }) {
   const relToRoot = relativePathForPointers(workspaceDir, rootDir);
   const behaviorRef =
@@ -149,10 +151,10 @@ export function renderRouterDoc({
   const localModuleLines = state.localModules.map((mod) => `- @.ailib/modules/${mod}.md`);
   const moduleLines = [...inheritedModuleLines, ...localModuleLines];
   const inheritedSkillLines = state.inheritedSkills.map((skill) => {
-    const skillPath = `@${toPosix(path.join(relToRoot, '.ailib/skills', `${skill}.md`))}`;
+    const skillPath = `@${toPosix(path.join(relToRoot, '.ailib/skills', targetId, `${skill}.md`))}`;
     return `- ${skillPath}`;
   });
-  const localSkillLines = state.localSkills.map((skill) => `- @.ailib/skills/${skill}.md`);
+  const localSkillLines = state.localSkills.map((skill) => `- @.ailib/skills/${targetId}/${skill}.md`);
   const skillLines = [...inheritedSkillLines, ...localSkillLines];
   const docsBlock =
     path.resolve(workspaceDir) === path.resolve(rootDir)

--- a/src/cli/workspace-assets.test.ts
+++ b/src/cli/workspace-assets.test.ts
@@ -18,7 +18,18 @@ const registry: Registry = {
     }
   },
   targets: {
-    cursor: { output: '.cursor/rules/ailib.mdc' }
+    cursor: {
+      output: '.cursor/rules/ailib.mdc',
+      skill_profile: {
+        format: 'cursor'
+      }
+    },
+    'claude-code': {
+      output: 'CLAUDE.md',
+      skill_profile: {
+        format: 'claude-code'
+      }
+    }
   },
   skills: {
     'architecture-decision-flow': {
@@ -40,11 +51,15 @@ const registry: Registry = {
     'missing-packaged-skill': {
       display: 'Missing packaged skill',
       path: 'skills/missing-packaged-skill.md'
+    },
+    'target-format-skill': {
+      display: 'Target format skill',
+      path: 'skills/target-format-skill.md'
     }
   }
 };
 
-function state(localModules: string[], localSkills: string[] = []): WorkspaceState {
+function state(localModules: string[], localSkills: string[] = [], targets: string[] = ['cursor']): WorkspaceState {
   return {
     effective: {
       $schema: 'https://ailib.dev/schema/config.schema.json',
@@ -52,7 +67,7 @@ function state(localModules: string[], localSkills: string[] = []): WorkspaceSta
       on_conflict: 'merge',
       language: 'typescript',
       modules: localModules,
-      targets: ['cursor'],
+      targets,
       skills: localSkills,
       docs_path: 'docs/',
       inheritedModules: [],
@@ -80,6 +95,25 @@ async function seedPackage(packageRoot: string) {
   await fs.writeFile(path.join(packageRoot, 'languages/typescript/core.md'), 'lang-core', 'utf8');
   await fs.writeFile(path.join(packageRoot, 'languages/typescript/modules/eslint.md'), 'eslint', 'utf8');
   await fs.writeFile(path.join(packageRoot, 'skills/architecture-decision-flow.md'), 'architecture-flow', 'utf8');
+  await fs.writeFile(
+    path.join(packageRoot, 'skills/target-format-skill.md'),
+    [
+      '---',
+      'name: target-format-skill',
+      'description: Target format validation skill',
+      '---',
+      '',
+      '# target-format-skill',
+      '',
+      '## Purpose',
+      '- Describe purpose',
+      '',
+      '## Workflow',
+      '- Describe workflow',
+      ''
+    ].join('\n'),
+    'utf8'
+  );
   await fs.mkdir(path.join(packageRoot, '.cursor/skills/task-driven-gh-flow'), { recursive: true });
   await fs.writeFile(path.join(packageRoot, '.cursor/skills/task-driven-gh-flow/SKILL.md'), 'skill-flow', 'utf8');
 }
@@ -144,6 +178,10 @@ test('ensureWorkspaceAssets copies and prunes skill assets', async () => {
     await fs.readFile(path.join(workspaceDir, '.ailib/skills/task-driven-gh-flow.md'), 'utf8'),
     'skill-flow'
   );
+  assert.equal(
+    await fs.readFile(path.join(workspaceDir, '.ailib/skills/cursor/task-driven-gh-flow.md'), 'utf8'),
+    'skill-flow'
+  );
   await assert.rejects(fs.readFile(path.join(workspaceDir, '.ailib/skills/legacy-skill.md'), 'utf8'));
   assert.equal(await fs.readFile(path.join(workspaceDir, '.ailib/skills/custom.md'), 'utf8'), 'custom-skill');
 });
@@ -194,6 +232,38 @@ test('ensureWorkspaceAssets prefers local custom skill over package source', asy
     await fs.readFile(path.join(workspaceDir, '.ailib/skills/task-driven-gh-flow.md'), 'utf8'),
     'workspace-local-skill'
   );
+});
+
+test('ensureWorkspaceAssets renders target-specific skill format variants', async () => {
+  const rootDir = await tempDir();
+  const workspaceDir = path.join(rootDir, 'apps/api');
+  const packageRoot = path.join(rootDir, 'pkg');
+  await seedPackage(packageRoot);
+
+  await ensureWorkspaceAssets({
+    workspaceDir,
+    packageRoot,
+    state: state([], ['target-format-skill'], ['cursor', 'claude-code']),
+    rootDir,
+    registry
+  });
+
+  const legacy = await fs.readFile(path.join(workspaceDir, '.ailib/skills/target-format-skill.md'), 'utf8');
+  const cursorRendered = await fs.readFile(
+    path.join(workspaceDir, '.ailib/skills/cursor/target-format-skill.md'),
+    'utf8'
+  );
+  const claudeRendered = await fs.readFile(
+    path.join(workspaceDir, '.ailib/skills/claude-code/target-format-skill.md'),
+    'utf8'
+  );
+
+  assert.match(legacy, /## Purpose/);
+  assert.match(cursorRendered, /## When to Use/);
+  assert.match(cursorRendered, /## Instructions/);
+  assert.match(cursorRendered, /Detailed instructions for the agent\./);
+  assert.match(claudeRendered, /## Purpose/);
+  assert.doesNotMatch(claudeRendered, /## When to Use/);
 });
 
 test('ensureWorkspaceAssets prefers root local custom skill over package source', async () => {

--- a/src/cli/workspace-assets.ts
+++ b/src/cli/workspace-assets.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { copySourceFile } from './file-helpers.ts';
 import { isUnderLocalCustomSkillsRoot, localCustomSkillPath } from './skill-paths.ts';
 import { exists, rmIfExists } from './utils.ts';
-import type { Registry, WorkspaceState } from './types.ts';
+import type { Registry, TargetDefinition, WorkspaceState } from './types.ts';
 
 export async function ensureWorkspaceAssets({
   workspaceDir,
@@ -70,41 +70,28 @@ export async function ensureWorkspaceAssets({
 
   const localSkills = state.localSkills;
   const localSkillSet = new Set(localSkills);
+  const selectedTargetIds = (state.effective.targets || []).filter((targetId) => Boolean(registry.targets[targetId]));
+  const selectedTargetSet = new Set(selectedTargetIds);
   const registrySkills = registry.skills || {};
   for (const skillId of localSkills) {
     const skillDef = registrySkills[skillId];
     ensure(skillDef, `Missing skill definition: ${skillId}`);
 
-    const target = path.join(outRoot, 'skills', `${skillId}.md`);
-    const workspaceLocalSource = path.join(workspaceDir, localCustomSkillPath(skillId));
-    if (await exists(workspaceLocalSource)) {
-      await copyFileFromSource(workspaceLocalSource, target);
-      continue;
+    const source = await resolveSkillSourceContent({
+      skillId,
+      skillPath: skillDef.path,
+      packageRoot,
+      workspaceDir,
+      rootDir,
+      outRoot
+    });
+    await writeFileFromContent(path.join(outRoot, 'skills', `${skillId}.md`), source);
+    for (const targetId of selectedTargetIds) {
+      const targetDef = registry.targets[targetId];
+      const targetFormat = resolveTargetSkillFormat({ targetId, targetDef });
+      const rendered = renderSkillMarkdownForTarget({ source, targetFormat });
+      await writeFileFromContent(path.join(outRoot, 'skills', targetId, `${skillId}.md`), rendered);
     }
-
-    const rootLocalSource = path.join(rootDir, localCustomSkillPath(skillId));
-    if (await exists(rootLocalSource)) {
-      await copyFileFromSource(rootLocalSource, target);
-      continue;
-    }
-
-    const sourceRel = skillDef.path;
-    const source = path.join(packageRoot, sourceRel);
-    if (await exists(source)) {
-      await copySourceFile({ packageRoot, sourceRel, target });
-      continue;
-    }
-
-    const existing = path.join(outRoot, 'skills', `${skillId}.md`);
-    if (await exists(existing)) continue;
-
-    if (isUnderLocalCustomSkillsRoot(sourceRel)) {
-      throw new Error(
-        `Missing local custom skill source: ${skillId} (checked ${localCustomSkillPath(skillId)} in workspace and root)`
-      );
-    }
-
-    ensure(false, `Missing skill source: ${sourceRel}`);
   }
 
   const skillDir = path.join(outRoot, 'skills');
@@ -115,13 +102,109 @@ export async function ensureWorkspaceAssets({
       if (!localSkillSet.has(id) && registrySkills[id]) await rmIfExists(path.join(skillDir, entry));
     }
   }
+  for (const targetId of Object.keys(registry.targets || {})) {
+    const targetDir = path.join(skillDir, targetId);
+    if (!(await exists(targetDir))) continue;
+    if (!selectedTargetSet.has(targetId)) {
+      await rmIfExists(targetDir);
+      continue;
+    }
+
+    for (const entry of await fs.readdir(targetDir)) {
+      if (!entry.endsWith('.md')) continue;
+      const id = entry.replace(/\.md$/u, '');
+      if (!localSkillSet.has(id) && registrySkills[id]) await rmIfExists(path.join(targetDir, entry));
+    }
+    const remaining = await fs.readdir(targetDir);
+    if (!remaining.length) await rmIfExists(targetDir);
+  }
 }
 
 function ensure(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(message);
 }
 
-async function copyFileFromSource(source: string, target: string) {
+async function writeFileFromContent(target: string, content: string) {
   await fs.mkdir(path.dirname(target), { recursive: true });
-  await fs.copyFile(source, target);
+  await fs.writeFile(target, content, 'utf8');
+}
+
+async function resolveSkillSourceContent({
+  skillId,
+  skillPath,
+  packageRoot,
+  workspaceDir,
+  rootDir,
+  outRoot
+}: {
+  skillId: string;
+  skillPath: string;
+  packageRoot: string;
+  workspaceDir: string;
+  rootDir: string;
+  outRoot: string;
+}) {
+  const workspaceLocalSource = path.join(workspaceDir, localCustomSkillPath(skillId));
+  if (await exists(workspaceLocalSource)) return fs.readFile(workspaceLocalSource, 'utf8');
+
+  const rootLocalSource = path.join(rootDir, localCustomSkillPath(skillId));
+  if (await exists(rootLocalSource)) return fs.readFile(rootLocalSource, 'utf8');
+
+  const packagedSource = path.join(packageRoot, skillPath);
+  if (await exists(packagedSource)) return fs.readFile(packagedSource, 'utf8');
+
+  const existing = path.join(outRoot, 'skills', `${skillId}.md`);
+  if (await exists(existing)) return fs.readFile(existing, 'utf8');
+
+  if (isUnderLocalCustomSkillsRoot(skillPath)) {
+    throw new Error(
+      `Missing local custom skill source: ${skillId} (checked ${localCustomSkillPath(skillId)} in workspace and root)`
+    );
+  }
+  ensure(false, `Missing skill source: ${skillPath}`);
+}
+
+function resolveTargetSkillFormat({
+  targetId,
+  targetDef
+}: {
+  targetId: string;
+  targetDef: TargetDefinition | undefined;
+}): 'cursor' | 'claude-code' {
+  const declared = targetDef?.skill_profile?.format;
+  if (declared === 'cursor' || declared === 'claude-code') return declared;
+  return targetId === 'cursor' ? 'cursor' : 'claude-code';
+}
+
+function renderSkillMarkdownForTarget({
+  source,
+  targetFormat
+}: {
+  source: string;
+  targetFormat: 'cursor' | 'claude-code';
+}) {
+  if (targetFormat === 'cursor') {
+    const mapped = source
+      .replace(/^##\s+Purpose\s*$/gm, '## When to Use')
+      .replace(/^##\s+Workflow\s*$/gm, '## Instructions');
+    return ensureInstructionLeadParagraph(mapped);
+  }
+  const mapped = source
+    .replace(/^##\s+When to Use\s*$/gm, '## Purpose')
+    .replace(/^##\s+Instructions\s*$/gm, '## Workflow');
+  return mapped.replace(/\nDetailed instructions for the agent\.\n+/m, '\n\n');
+}
+
+function ensureInstructionLeadParagraph(content: string): string {
+  if (!/^\s*##\s+Instructions\s*$/m.test(content)) return content;
+  if (content.includes('Detailed instructions for the agent.')) return content;
+  const headingMatch = content.match(/^(#\s+.+)$/m);
+  if (!headingMatch) return content;
+
+  const heading = headingMatch[1];
+  const index = content.indexOf(heading);
+  if (index < 0) return content;
+  const before = content.slice(0, index + heading.length);
+  const after = content.slice(index + heading.length).trimStart();
+  return `${before}\n\nDetailed instructions for the agent.\n\n${after}`;
 }

--- a/src/cli/workspace-state.test.ts
+++ b/src/cli/workspace-state.test.ts
@@ -113,6 +113,7 @@ test('buildWorkspaceState includes root behavior file for root workspace', async
   assert.ok(state.requiredFiles.includes('.ailib/behavior.md'));
   assert.ok(state.requiredFiles.includes('.ailib/standards.md'));
   assert.ok(state.requiredFiles.includes('.ailib/skills/task-driven-gh-flow.md'));
+  assert.ok(state.requiredFiles.includes('.ailib/skills/cursor/task-driven-gh-flow.md'));
 });
 
 test('getEffectiveWorkspaceConfig propagates module merge warnings', async () => {

--- a/src/cli/workspace-state.ts
+++ b/src/cli/workspace-state.ts
@@ -59,7 +59,8 @@ export async function buildWorkspaceState({
     '.ailib/test-standards.md',
     '.ailib/standards.md',
     ...effective.localModules.map((m) => `.ailib/modules/${m}.md`),
-    ...effective.localSkills.map((s) => `.ailib/skills/${s}.md`)
+    ...effective.localSkills.map((s) => `.ailib/skills/${s}.md`),
+    ...effective.localSkills.flatMap((s) => effective.targets.map((targetId) => `.ailib/skills/${targetId}/${s}.md`))
   ];
   if (path.resolve(workspaceDir) === path.resolve(rootDir)) requiredFiles.unshift('.ailib/behavior.md');
 


### PR DESCRIPTION
## Summary
- render target-specific skill artifacts at .ailib/skills/<target>/<skill>.md for each selected target
- update router generation to reference target-scoped skill pointers for standard and copilot outputs
- keep legacy .ailib/skills/<skill>.md files for migration-safe compatibility while adding new paths

## Test plan
- [x] bun test src/cli/workspace-assets.test.ts src/cli/router-generation.test.ts src/cli/workspace-state.test.ts
- [x] bun run check

Refs #343
Closes #343