### PR TITLE
test: recover guided init coverage

### DIFF
--- a/src/cli/init-guided.test.ts
+++ b/src/cli/init-guided.test.ts
@@ -14,8 +14,8 @@ const registry: Registry = {
   version: 'test',
   slots: ['linter'],
   languages: {
-    typescript: { modules: { eslint: { slot: 'linter' } } },
-    python: { modules: { ruff: { slot: 'linter' } } }
+    typescript: { modules: { biome: { slot: 'linter' }, eslint: { slot: 'linter' } } },
+    python: { modules: { black: { slot: 'linter' }, ruff: { slot: 'linter' } } }
   },
   targets: {
     cursor: { output: '.cursor/rules/ailib.mdc' },
@@ -36,6 +36,15 @@ const registry: Registry = {
       path: 'skills/release-readiness.md',
       skill_type: 'reliability',
       requires: ['architecture-decision-flow'],
+      compatible: {
+        languages: ['typescript'],
+        targets: ['cursor', 'claude-code']
+      }
+    },
+    'incident-review': {
+      display: 'Incident review',
+      path: 'skills/incident-review.md',
+      skill_type: 'reliability',
       compatible: {
         languages: ['typescript'],
         targets: ['cursor', 'claude-code']
@@ -79,7 +88,7 @@ test('resolveGuidedInitSelections retries invalid input and auto-adds required s
     '1,2', // valid targets
     '2', // typescript
     '', // modules -> defaults (none)
-    '2', // release-readiness (auto-add architecture dependency)
+    '3', // release-readiness (auto-add architecture dependency)
     'maybe', // invalid yes/no answer
     'y', // confirm workspace overrides
     '1' // services/ml language = python
@@ -113,4 +122,226 @@ test('resolveGuidedInitSelections retries invalid input and auto-adds required s
   assert.match(writes.join(''), /Please answer yes or no/);
   assert.match(writes.join(''), /Auto-selected required skills/);
   assert.match(writes.join(''), /already has ailib\.config\.json/);
+});
+
+test('resolveGuidedInitSelections requires ask handler in interactive mode', async () => {
+  const rootDir = await tempDir();
+  await assert.rejects(
+    resolveGuidedInitSelections({
+      registry,
+      rootDir,
+      configFile: 'ailib.config.json',
+      bare: true,
+      workspacePatterns: [],
+      defaults: {
+        language: 'typescript',
+        modules: [],
+        targets: ['cursor'],
+        skills: []
+      },
+      promptIO: {
+        interactive: true
+      }
+    }),
+    /Interactive guided init requires prompt ask handler/
+  );
+});
+
+test('resolveGuidedInitSelections validates empty language choices and invalid single selections', async () => {
+  const rootDir = await tempDir();
+  const missingLanguagesRegistry: Registry = {
+    ...registry,
+    languages: {}
+  };
+  await assert.rejects(
+    resolveGuidedInitSelections({
+      registry: missingLanguagesRegistry,
+      rootDir,
+      configFile: 'ailib.config.json',
+      bare: true,
+      workspacePatterns: [],
+      defaults: {
+        language: 'typescript',
+        modules: [],
+        targets: ['cursor'],
+        skills: []
+      },
+      promptIO: {
+        interactive: true,
+        ask: async () => '',
+        write: () => {}
+      }
+    }),
+    /No available choices for Default language/
+  );
+});
+
+test('resolveGuidedInitSelections supports id tokens and retries invalid multi-select syntax', async () => {
+  const rootDir = await tempDir();
+  const answers = [
+    ',', // invalid empty token set for required targets multi-select
+    'cursor', // id token (non-numeric) for targets
+    'invalid-language', // invalid single choice token
+    'typescript', // id token (non-numeric) for language
+    'eslint', // id token for modules
+    'none' // explicit empty skills
+  ];
+  const writes: string[] = [];
+  const result = await resolveGuidedInitSelections({
+    registry,
+    rootDir,
+    configFile: 'ailib.config.json',
+    bare: true,
+    workspacePatterns: [],
+    defaults: {
+      language: 'typescript',
+      modules: [],
+      targets: ['cursor'],
+      skills: []
+    },
+    promptIO: {
+      interactive: true,
+      ask: async () => answers.shift() || '',
+      write: (line: string) => writes.push(line)
+    }
+  });
+
+  assert.deepEqual(result.targets, ['cursor']);
+  assert.deepEqual(result.modules, ['eslint']);
+  assert.deepEqual(result.skills, []);
+  const output = writes.join('');
+  assert.match(output, /At least one selection is required/);
+  assert.match(output, /Invalid selection 'invalid-language'/);
+});
+
+test('resolveGuidedInitSelections handles empty module and skill groups gracefully', async () => {
+  const rootDir = await tempDir();
+  const goOnlyRegistry: Registry = {
+    ...registry,
+    languages: {
+      go: { modules: {} }
+    }
+  };
+  const writes: string[] = [];
+  const result = await resolveGuidedInitSelections({
+    registry: goOnlyRegistry,
+    rootDir,
+    configFile: 'ailib.config.json',
+    bare: true,
+    workspacePatterns: [],
+    defaults: {
+      language: 'go',
+      modules: [],
+      targets: ['cursor'],
+      skills: []
+    },
+    promptIO: {
+      interactive: true,
+      ask: async () => '',
+      write: (line: string) => writes.push(line)
+    }
+  });
+
+  assert.equal(result.language, 'go');
+  assert.deepEqual(result.modules, []);
+  assert.deepEqual(result.skills, []);
+  const output = writes.join('');
+  assert.match(output, /Modules \(go\): no compatible options/);
+  assert.match(output, /Skills: no compatible options/);
+  assert.match(output, /\(none\)/);
+});
+
+test('resolveGuidedInitSelections accepts comma-only input for optional multi-select', async () => {
+  const rootDir = await tempDir();
+  const answers = [
+    '1', // target
+    '2', // typescript
+    ',', // modules (allowEmpty=true, empty token set)
+    '' // skills defaults
+  ];
+  const result = await resolveGuidedInitSelections({
+    registry,
+    rootDir,
+    configFile: 'ailib.config.json',
+    bare: true,
+    workspacePatterns: [],
+    defaults: {
+      language: 'typescript',
+      modules: [],
+      targets: ['cursor'],
+      skills: []
+    },
+    promptIO: {
+      interactive: true,
+      ask: async () => answers.shift() || '',
+      write: () => {}
+    }
+  });
+
+  assert.deepEqual(result.modules, []);
+});
+
+test('resolveGuidedInitSelections traverses double-star patterns and ignores missing paths', async () => {
+  const rootDir = await tempDir();
+  await fs.mkdir(path.join(rootDir, 'apps', 'api'), { recursive: true });
+  await fs.mkdir(path.join(rootDir, 'services', 'worker'), { recursive: true });
+
+  const answers = [
+    '1', // target
+    '2', // typescript
+    '', // modules
+    '', // skills
+    'n' // skip workspace language override configuration
+  ];
+  const result = await resolveGuidedInitSelections({
+    registry,
+    rootDir,
+    configFile: 'ailib.config.json',
+    bare: false,
+    workspacePatterns: ['**', 'missing/path'],
+    defaults: {
+      language: 'typescript',
+      modules: [],
+      targets: ['cursor'],
+      skills: []
+    },
+    promptIO: {
+      interactive: true,
+      ask: async () => answers.shift() || '',
+      write: () => {}
+    }
+  });
+
+  assert.equal(result.language, 'typescript');
+  assert.deepEqual(result.workspaceLanguageOverrides, {});
+});
+
+test('resolveGuidedInitSelections supports default writer when prompt write is omitted', async () => {
+  const rootDir = await tempDir();
+  const answers = [
+    '', // targets defaults
+    '', // language default
+    '', // modules default
+    '' // skills default
+  ];
+  const result = await resolveGuidedInitSelections({
+    registry,
+    rootDir,
+    configFile: 'ailib.config.json',
+    bare: true,
+    workspacePatterns: [],
+    defaults: {
+      language: 'typescript',
+      modules: ['eslint'],
+      targets: ['cursor'],
+      skills: ['architecture-decision-flow']
+    },
+    promptIO: {
+      interactive: true,
+      ask: async () => answers.shift() || ''
+    }
+  });
+
+  assert.deepEqual(result.modules, ['eslint']);
+  assert.deepEqual(result.targets, ['cursor']);
 });

--- a/src/cli/init-guided.ts
+++ b/src/cli/init-guided.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { createInterface } from 'node:readline/promises';
 import { exists, toPosix, uniqueList } from './utils.ts';
 import type { Registry, SkillDefinition } from './types.ts';
 
@@ -25,6 +24,7 @@ export type InitPromptIO = {
   interactive?: boolean;
   ask?: (question: string) => Promise<string>;
   write?: (line: string) => void;
+  close?: () => void;
 };
 
 export type GuidedInitSelections = {
@@ -188,19 +188,10 @@ function createPromptSession(promptIO?: InitPromptIO): PromptSession | null {
     return {
       write,
       ask: promptIO.ask,
-      close: () => {}
+      close: promptIO.close || (() => {})
     };
   }
-
-  const rl = createInterface({
-    input: process.stdin,
-    output: process.stdout
-  });
-  return {
-    write,
-    ask: (question: string) => rl.question(question),
-    close: () => rl.close()
-  };
+  throw new Error('Interactive guided init requires prompt ask handler');
 }
 
 async function promptSingleChoice({
@@ -219,14 +210,19 @@ async function promptSingleChoice({
   }
   const fallback = defaultId && choices.some((choice) => choice.id === defaultId) ? defaultId : choices[0].id;
   const indexMap = renderChoices([{ heading: title, choices }], session);
-  while (true) {
+  let selectedId = fallback;
+  for (;;) {
     const defaultIndex = indexMap.findIndex((entry) => entry.id === fallback) + 1;
     const answer = (await session.ask(`Select one [default: ${String(defaultIndex)}]: `)).trim();
-    if (!answer) return fallback;
+    if (!answer) break;
     const selected = resolveChoiceToken(answer, indexMap);
-    if (selected) return selected.id;
+    if (selected) {
+      selectedId = selected.id;
+      break;
+    }
     session.write(`Invalid selection '${answer}'. Try again.\n`);
   }
+  return selectedId;
 }
 
 async function promptMultiChoice({
@@ -253,7 +249,8 @@ async function promptMultiChoice({
     return [];
   }
 
-  while (true) {
+  let selectedIds: string[] = defaults;
+  for (;;) {
     const defaultIndexes = defaults
       .map((id) => indexMap.findIndex((entry) => entry.id === id) + 1)
       .filter((idx) => idx > 0);
@@ -261,15 +258,24 @@ async function promptMultiChoice({
     const answer = (
       await session.ask(`Select one or more [default: ${defaultText}; use comma-separated values]: `)
     ).trim();
-    if (!answer) return defaults;
-    if (allowEmpty && /^none$/iu.test(answer)) return [];
+    if (!answer) {
+      selectedIds = defaults;
+      break;
+    }
+    if (allowEmpty && /^none$/iu.test(answer)) {
+      selectedIds = [];
+      break;
+    }
 
     const tokens = answer
       .split(',')
       .map((token) => token.trim())
       .filter(Boolean);
     if (!tokens.length) {
-      if (allowEmpty) return [];
+      if (allowEmpty) {
+        selectedIds = [];
+        break;
+      }
       session.write('At least one selection is required.\n');
       continue;
     }
@@ -291,12 +297,10 @@ async function promptMultiChoice({
     }
 
     const deduped = uniqueList(resolved);
-    if (!allowEmpty && !deduped.length) {
-      session.write('At least one selection is required.\n');
-      continue;
-    }
-    return deduped;
+    selectedIds = deduped;
+    break;
   }
+  return selectedIds;
 }
 
 async function promptYesNo({
@@ -308,13 +312,21 @@ async function promptYesNo({
   defaultValue: boolean;
   session: PromptSession;
 }) {
-  while (true) {
+  let selected = defaultValue;
+  for (;;) {
     const answer = (await session.ask(question)).trim().toLowerCase();
-    if (!answer) return defaultValue;
-    if (['y', 'yes'].includes(answer)) return true;
-    if (['n', 'no'].includes(answer)) return false;
+    if (!answer) break;
+    if (['y', 'yes'].includes(answer)) {
+      selected = true;
+      break;
+    }
+    if (['n', 'no'].includes(answer)) {
+      selected = false;
+      break;
+    }
     session.write(`Please answer yes or no.\n`);
   }
+  return selected;
 }
 
 async function promptWorkspaceLanguageOverrides({

--- a/src/cli/init.test.ts
+++ b/src/cli/init.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { initCommand } from './init.ts';
+import { initCommand, upsertWorkspaceLanguageOverrides } from './init.ts';
 import type { CliFlags, Registry, WorkspaceConfig } from './types.ts';
 import type { InitPromptIO } from './init-guided.ts';
 
@@ -170,4 +170,37 @@ test('initCommand guided flow writes monorepo language override configs', async 
   assert.equal(serviceConfig.extends, '../../ailib.config.json');
 
   await assert.rejects(fs.readFile(path.join(rootDir, 'apps', 'web', 'ailib.config.json'), 'utf8'));
+});
+
+test('upsertWorkspaceLanguageOverrides updates existing workspace config', async () => {
+  const rootDir = await tempDir();
+  const workspaceDir = path.join(rootDir, 'services', 'ml');
+  await fs.mkdir(workspaceDir, { recursive: true });
+  await fs.writeFile(
+    path.join(workspaceDir, 'ailib.config.json'),
+    JSON.stringify(
+      {
+        $schema: 'https://ailib.dev/schema/config.schema.json',
+        extends: '../../ailib.config.json',
+        docs_path: './docs/',
+        modules: ['ruff']
+      },
+      null,
+      2
+    ) + '\n',
+    'utf8'
+  );
+
+  await upsertWorkspaceLanguageOverrides({
+    rootDir,
+    configFile: 'ailib.config.json',
+    defaultLanguage: 'typescript',
+    workspaceLanguageOverrides: { 'services/ml': 'python' }
+  });
+
+  const updated = JSON.parse(
+    await fs.readFile(path.join(workspaceDir, 'ailib.config.json'), 'utf8')
+  ) as WorkspaceConfig;
+  assert.equal(updated.language, 'python');
+  assert.deepEqual(updated.modules, ['ruff']);
 });

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { createInterface } from 'node:readline/promises';
 import { ensure } from './assertions.ts';
 import { detectProjectRoot, findNearestMonorepoRoot } from './context-resolution.ts';
 import { getStringFlag } from './flags.ts';
@@ -60,6 +61,7 @@ export async function initCommand({
     const defaultWorkspacePatterns = flags.bare === true ? [] : splitCsv(flags.workspaces);
     const workspacePatterns =
       flags.bare === true ? [] : defaultWorkspacePatterns.length ? defaultWorkspacePatterns : ['apps/*', 'services/*'];
+    const guidedPromptIO = promptIO || createDefaultPromptIO();
     const guided = await resolveGuidedInitSelections({
       registry,
       rootDir: projectRoot,
@@ -72,7 +74,7 @@ export async function initCommand({
         targets,
         skills
       },
-      promptIO
+      promptIO: guidedPromptIO
     });
     language = guided.language;
     modules = guided.modules;
@@ -152,7 +154,19 @@ export async function initCommand({
   process.stdout.write('ailib initialized\n');
 }
 
-async function upsertWorkspaceLanguageOverrides({
+function createDefaultPromptIO(): InitPromptIO {
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout
+  });
+  return {
+    ask: rl.question.bind(rl),
+    write: process.stdout.write.bind(process.stdout),
+    close: rl.close.bind(rl)
+  };
+}
+
+export async function upsertWorkspaceLanguageOverrides({
   rootDir,
   configFile,
   defaultLanguage,


### PR DESCRIPTION
## Summary
- add focused guided-init tests for previously uncovered prompt and workspace-discovery branches
- refactor guided prompt loops to avoid unreachable loop endings while preserving behavior
- export and test workspace language override upsert helper to cover existing-config update path

## Test plan
- [x] bun test src/cli/init-guided.test.ts src/cli/init.test.ts
- [x] bun run coverage:check
- [x] bun run check

Refs #351

Made with [Cursor](https://cursor.com)