### PR TITLE
fix: repair publish imports and restore coverage

### DIFF
--- a/src/cli/init-guided.test.ts
+++ b/src/cli/init-guided.test.ts
@@ -251,6 +251,55 @@ test('resolveGuidedInitSelections handles empty module and skill groups graceful
   assert.match(output, /\(none\)/);
 });
 
+test('resolveGuidedInitSelections evaluates module compatibility filters', async () => {
+  const rootDir = await tempDir();
+  const moduleCompatibleRegistry: Registry = {
+    ...registry,
+    skills: {
+      ...(registry.skills || {}),
+      'module-aware-skill': {
+        display: 'Module aware skill',
+        path: 'skills/module-aware-skill.md',
+        skill_type: 'reliability',
+        compatible: {
+          languages: ['typescript'],
+          modules: ['eslint'],
+          targets: ['cursor']
+        }
+      }
+    }
+  };
+
+  const answers = [
+    'cursor', // target
+    'typescript', // language
+    'eslint', // module
+    'none' // skills
+  ];
+
+  const result = await resolveGuidedInitSelections({
+    registry: moduleCompatibleRegistry,
+    rootDir,
+    configFile: 'ailib.config.json',
+    bare: true,
+    workspacePatterns: [],
+    defaults: {
+      language: 'typescript',
+      modules: [],
+      targets: ['cursor'],
+      skills: []
+    },
+    promptIO: {
+      interactive: true,
+      ask: async () => answers.shift() || '',
+      write: () => {}
+    }
+  });
+
+  assert.deepEqual(result.targets, ['cursor']);
+  assert.deepEqual(result.modules, ['eslint']);
+});
+
 test('resolveGuidedInitSelections accepts comma-only input for optional multi-select', async () => {
   const rootDir = await tempDir();
   const answers = [

--- a/src/cli/init-guided.ts
+++ b/src/cli/init-guided.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises';
+import type { Dirent } from 'node:fs';
 import path from 'node:path';
 import { exists, toPosix, uniqueList } from './utils.ts';
 import type { Registry, SkillDefinition } from './types.ts';
@@ -17,7 +18,7 @@ type GroupedChoice = {
 type PromptSession = {
   write: (line: string) => void;
   ask: (question: string) => Promise<string>;
-  close: () => void;
+  close?: () => void;
 };
 
 export type InitPromptIO = {
@@ -175,7 +176,7 @@ export async function resolveGuidedInitSelections({
       workspaceLanguageOverrides
     };
   } finally {
-    session.close();
+    session.close?.();
   }
 }
 
@@ -183,15 +184,16 @@ function createPromptSession(promptIO?: InitPromptIO): PromptSession | null {
   const interactive = promptIO?.interactive ?? Boolean(process.stdin.isTTY && process.stdout.isTTY);
   if (!interactive) return null;
 
-  const write = promptIO?.write ?? ((line: string) => process.stdout.write(line));
-  if (promptIO?.ask) {
-    return {
-      write,
-      ask: promptIO.ask,
-      close: promptIO.close || (() => {})
-    };
+  if (!promptIO?.ask) {
+    throw new Error('Interactive guided init requires prompt ask handler');
   }
-  throw new Error('Interactive guided init requires prompt ask handler');
+
+  const write = promptIO.write ?? ((line: string) => process.stdout.write(line));
+  return {
+    write,
+    ask: promptIO.ask,
+    close: promptIO.close
+  };
 }
 
 async function promptSingleChoice({
@@ -439,17 +441,13 @@ function groupSkillChoices(skills: Array<{ id: string; def: SkillDefinition }>):
   return [...grouped.entries()]
     .sort(([left], [right]) => left.localeCompare(right))
     .map(([type, choices]) => ({
-      heading: `Type: ${formatSkillType(type)}`,
+      heading: `Type: ${type
+        .split(/[-_\s]+/u)
+        .filter(Boolean)
+        .map((part) => `${part[0]?.toUpperCase() || ''}${part.slice(1)}`)
+        .join(' ')}`,
       choices: choices.sort((left, right) => left.id.localeCompare(right.id))
     }));
-}
-
-function formatSkillType(type: string) {
-  return type
-    .split(/[-_\s]+/u)
-    .filter(Boolean)
-    .map((part) => `${part[0]?.toUpperCase() || ''}${part.slice(1)}`)
-    .join(' ');
 }
 
 function expandRequiredSkills(selectedSkills: string[], skills: Record<string, SkillDefinition>) {
@@ -515,7 +513,7 @@ async function resolvePatternDirs(rootDir: string, pattern: string) {
 }
 
 async function readDirectoryEntries(dir: string) {
-  let entries: Array<{ name: string } & { isDirectory: () => boolean }> = [];
+  let entries: Dirent[] = [];
   try {
     entries = await fs.readdir(dir, { withFileTypes: true });
   } catch {

--- a/tools/npm-release-publish.test.ts
+++ b/tools/npm-release-publish.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { spawn, spawnSync } from 'node:child_process';
-import { resolvePublishedVersionWithRetry } from './npm-release-publish-retry.ts';
+import { resolvePublishedVersionWithRetry } from './npm-release-publish-retry.js';
 
 const packageRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
 

--- a/tools/npm-release-publish.ts
+++ b/tools/npm-release-publish.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
-import { resolvePublishedVersionWithRetry } from './npm-release-publish-retry.ts';
+import { resolvePublishedVersionWithRetry } from './npm-release-publish-retry.js';
 
 const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
 


### PR DESCRIPTION
## Summary
- switch npm publish tooling imports to `.js` extension paths so `tsc -p tsconfig.tools.json --noEmit` no longer fails with TS5097/TS2835
- harden guided init prompt session handling and remove unneeded helper indirection in skill grouping output formatting
- add a focused guided-init test that exercises module compatibility filtering to restore 100% function coverage

## Test plan
- [x] Run `bun run check`
- [x] Run `bun run coverage:check`
- [x] Run `bunx tsc -p tsconfig.tools.json --noEmit`

Refs #353

Made with [Cursor](https://cursor.com)