### PR TITLE
feat: add guided init onboarding flow

### DIFF
--- a/docs/cli-usage-guide.md
+++ b/docs/cli-usage-guide.md
@@ -30,6 +30,25 @@ Core commands:
 ailib init --language=typescript --modules=eslint,vitest --targets=claude-code,cursor,copilot
 ```
 
+You can also run plain interactive setup:
+
+```bash
+ailib init
+```
+
+The guided flow asks for:
+
+- targets (multi-select)
+- default language
+- modules (multi-select)
+- skills grouped by `skill_type` (multi-select)
+
+To preselect skills directly in non-interactive mode, use `--skills`:
+
+```bash
+ailib init --language=typescript --modules=eslint --targets=claude-code,cursor --skills=task-driven-gh-flow,release-readiness
+```
+
 Expected result:
 
 - `ailib.config.json` created at repo root
@@ -113,6 +132,8 @@ ailib init --language=typescript --modules=eslint,vitest --targets=claude-code,c
 ```
 
 This creates a root config and enables workspace discovery.
+
+With plain `ailib init`, the guided flow can optionally configure per-workspace language overrides for detected workspace directories. It writes workspace `ailib.config.json` files only for workspaces where you choose a language different from the root default.
 
 ### 2) Initialize service workspace with inheritance
 

--- a/registry.json
+++ b/registry.json
@@ -339,6 +339,7 @@
     "architecture-decision-flow": {
       "display": "Architecture decision flow",
       "description": "Drive architecture decisions end-to-end using RFC and DACI, from problem framing to rollout review.",
+      "skill_type": "architecture",
       "path": "skills/architecture-decision-flow.md",
       "compatible": {
         "languages": [
@@ -363,6 +364,7 @@
     "clean-code-refactoring": {
       "display": "Clean code refactoring",
       "description": "Plan and execute safe refactors with clear boundaries, SOLID checks, and behavior-preserving verification.",
+      "skill_type": "code-quality",
       "path": "skills/clean-code-refactoring.md",
       "compatible": {
         "languages": [
@@ -387,6 +389,7 @@
     "code-review-rigor": {
       "display": "Code review rigor",
       "description": "Run bug-risk-first code reviews that prioritize behavioral regressions, test gaps, and unsafe assumptions.",
+      "skill_type": "code-quality",
       "path": "skills/code-review-rigor.md",
       "compatible": {
         "languages": [
@@ -411,6 +414,7 @@
     "rfc-authoring": {
       "display": "RFC authoring",
       "description": "Write concise RFCs with context, options, tradeoffs, recommendation, and rollout planning.",
+      "skill_type": "architecture",
       "path": "skills/rfc-authoring.md",
       "requires": [
         "architecture-decision-flow"
@@ -438,6 +442,7 @@
     "daci-facilitation": {
       "display": "DACI facilitation",
       "description": "Establish DACI ownership and run efficient decision reviews with clear accountability.",
+      "skill_type": "architecture",
       "path": "skills/daci-facilitation.md",
       "requires": [
         "architecture-decision-flow"
@@ -465,6 +470,7 @@
     "design-review-checklist": {
       "display": "Design review checklist",
       "description": "Run consistent technical design reviews for correctness, operability, security, and maintainability.",
+      "skill_type": "architecture",
       "path": "skills/design-review-checklist.md",
       "compatible": {
         "languages": [
@@ -489,6 +495,7 @@
     "delivery-flow-refinement": {
       "display": "Delivery flow refinement",
       "description": "Improve software delivery flow by reducing bottlenecks across planning, implementation, review, and release.",
+      "skill_type": "delivery",
       "path": "skills/delivery-flow-refinement.md",
       "compatible": {
         "languages": [
@@ -513,6 +520,7 @@
     "jira-delivery-practices": {
       "display": "Jira delivery practices",
       "description": "Apply Jira workflow best practices to keep software delivery planning, execution, and release traceability aligned.",
+      "skill_type": "delivery",
       "path": "skills/jira-delivery-practices.md",
       "compatible": {
         "languages": [
@@ -537,6 +545,7 @@
     "notion-delivery-practices": {
       "display": "Notion delivery practices",
       "description": "Apply Notion documentation best practices to keep software development context, decisions, and delivery playbooks current.",
+      "skill_type": "delivery",
       "path": "skills/notion-delivery-practices.md",
       "compatible": {
         "languages": [
@@ -561,6 +570,7 @@
     "task-driven-gh-flow": {
       "display": "Task-driven GH flow",
       "description": "Execute roadmap work through GitHub tasks with strict traceability. Use when implementing planned backlog items, creating small PRs, linking PRs to issues, updating GitHub Projects after merge, and splitting tasks into sub-issues when a single PR is not enough.",
+      "skill_type": "delivery",
       "path": "skills/task-driven-gh-flow.md",
       "compatible": {
         "languages": [
@@ -585,6 +595,7 @@
     "release-readiness": {
       "display": "Release readiness",
       "description": "Validate a change is safe to release with checklist-driven checks, rollback preparation, and post-merge verification.",
+      "skill_type": "reliability",
       "path": "skills/release-readiness.md",
       "compatible": {
         "languages": [
@@ -609,6 +620,7 @@
     "observability-design": {
       "display": "Observability design",
       "description": "Design observability across logs, metrics, traces, alerts, and dashboards to detect and diagnose production issues quickly.",
+      "skill_type": "reliability",
       "path": "skills/observability-design.md",
       "compatible": {
         "languages": [
@@ -633,6 +645,7 @@
     "incident-review": {
       "display": "Incident review",
       "description": "Run a structured incident review with timeline reconstruction, contributing-factor analysis, action planning, and clear ownership.",
+      "skill_type": "reliability",
       "path": "skills/incident-review.md",
       "compatible": {
         "languages": [
@@ -657,6 +670,7 @@
     "migration-planning": {
       "display": "Migration planning",
       "description": "Plan data and API migrations with phased rollouts, compatibility safeguards, and tested fallback paths.",
+      "skill_type": "reliability",
       "path": "skills/migration-planning.md",
       "compatible": {
         "languages": [
@@ -681,6 +695,7 @@
     "solid-principles-application": {
       "display": "SOLID principles application",
       "description": "Apply SRP, OCP, LSP, ISP, and DIP with practical design checks during implementation and refactoring.",
+      "skill_type": "code-quality",
       "path": "skills/solid-principles-application.md",
       "compatible": {
         "languages": [
@@ -705,6 +720,7 @@
     "tdd-cycle-workflow": {
       "display": "TDD cycle workflow",
       "description": "Drive implementation with red-green-refactor loops and seam-first testability for safe, incremental delivery.",
+      "skill_type": "code-quality",
       "path": "skills/tdd-cycle-workflow.md",
       "compatible": {
         "languages": [

--- a/registry/core.json
+++ b/registry/core.json
@@ -190,6 +190,7 @@
     "architecture-decision-flow": {
       "display": "Architecture decision flow",
       "description": "Drive architecture decisions end-to-end using RFC and DACI, from problem framing to rollout review.",
+      "skill_type": "architecture",
       "path": "skills/architecture-decision-flow.md",
       "compatible": {
         "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
@@ -199,6 +200,7 @@
     "clean-code-refactoring": {
       "display": "Clean code refactoring",
       "description": "Plan and execute safe refactors with clear boundaries, SOLID checks, and behavior-preserving verification.",
+      "skill_type": "code-quality",
       "path": "skills/clean-code-refactoring.md",
       "compatible": {
         "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
@@ -208,6 +210,7 @@
     "code-review-rigor": {
       "display": "Code review rigor",
       "description": "Run bug-risk-first code reviews that prioritize behavioral regressions, test gaps, and unsafe assumptions.",
+      "skill_type": "code-quality",
       "path": "skills/code-review-rigor.md",
       "compatible": {
         "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
@@ -217,6 +220,7 @@
     "rfc-authoring": {
       "display": "RFC authoring",
       "description": "Write concise RFCs with context, options, tradeoffs, recommendation, and rollout planning.",
+      "skill_type": "architecture",
       "path": "skills/rfc-authoring.md",
       "requires": ["architecture-decision-flow"],
       "compatible": {
@@ -227,6 +231,7 @@
     "daci-facilitation": {
       "display": "DACI facilitation",
       "description": "Establish DACI ownership and run efficient decision reviews with clear accountability.",
+      "skill_type": "architecture",
       "path": "skills/daci-facilitation.md",
       "requires": ["architecture-decision-flow"],
       "compatible": {
@@ -237,6 +242,7 @@
     "design-review-checklist": {
       "display": "Design review checklist",
       "description": "Run consistent technical design reviews for correctness, operability, security, and maintainability.",
+      "skill_type": "architecture",
       "path": "skills/design-review-checklist.md",
       "compatible": {
         "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
@@ -246,6 +252,7 @@
     "delivery-flow-refinement": {
       "display": "Delivery flow refinement",
       "description": "Improve software delivery flow by reducing bottlenecks across planning, implementation, review, and release.",
+      "skill_type": "delivery",
       "path": "skills/delivery-flow-refinement.md",
       "compatible": {
         "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
@@ -255,6 +262,7 @@
     "jira-delivery-practices": {
       "display": "Jira delivery practices",
       "description": "Apply Jira workflow best practices to keep software delivery planning, execution, and release traceability aligned.",
+      "skill_type": "delivery",
       "path": "skills/jira-delivery-practices.md",
       "compatible": {
         "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
@@ -264,6 +272,7 @@
     "notion-delivery-practices": {
       "display": "Notion delivery practices",
       "description": "Apply Notion documentation best practices to keep software development context, decisions, and delivery playbooks current.",
+      "skill_type": "delivery",
       "path": "skills/notion-delivery-practices.md",
       "compatible": {
         "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
@@ -273,6 +282,7 @@
     "task-driven-gh-flow": {
       "display": "Task-driven GH flow",
       "description": "Execute roadmap work through GitHub tasks with strict traceability. Use when implementing planned backlog items, creating small PRs, linking PRs to issues, updating GitHub Projects after merge, and splitting tasks into sub-issues when a single PR is not enough.",
+      "skill_type": "delivery",
       "path": "skills/task-driven-gh-flow.md",
       "compatible": {
         "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
@@ -282,6 +292,7 @@
     "release-readiness": {
       "display": "Release readiness",
       "description": "Validate a change is safe to release with checklist-driven checks, rollback preparation, and post-merge verification.",
+      "skill_type": "reliability",
       "path": "skills/release-readiness.md",
       "compatible": {
         "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
@@ -291,6 +302,7 @@
     "observability-design": {
       "display": "Observability design",
       "description": "Design observability across logs, metrics, traces, alerts, and dashboards to detect and diagnose production issues quickly.",
+      "skill_type": "reliability",
       "path": "skills/observability-design.md",
       "compatible": {
         "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
@@ -300,6 +312,7 @@
     "incident-review": {
       "display": "Incident review",
       "description": "Run a structured incident review with timeline reconstruction, contributing-factor analysis, action planning, and clear ownership.",
+      "skill_type": "reliability",
       "path": "skills/incident-review.md",
       "compatible": {
         "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
@@ -309,6 +322,7 @@
     "migration-planning": {
       "display": "Migration planning",
       "description": "Plan data and API migrations with phased rollouts, compatibility safeguards, and tested fallback paths.",
+      "skill_type": "reliability",
       "path": "skills/migration-planning.md",
       "compatible": {
         "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
@@ -318,6 +332,7 @@
     "solid-principles-application": {
       "display": "SOLID principles application",
       "description": "Apply SRP, OCP, LSP, ISP, and DIP with practical design checks during implementation and refactoring.",
+      "skill_type": "code-quality",
       "path": "skills/solid-principles-application.md",
       "compatible": {
         "languages": ["typescript", "python", "go", "java", "rust", "javascript"],
@@ -327,6 +342,7 @@
     "tdd-cycle-workflow": {
       "display": "TDD cycle workflow",
       "description": "Drive implementation with red-green-refactor loops and seam-first testability for safe, incremental delivery.",
+      "skill_type": "code-quality",
       "path": "skills/tdd-cycle-workflow.md",
       "compatible": {
         "languages": ["typescript", "python", "go", "java", "rust", "javascript"],

--- a/schema/registry.schema.json
+++ b/schema/registry.schema.json
@@ -65,6 +65,7 @@
         "properties": {
           "display": { "type": "string" },
           "description": { "type": "string" },
+          "skill_type": { "type": "string" },
           "path": { "type": "string" },
           "requires": { "type": "array", "items": { "type": "string" } },
           "conflicts_with": { "type": "array", "items": { "type": "string" } },

--- a/src/cli/help.test.ts
+++ b/src/cli/help.test.ts
@@ -29,6 +29,8 @@ test('printHelp renders expected command listing', () => {
 
   assert.match(output, /ailib commands:/);
   assert.match(output, /ailib init/);
+  assert.match(output, /--skills=s1,s2/);
+  assert.match(output, /guided setup/);
   assert.match(output, /ailib modules explain <module>/);
   assert.match(output, /ailib skills list/);
   assert.match(output, /ailib skills explain <skill-id>/);

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -1,7 +1,7 @@
 export function printHelp() {
   process.stdout.write(
     'ailib commands:\n' +
-      '  ailib init [--language=<lang>] [--targets=a,b] [--modules=m1,m2] [--workspaces=a/*,b/*] [--bare] [--no-inherit] [--on-conflict=overwrite|merge|skip|abort]\n' +
+      '  ailib init [--language=<lang>] [--targets=a,b] [--modules=m1,m2] [--skills=s1,s2] [--workspaces=a/*,b/*] [--bare] [--no-inherit] [--on-conflict=overwrite|merge|skip|abort] (plain `ailib init` starts guided setup)\n' +
       '  ailib update [--workspace=<path>]\n' +
       '  ailib add <module> [--workspace=<path>]\n' +
       '  ailib remove <module> [--workspace=<path>]\n' +

--- a/src/cli/init-guided.test.ts
+++ b/src/cli/init-guided.test.ts
@@ -1,0 +1,116 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { resolveGuidedInitSelections } from './init-guided.ts';
+import type { Registry } from './types.ts';
+
+async function tempDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'ailib-init-guided-'));
+}
+
+const registry: Registry = {
+  version: 'test',
+  slots: ['linter'],
+  languages: {
+    typescript: { modules: { eslint: { slot: 'linter' } } },
+    python: { modules: { ruff: { slot: 'linter' } } }
+  },
+  targets: {
+    cursor: { output: '.cursor/rules/ailib.mdc' },
+    'claude-code': { output: 'CLAUDE.md' }
+  },
+  skills: {
+    'architecture-decision-flow': {
+      display: 'Architecture decision flow',
+      path: 'skills/architecture-decision-flow.md',
+      skill_type: 'architecture',
+      compatible: {
+        languages: ['typescript'],
+        targets: ['cursor', 'claude-code']
+      }
+    },
+    'release-readiness': {
+      display: 'Release readiness',
+      path: 'skills/release-readiness.md',
+      skill_type: 'reliability',
+      requires: ['architecture-decision-flow'],
+      compatible: {
+        languages: ['typescript'],
+        targets: ['cursor', 'claude-code']
+      }
+    }
+  }
+};
+
+test('resolveGuidedInitSelections falls back to defaults when not interactive', async () => {
+  const rootDir = await tempDir();
+  const result = await resolveGuidedInitSelections({
+    registry,
+    rootDir,
+    configFile: 'ailib.config.json',
+    bare: true,
+    workspacePatterns: [],
+    defaults: {
+      language: 'typescript',
+      modules: ['eslint'],
+      targets: ['cursor'],
+      skills: ['architecture-decision-flow']
+    },
+    promptIO: { interactive: false }
+  });
+
+  assert.equal(result.language, 'typescript');
+  assert.deepEqual(result.modules, ['eslint']);
+  assert.deepEqual(result.targets, ['cursor']);
+  assert.deepEqual(result.skills, ['architecture-decision-flow']);
+  assert.deepEqual(result.workspaceLanguageOverrides, {});
+});
+
+test('resolveGuidedInitSelections retries invalid input and auto-adds required skills', async () => {
+  const rootDir = await tempDir();
+  await fs.mkdir(path.join(rootDir, 'apps', 'web'), { recursive: true });
+  await fs.mkdir(path.join(rootDir, 'services', 'ml'), { recursive: true });
+  await fs.writeFile(path.join(rootDir, 'apps', 'web', 'ailib.config.json'), '{"language":"typescript"}\n', 'utf8');
+
+  const answers = [
+    '9', // invalid target answer
+    '1,2', // valid targets
+    '2', // typescript
+    '', // modules -> defaults (none)
+    '2', // release-readiness (auto-add architecture dependency)
+    'maybe', // invalid yes/no answer
+    'y', // confirm workspace overrides
+    '1' // services/ml language = python
+  ];
+  const writes: string[] = [];
+  const result = await resolveGuidedInitSelections({
+    registry,
+    rootDir,
+    configFile: 'ailib.config.json',
+    bare: false,
+    workspacePatterns: ['apps/*', 'services/*'],
+    defaults: {
+      language: 'typescript',
+      modules: [],
+      targets: ['cursor', 'claude-code'],
+      skills: []
+    },
+    promptIO: {
+      interactive: true,
+      ask: async () => answers.shift() || '',
+      write: (line: string) => writes.push(line)
+    }
+  });
+
+  assert.deepEqual(result.targets, ['claude-code', 'cursor']);
+  assert.equal(result.language, 'typescript');
+  assert.deepEqual(result.modules, []);
+  assert.deepEqual(result.skills, ['release-readiness', 'architecture-decision-flow']);
+  assert.deepEqual(result.workspaceLanguageOverrides, { 'services/ml': 'python' });
+  assert.match(writes.join(''), /Invalid selection/);
+  assert.match(writes.join(''), /Please answer yes or no/);
+  assert.match(writes.join(''), /Auto-selected required skills/);
+  assert.match(writes.join(''), /already has ailib\.config\.json/);
+});

--- a/src/cli/init-guided.ts
+++ b/src/cli/init-guided.ts
@@ -1,0 +1,522 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { createInterface } from 'node:readline/promises';
+import { exists, toPosix, uniqueList } from './utils.ts';
+import type { Registry, SkillDefinition } from './types.ts';
+
+type Choice = {
+  id: string;
+  label: string;
+  description?: string;
+};
+
+type GroupedChoice = {
+  heading: string;
+  choices: Choice[];
+};
+
+type PromptSession = {
+  write: (line: string) => void;
+  ask: (question: string) => Promise<string>;
+  close: () => void;
+};
+
+export type InitPromptIO = {
+  interactive?: boolean;
+  ask?: (question: string) => Promise<string>;
+  write?: (line: string) => void;
+};
+
+export type GuidedInitSelections = {
+  language: string;
+  modules: string[];
+  targets: string[];
+  skills: string[];
+  workspaceLanguageOverrides: Record<string, string>;
+};
+
+export async function resolveGuidedInitSelections({
+  registry,
+  rootDir,
+  configFile,
+  bare,
+  workspacePatterns,
+  defaults,
+  promptIO
+}: {
+  registry: Registry;
+  rootDir: string;
+  configFile: string;
+  bare: boolean;
+  workspacePatterns: string[];
+  defaults: {
+    language: string;
+    modules: string[];
+    targets: string[];
+    skills: string[];
+  };
+  promptIO?: InitPromptIO;
+}): Promise<GuidedInitSelections> {
+  const session = createPromptSession(promptIO);
+  if (!session) {
+    return {
+      language: defaults.language,
+      modules: defaults.modules,
+      targets: defaults.targets,
+      skills: defaults.skills,
+      workspaceLanguageOverrides: {}
+    };
+  }
+
+  try {
+    session.write('\nailib init guided setup\n');
+    session.write('Select options by number. Use comma-separated values for multi-select.\n\n');
+
+    const targets = await promptMultiChoice({
+      title: 'Targets',
+      groups: [
+        {
+          heading: 'Available targets',
+          choices: Object.entries(registry.targets)
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([id, def]) => ({
+              id,
+              label: id,
+              description: def.display || def.output
+            }))
+        }
+      ],
+      defaultIds: defaults.targets,
+      allowEmpty: false,
+      emptyLabel: 'none',
+      session
+    });
+
+    const language = await promptSingleChoice({
+      title: 'Default language',
+      choices: Object.entries(registry.languages)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([id]) => ({ id, label: id })),
+      defaultId: defaults.language,
+      session
+    });
+
+    const modules = await promptMultiChoice({
+      title: `Modules (${language})`,
+      groups: [
+        {
+          heading: 'Available modules',
+          choices: Object.entries(registry.languages[language]?.modules || {})
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([id, def]) => ({
+              id,
+              label: id,
+              description: `slot: ${def.slot}`
+            }))
+        }
+      ],
+      defaultIds: defaults.modules,
+      allowEmpty: true,
+      emptyLabel: 'none',
+      session
+    });
+
+    const compatibleSkills = resolveCompatibleSkills({
+      registry,
+      language,
+      modules,
+      targets
+    });
+    const groupedSkillChoices = groupSkillChoices(compatibleSkills);
+    const skills = await promptMultiChoice({
+      title: 'Skills',
+      groups: groupedSkillChoices,
+      defaultIds: defaults.skills.filter((id) => compatibleSkills.some((skill) => skill.id === id)),
+      allowEmpty: true,
+      emptyLabel: 'none',
+      session
+    });
+    const expandedSkills = expandRequiredSkills(skills, registry.skills || {});
+    const addedDependencies = expandedSkills.filter((id) => !skills.includes(id));
+    if (addedDependencies.length) {
+      session.write(`Auto-selected required skills: ${addedDependencies.join(', ')}\n`);
+    }
+
+    let workspaceLanguageOverrides: Record<string, string> = {};
+    if (!bare && workspacePatterns.length) {
+      const candidates = await discoverWorkspaceCandidates(rootDir, workspacePatterns);
+      if (candidates.length) {
+        const configureOverrides = await promptYesNo({
+          question: 'Configure workspace-specific language overrides? [y/N]: ',
+          defaultValue: false,
+          session
+        });
+        if (configureOverrides) {
+          workspaceLanguageOverrides = await promptWorkspaceLanguageOverrides({
+            rootDir,
+            configFile,
+            candidates,
+            defaultLanguage: language,
+            languageChoices: Object.entries(registry.languages)
+              .sort(([a], [b]) => a.localeCompare(b))
+              .map(([id]) => ({ id, label: id })),
+            session
+          });
+        }
+      }
+    }
+
+    session.write('\n');
+    return {
+      language,
+      modules,
+      targets,
+      skills: expandedSkills,
+      workspaceLanguageOverrides
+    };
+  } finally {
+    session.close();
+  }
+}
+
+function createPromptSession(promptIO?: InitPromptIO): PromptSession | null {
+  const interactive = promptIO?.interactive ?? Boolean(process.stdin.isTTY && process.stdout.isTTY);
+  if (!interactive) return null;
+
+  const write = promptIO?.write ?? ((line: string) => process.stdout.write(line));
+  if (promptIO?.ask) {
+    return {
+      write,
+      ask: promptIO.ask,
+      close: () => {}
+    };
+  }
+
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout
+  });
+  return {
+    write,
+    ask: (question: string) => rl.question(question),
+    close: () => rl.close()
+  };
+}
+
+async function promptSingleChoice({
+  title,
+  choices,
+  defaultId,
+  session
+}: {
+  title: string;
+  choices: Choice[];
+  defaultId?: string;
+  session: PromptSession;
+}) {
+  if (!choices.length) {
+    throw new Error(`No available choices for ${title}`);
+  }
+  const fallback = defaultId && choices.some((choice) => choice.id === defaultId) ? defaultId : choices[0].id;
+  const indexMap = renderChoices([{ heading: title, choices }], session);
+  while (true) {
+    const defaultIndex = indexMap.findIndex((entry) => entry.id === fallback) + 1;
+    const answer = (await session.ask(`Select one [default: ${String(defaultIndex)}]: `)).trim();
+    if (!answer) return fallback;
+    const selected = resolveChoiceToken(answer, indexMap);
+    if (selected) return selected.id;
+    session.write(`Invalid selection '${answer}'. Try again.\n`);
+  }
+}
+
+async function promptMultiChoice({
+  title,
+  groups,
+  defaultIds,
+  allowEmpty,
+  emptyLabel,
+  session
+}: {
+  title: string;
+  groups: GroupedChoice[];
+  defaultIds: string[];
+  allowEmpty: boolean;
+  emptyLabel: string;
+  session: PromptSession;
+}) {
+  const availableChoices = groups.flatMap((group) => group.choices);
+  const availableSet = new Set(availableChoices.map((choice) => choice.id));
+  const defaults = uniqueList(defaultIds.filter((id) => availableSet.has(id)));
+  const indexMap = renderChoices(groups.length ? groups : [{ heading: title, choices: [] }], session);
+  if (!indexMap.length) {
+    session.write(`${title}: no compatible options.\n`);
+    return [];
+  }
+
+  while (true) {
+    const defaultIndexes = defaults
+      .map((id) => indexMap.findIndex((entry) => entry.id === id) + 1)
+      .filter((idx) => idx > 0);
+    const defaultText = defaultIndexes.length ? defaultIndexes.join(',') : emptyLabel;
+    const answer = (
+      await session.ask(`Select one or more [default: ${defaultText}; use comma-separated values]: `)
+    ).trim();
+    if (!answer) return defaults;
+    if (allowEmpty && /^none$/iu.test(answer)) return [];
+
+    const tokens = answer
+      .split(',')
+      .map((token) => token.trim())
+      .filter(Boolean);
+    if (!tokens.length) {
+      if (allowEmpty) return [];
+      session.write('At least one selection is required.\n');
+      continue;
+    }
+
+    const resolved: string[] = [];
+    let invalidToken: string | null = null;
+    for (const token of tokens) {
+      const selected = resolveChoiceToken(token, indexMap);
+      if (!selected) {
+        invalidToken = token;
+        break;
+      }
+      resolved.push(selected.id);
+    }
+
+    if (invalidToken) {
+      session.write(`Invalid selection '${invalidToken}'. Try again.\n`);
+      continue;
+    }
+
+    const deduped = uniqueList(resolved);
+    if (!allowEmpty && !deduped.length) {
+      session.write('At least one selection is required.\n');
+      continue;
+    }
+    return deduped;
+  }
+}
+
+async function promptYesNo({
+  question,
+  defaultValue,
+  session
+}: {
+  question: string;
+  defaultValue: boolean;
+  session: PromptSession;
+}) {
+  while (true) {
+    const answer = (await session.ask(question)).trim().toLowerCase();
+    if (!answer) return defaultValue;
+    if (['y', 'yes'].includes(answer)) return true;
+    if (['n', 'no'].includes(answer)) return false;
+    session.write(`Please answer yes or no.\n`);
+  }
+}
+
+async function promptWorkspaceLanguageOverrides({
+  rootDir,
+  configFile,
+  candidates,
+  defaultLanguage,
+  languageChoices,
+  session
+}: {
+  rootDir: string;
+  configFile: string;
+  candidates: string[];
+  defaultLanguage: string;
+  languageChoices: Choice[];
+  session: PromptSession;
+}) {
+  const overrides: Record<string, string> = {};
+  for (const workspaceDir of candidates) {
+    const rel = toPosix(path.relative(rootDir, workspaceDir));
+    const existingPath = path.join(workspaceDir, configFile);
+    if (await exists(existingPath)) {
+      session.write(`Workspace '${rel}' already has ${configFile}; keeping existing language.\n`);
+      continue;
+    }
+    const selectedLanguage = await promptSingleChoice({
+      title: `Language for workspace ${rel}`,
+      choices: languageChoices,
+      defaultId: defaultLanguage,
+      session
+    });
+    if (selectedLanguage !== defaultLanguage) {
+      overrides[rel] = selectedLanguage;
+    }
+  }
+  return overrides;
+}
+
+function resolveChoiceToken(token: string, indexMap: Array<{ id: string }>) {
+  if (/^\d+$/u.test(token)) {
+    const idx = Number.parseInt(token, 10) - 1;
+    if (idx < 0 || idx >= indexMap.length) return null;
+    return indexMap[idx];
+  }
+  return indexMap.find((entry) => entry.id === token) || null;
+}
+
+function renderChoices(groups: GroupedChoice[], session: PromptSession) {
+  const indexMap: Array<{ id: string }> = [];
+  for (const group of groups) {
+    session.write(`\n${group.heading}\n`);
+    if (!group.choices.length) {
+      session.write('  (none)\n');
+      continue;
+    }
+    for (const choice of group.choices) {
+      indexMap.push({ id: choice.id });
+      const index = indexMap.length;
+      const description = choice.description ? ` - ${choice.description}` : '';
+      session.write(`  ${String(index)}) ${choice.label}${description}\n`);
+    }
+  }
+  return indexMap;
+}
+
+function resolveCompatibleSkills({
+  registry,
+  language,
+  modules,
+  targets
+}: {
+  registry: Registry;
+  language: string;
+  modules: string[];
+  targets: string[];
+}) {
+  const selectedModules = new Set(modules);
+  const selectedTargets = new Set(targets);
+  const selectedSkills = Object.entries(registry.skills || {}).filter(([, def]) => {
+    const compatible = def.compatible || {};
+    if (compatible.languages?.length && !compatible.languages.includes(language)) return false;
+    if (compatible.modules?.length && !compatible.modules.some((moduleId) => selectedModules.has(moduleId)))
+      return false;
+    if (compatible.targets?.length && !compatible.targets.some((targetId) => selectedTargets.has(targetId)))
+      return false;
+    return true;
+  });
+  return selectedSkills
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([id, def]) => ({
+      id,
+      def
+    }));
+}
+
+function groupSkillChoices(skills: Array<{ id: string; def: SkillDefinition }>): GroupedChoice[] {
+  const grouped = new Map<string, Choice[]>();
+  for (const skill of skills) {
+    const rawType = (skill.def.skill_type || 'other').trim();
+    const type = rawType || 'other';
+    const list = grouped.get(type) || [];
+    list.push({
+      id: skill.id,
+      label: skill.id,
+      description: skill.def.display
+    });
+    grouped.set(type, list);
+  }
+
+  return [...grouped.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([type, choices]) => ({
+      heading: `Type: ${formatSkillType(type)}`,
+      choices: choices.sort((left, right) => left.id.localeCompare(right.id))
+    }));
+}
+
+function formatSkillType(type: string) {
+  return type
+    .split(/[-_\s]+/u)
+    .filter(Boolean)
+    .map((part) => `${part[0]?.toUpperCase() || ''}${part.slice(1)}`)
+    .join(' ');
+}
+
+function expandRequiredSkills(selectedSkills: string[], skills: Record<string, SkillDefinition>) {
+  const expanded = new Set(selectedSkills);
+  const queue = [...selectedSkills];
+  while (queue.length) {
+    const skillId = queue.shift();
+    if (!skillId) continue;
+    for (const dependency of skills[skillId]?.requires || []) {
+      if (!expanded.has(dependency)) {
+        expanded.add(dependency);
+        queue.push(dependency);
+      }
+    }
+  }
+  return [...expanded];
+}
+
+async function discoverWorkspaceCandidates(rootDir: string, workspacePatterns: string[]) {
+  const out = new Set<string>();
+  for (const pattern of workspacePatterns) {
+    const resolved = await resolvePatternDirs(rootDir, pattern);
+    for (const dir of resolved) out.add(path.resolve(dir));
+  }
+  return [...out].sort();
+}
+
+async function resolvePatternDirs(rootDir: string, pattern: string) {
+  const normalized = toPosix(pattern).replace(/^\.?\//u, '');
+  if (!normalized) return [];
+  const segments = normalized.split('/').filter(Boolean);
+  const matches: string[] = [];
+
+  async function walk(currentDir: string, idx: number): Promise<void> {
+    if (idx >= segments.length) {
+      if (await isDirectory(currentDir)) matches.push(currentDir);
+      return;
+    }
+
+    const segment = segments[idx];
+    if (segment === '**') {
+      await walk(currentDir, idx + 1);
+      const entries = await readDirectoryEntries(currentDir);
+      for (const entry of entries) {
+        await walk(path.join(currentDir, entry.name), idx);
+      }
+      return;
+    }
+
+    if (segment === '*') {
+      const entries = await readDirectoryEntries(currentDir);
+      for (const entry of entries) {
+        await walk(path.join(currentDir, entry.name), idx + 1);
+      }
+      return;
+    }
+
+    await walk(path.join(currentDir, segment), idx + 1);
+  }
+
+  await walk(rootDir, 0);
+  return matches;
+}
+
+async function readDirectoryEntries(dir: string) {
+  let entries: Array<{ name: string } & { isDirectory: () => boolean }> = [];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries.filter((entry) => entry.isDirectory() && !entry.name.startsWith('.') && entry.name !== 'node_modules');
+}
+
+async function isDirectory(filePath: string) {
+  try {
+    const stat = await fs.stat(filePath);
+    return stat.isDirectory();
+  } catch {
+    return false;
+  }
+}

--- a/src/cli/init.test.ts
+++ b/src/cli/init.test.ts
@@ -5,6 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { initCommand } from './init.ts';
 import type { CliFlags, Registry, WorkspaceConfig } from './types.ts';
+import type { InitPromptIO } from './init-guided.ts';
 
 async function tempDir() {
   return fs.mkdtemp(path.join(os.tmpdir(), 'ailib-init-'));
@@ -13,9 +14,42 @@ async function tempDir() {
 const registry: Registry = {
   version: 'test-registry',
   slots: ['linter'],
-  languages: { typescript: { modules: { eslint: { slot: 'linter' } } } },
-  targets: { cursor: { output: '.cursor/rules/ai.md' } }
+  languages: {
+    typescript: { modules: { eslint: { slot: 'linter' } } },
+    python: { modules: { ruff: { slot: 'linter' } } }
+  },
+  targets: { cursor: { output: '.cursor/rules/ai.md' }, 'claude-code': { output: 'CLAUDE.md' } },
+  skills: {
+    'task-driven-gh-flow': {
+      display: 'Task-driven GH flow',
+      path: 'skills/task-driven-gh-flow.md',
+      skill_type: 'delivery',
+      compatible: {
+        languages: ['typescript'],
+        targets: ['cursor', 'claude-code']
+      }
+    },
+    'release-readiness': {
+      display: 'Release readiness',
+      path: 'skills/release-readiness.md',
+      skill_type: 'reliability',
+      requires: ['task-driven-gh-flow'],
+      compatible: {
+        languages: ['typescript'],
+        targets: ['cursor', 'claude-code']
+      }
+    }
+  }
 };
+
+function createPromptIO(answers: string[]): InitPromptIO {
+  const queue = [...answers];
+  return {
+    interactive: true,
+    ask: async () => queue.shift() ?? '',
+    write: () => {}
+  };
+}
 
 test('initCommand writes root config and calls update', async () => {
   const rootDir = await tempDir();
@@ -68,4 +102,72 @@ test('initCommand in service context writes extends config', async () => {
   const config = JSON.parse(await fs.readFile(path.join(serviceDir, 'ailib.config.json'), 'utf8')) as WorkspaceConfig;
   assert.ok(config.extends);
   assert.equal(calledOverride, serviceDir);
+});
+
+test('initCommand guided flow selects targets language modules and skills', async () => {
+  const rootDir = await tempDir();
+  await fs.writeFile(path.join(rootDir, 'package.json'), '{"name":"root"}\n', 'utf8');
+  const packageRoot = path.join(rootDir, 'pkg');
+  await fs.mkdir(packageRoot, { recursive: true });
+  await fs.writeFile(path.join(packageRoot, 'registry.json'), `${JSON.stringify(registry)}\n`, 'utf8');
+
+  await initCommand({
+    cwd: rootDir,
+    packageRoot,
+    flags: { _: [] } as CliFlags,
+    configFile: 'ailib.config.json',
+    canonicalSlot: (_registry, slot) => slot || null,
+    applyWorkspaceUpdate: async () => {},
+    promptIO: createPromptIO([
+      '1,2', // targets
+      '2', // default language = typescript
+      '1', // modules (eslint)
+      '2,1' // skills (release-readiness + task-driven-gh-flow)
+    ])
+  });
+
+  const config = JSON.parse(await fs.readFile(path.join(rootDir, 'ailib.config.json'), 'utf8')) as WorkspaceConfig;
+  assert.equal(config.language, 'typescript');
+  assert.deepEqual(config.modules, ['eslint']);
+  assert.deepEqual(config.targets, ['claude-code', 'cursor']);
+  assert.deepEqual(config.skills, ['release-readiness', 'task-driven-gh-flow']);
+});
+
+test('initCommand guided flow writes monorepo language override configs', async () => {
+  const rootDir = await tempDir();
+  await fs.writeFile(path.join(rootDir, 'package.json'), '{"name":"root"}\n', 'utf8');
+  await fs.mkdir(path.join(rootDir, 'apps', 'web'), { recursive: true });
+  await fs.mkdir(path.join(rootDir, 'services', 'ml'), { recursive: true });
+  const packageRoot = path.join(rootDir, 'pkg');
+  await fs.mkdir(packageRoot, { recursive: true });
+  await fs.writeFile(path.join(packageRoot, 'registry.json'), `${JSON.stringify(registry)}\n`, 'utf8');
+
+  await initCommand({
+    cwd: rootDir,
+    packageRoot,
+    flags: { _: [] } as CliFlags,
+    configFile: 'ailib.config.json',
+    canonicalSlot: (_registry, slot) => slot || null,
+    applyWorkspaceUpdate: async () => {},
+    promptIO: createPromptIO([
+      '2', // targets (cursor)
+      '2', // default language = typescript
+      '', // modules -> none
+      '', // skills -> none
+      'y', // configure workspace overrides
+      '', // apps/web -> keep default typescript
+      '1' // services/ml -> python
+    ])
+  });
+
+  const rootConfig = JSON.parse(await fs.readFile(path.join(rootDir, 'ailib.config.json'), 'utf8')) as WorkspaceConfig;
+  assert.equal(rootConfig.language, 'typescript');
+
+  const serviceConfig = JSON.parse(
+    await fs.readFile(path.join(rootDir, 'services', 'ml', 'ailib.config.json'), 'utf8')
+  ) as WorkspaceConfig;
+  assert.equal(serviceConfig.language, 'python');
+  assert.equal(serviceConfig.extends, '../../ailib.config.json');
+
+  await assert.rejects(fs.readFile(path.join(rootDir, 'apps', 'web', 'ailib.config.json'), 'utf8'));
 });

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -3,10 +3,13 @@ import path from 'node:path';
 import { ensure } from './assertions.ts';
 import { detectProjectRoot, findNearestMonorepoRoot } from './context-resolution.ts';
 import { getStringFlag } from './flags.ts';
+import { resolveGuidedInitSelections } from './init-guided.ts';
 import { validateModuleSelection } from './module-validation.ts';
+import { validateSkillSelection } from './skill-validation.ts';
 import { bindRegistryCanonicalSlot } from './slot-resolver.ts';
-import { readJson, splitCsv, toPosix, uniqueList } from './utils.ts';
+import { exists, readJson, splitCsv, toPosix, uniqueList } from './utils.ts';
 import type { CliFlags, Registry, WorkspaceConfig } from './types.ts';
+import type { InitPromptIO } from './init-guided.ts';
 
 export async function initCommand({
   cwd,
@@ -14,7 +17,8 @@ export async function initCommand({
   flags,
   configFile,
   canonicalSlot,
-  applyWorkspaceUpdate
+  applyWorkspaceUpdate,
+  promptIO
 }: {
   cwd: string;
   packageRoot: string;
@@ -27,17 +31,59 @@ export async function initCommand({
     workspaceOverride?: string;
     forceOnConflict?: string;
   }) => Promise<void>;
+  promptIO?: InitPromptIO;
 }) {
   const registry = await readJson<Registry>(path.join(packageRoot, 'registry.json'));
   const nearestRoot = await findNearestMonorepoRoot(path.resolve(cwd));
   const inServiceContext = Boolean(nearestRoot && path.resolve(cwd) !== nearestRoot);
+  const projectRoot = inServiceContext ? path.resolve(cwd) : await detectProjectRoot(cwd);
 
-  const language = getStringFlag(flags, 'language') || Object.keys(registry.languages)[0];
-  ensure(registry.languages[language], `Unsupported language: ${language}`);
-
-  const modules = uniqueList(splitCsv(flags.modules));
+  const requestedLanguage = getStringFlag(flags, 'language');
+  const requestedModules = uniqueList(splitCsv(flags.modules));
   const requestedTargets = splitCsv(flags.targets);
-  const targets = uniqueList(requestedTargets.length ? requestedTargets : Object.keys(registry.targets));
+  const requestedSkills = uniqueList(splitCsv(flags.skills));
+  const hasSelectionFlags =
+    requestedLanguage !== undefined ||
+    flags.modules !== undefined ||
+    flags.targets !== undefined ||
+    flags.skills !== undefined;
+  const defaultLanguage = requestedLanguage || Object.keys(registry.languages)[0];
+  ensure(registry.languages[defaultLanguage], `Unsupported language: ${defaultLanguage}`);
+
+  let language = defaultLanguage;
+  let modules = requestedModules;
+  let targets = uniqueList(requestedTargets.length ? requestedTargets : Object.keys(registry.targets));
+  let skills = requestedSkills;
+  let workspaceLanguageOverrides: Record<string, string> = {};
+
+  if (!hasSelectionFlags) {
+    const defaultWorkspacePatterns = flags.bare === true ? [] : splitCsv(flags.workspaces);
+    const workspacePatterns =
+      flags.bare === true ? [] : defaultWorkspacePatterns.length ? defaultWorkspacePatterns : ['apps/*', 'services/*'];
+    const guided = await resolveGuidedInitSelections({
+      registry,
+      rootDir: projectRoot,
+      configFile,
+      bare: flags.bare === true,
+      workspacePatterns,
+      defaults: {
+        language: defaultLanguage,
+        modules: requestedModules,
+        targets,
+        skills
+      },
+      promptIO
+    });
+    language = guided.language;
+    modules = guided.modules;
+    targets = guided.targets;
+    skills = guided.skills;
+    workspaceLanguageOverrides = guided.workspaceLanguageOverrides;
+  }
+
+  for (const target of targets) {
+    ensure(registry.targets[target], `Unsupported target: ${target}`);
+  }
   const onConflict = getStringFlag(flags, 'on-conflict') || 'merge';
   const canonicalSlotForRegistry = bindRegistryCanonicalSlot(registry, canonicalSlot);
 
@@ -47,10 +93,16 @@ export async function initCommand({
     modules,
     canonicalSlot: canonicalSlotForRegistry
   });
+  validateSkillSelection({
+    registry,
+    skills,
+    language,
+    modules,
+    targets
+  });
 
   if (inServiceContext && flags['no-inherit'] !== true) {
     ensure(nearestRoot, 'Could not resolve monorepo root for service initialization');
-    const projectRoot = path.resolve(cwd);
     const rel = toPosix(path.relative(projectRoot, path.join(nearestRoot, configFile)));
     const config: WorkspaceConfig = {
       $schema: 'https://ailib.dev/schema/config.schema.json',
@@ -60,6 +112,7 @@ export async function initCommand({
       docs_path: './docs/'
     };
     if (targets.length) config.targets = targets;
+    if (skills.length) config.skills = skills;
 
     await fs.writeFile(path.join(projectRoot, configFile), `${JSON.stringify(config, null, 2)}\n`, 'utf8');
     await applyWorkspaceUpdate({
@@ -72,13 +125,13 @@ export async function initCommand({
     return;
   }
 
-  const projectRoot = await detectProjectRoot(cwd);
   const config: WorkspaceConfig = {
     $schema: 'https://ailib.dev/schema/config.schema.json',
     registry_ref: registry.version,
     language,
     modules,
     targets,
+    skills,
     docs_path: 'docs/',
     on_conflict: onConflict
   };
@@ -89,6 +142,44 @@ export async function initCommand({
   }
 
   await fs.writeFile(path.join(projectRoot, configFile), `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+  await upsertWorkspaceLanguageOverrides({
+    rootDir: projectRoot,
+    configFile,
+    defaultLanguage: language,
+    workspaceLanguageOverrides
+  });
   await applyWorkspaceUpdate({ packageRoot, rootDir: projectRoot, forceOnConflict: onConflict });
   process.stdout.write('ailib initialized\n');
+}
+
+async function upsertWorkspaceLanguageOverrides({
+  rootDir,
+  configFile,
+  defaultLanguage,
+  workspaceLanguageOverrides
+}: {
+  rootDir: string;
+  configFile: string;
+  defaultLanguage: string;
+  workspaceLanguageOverrides: Record<string, string>;
+}) {
+  for (const [workspaceRel, language] of Object.entries(workspaceLanguageOverrides)) {
+    if (language === defaultLanguage) continue;
+    const workspaceDir = path.resolve(rootDir, workspaceRel);
+    await fs.mkdir(workspaceDir, { recursive: true });
+    const configPath = path.join(workspaceDir, configFile);
+    const extendsPath = toPosix(path.relative(workspaceDir, path.join(rootDir, configFile)));
+
+    let config: WorkspaceConfig;
+    if (await exists(configPath)) {
+      config = (await readJson<WorkspaceConfig>(configPath)) || {};
+    } else {
+      config = { $schema: 'https://ailib.dev/schema/config.schema.json', docs_path: './docs/' };
+    }
+    config.extends = config.extends || extendsPath;
+    config.language = language;
+    if (!config.docs_path && !config.workspaces) config.docs_path = './docs/';
+
+    await fs.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+  }
 }

--- a/src/cli/types.test.ts
+++ b/src/cli/types.test.ts
@@ -1,7 +1,14 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import type { CliFlags, CommandContext, RunOptions, TargetDefinition, WorkspaceConfig } from './types.ts';
+import type {
+  CliFlags,
+  CommandContext,
+  RunOptions,
+  SkillDefinition,
+  TargetDefinition,
+  WorkspaceConfig
+} from './types.ts';
 
 test('types module supports expected shape usage', () => {
   const runOptions: RunOptions = { cwd: '/tmp/project', packageRoot: '/tmp/pkg' };
@@ -11,6 +18,11 @@ test('types module supports expected shape usage', () => {
     modules: ['eslint'],
     targets: ['claude-code'],
     skills: ['task-driven-gh-flow']
+  };
+  const skill: SkillDefinition = {
+    display: 'Task-driven GH flow',
+    path: 'skills/task-driven-gh-flow.md',
+    skill_type: 'delivery'
   };
   const target: TargetDefinition = {
     output: 'CLAUDE.md',
@@ -30,5 +42,6 @@ test('types module supports expected shape usage', () => {
   assert.equal(context.flags._[0], 'init');
   assert.equal(config.modules?.[0], 'eslint');
   assert.equal(config.skills?.[0], 'task-driven-gh-flow');
+  assert.equal(skill.skill_type, 'delivery');
   assert.equal(target.skill_profile?.format, 'claude-code');
 });

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -45,6 +45,7 @@ export interface SkillDefinition {
   display: string;
   path: string;
   description?: string;
+  skill_type?: string;
   requires?: string[];
   conflicts_with?: string[];
   compatible?: SkillCompatibility;

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -344,6 +344,40 @@ test('init supports generic target outputs including openai and gemini', async (
   assert.equal(await exists(path.join(cwd, 'GEMINI.md')), true);
 });
 
+test('plain init without selection flags falls back to defaults in non-interactive mode', async () => {
+  const cwd = await makeProject();
+  await run(['init', '--bare'], { cwd, packageRoot });
+
+  const config = JSON.parse(await fs.readFile(path.join(cwd, 'ailib.config.json'), 'utf8')) as {
+    language?: string;
+    targets?: string[];
+  };
+  assert.equal(typeof config.language, 'string');
+  assert.ok((config.language || '').length > 0);
+  assert.ok(Array.isArray(config.targets));
+  assert.ok((config.targets || []).includes('cursor'));
+});
+
+test('init persists selected skills via --skills flag', async () => {
+  const cwd = await makeProject();
+  await run(
+    [
+      'init',
+      '--language=typescript',
+      '--modules=eslint',
+      '--targets=claude-code',
+      '--skills=task-driven-gh-flow',
+      '--bare'
+    ],
+    { cwd, packageRoot }
+  );
+
+  const config = JSON.parse(await fs.readFile(path.join(cwd, 'ailib.config.json'), 'utf8')) as {
+    skills?: string[];
+  };
+  assert.deepEqual(config.skills, ['task-driven-gh-flow']);
+});
+
 test('monorepo update inherits root and supports service override modules', async () => {
   const root = await makeMonorepo();
   await run(


### PR DESCRIPTION
## Summary
- add a plain `ailib init` guided setup flow with interactive multi-select for targets, modules, and skills
- add `skill_type` to the registry contract and group guided skill choices by type
- add monorepo-aware root language defaults with optional per-workspace language override config generation
- add tests and docs for guided init behavior, `--skills` support, and non-interactive defaults fallback

## Test plan
- [x] bun test
- [x] bun run check

Refs #349

Made with [Cursor](https://cursor.com)