### PR TITLE
feat: add keyboard init onboarding picker

### DIFF
--- a/src/cli/init-guided.test.ts
+++ b/src/cli/init-guided.test.ts
@@ -508,3 +508,111 @@ test('resolveGuidedInitSelections aborts when user cancels after summary review'
     /Guided init cancelled by user/
   );
 });
+
+test('resolveGuidedInitSelections uses custom selector handlers when provided', async () => {
+  const rootDir = await tempDir();
+  const calls: string[] = [];
+  const result = await resolveGuidedInitSelections({
+    registry,
+    rootDir,
+    configFile: 'ailib.config.json',
+    bare: true,
+    workspacePatterns: [],
+    defaults: {
+      language: 'typescript',
+      modules: [],
+      targets: ['cursor'],
+      skills: []
+    },
+    promptIO: {
+      interactive: true,
+      ask: async () => '',
+      write: () => {},
+      selectMany: async ({ title }) => {
+        calls.push(`multi:${title}`);
+        if (title === 'Targets') return ['cursor'];
+        if (title === 'Modules (typescript)') return ['eslint'];
+        if (title === 'Skills') return ['incident-review'];
+        return [];
+      },
+      selectOne: async ({ title }) => {
+        calls.push(`single:${title}`);
+        if (title === 'Default language') return 'typescript';
+        throw new Error(`Unexpected single select: ${title}`);
+      },
+      confirm: async ({ question, defaultValue }) => {
+        calls.push(`confirm:${question}:${String(defaultValue)}`);
+        return true;
+      }
+    }
+  });
+
+  assert.deepEqual(result.targets, ['cursor']);
+  assert.equal(result.language, 'typescript');
+  assert.deepEqual(result.modules, ['eslint']);
+  assert.deepEqual(result.skills, ['incident-review']);
+  assert.ok(calls.includes('single:Default language'));
+  assert.ok(calls.includes('multi:Targets'));
+  assert.ok(calls.includes('multi:Modules (typescript)'));
+  assert.ok(calls.includes('multi:Skills'));
+});
+
+test('resolveGuidedInitSelections rejects invalid single-choice id from selector handler', async () => {
+  const rootDir = await tempDir();
+  await assert.rejects(
+    resolveGuidedInitSelections({
+      registry,
+      rootDir,
+      configFile: 'ailib.config.json',
+      bare: true,
+      workspacePatterns: [],
+      defaults: {
+        language: 'typescript',
+        modules: [],
+        targets: ['cursor'],
+        skills: []
+      },
+      promptIO: {
+        interactive: true,
+        ask: async () => '',
+        write: () => {},
+        selectMany: async ({ title }) => (title === 'Targets' ? ['cursor'] : []),
+        selectOne: async () => 'not-a-language',
+        confirm: async () => true
+      }
+    }),
+    /Invalid selection 'not-a-language' for Default language/
+  );
+});
+
+test('resolveGuidedInitSelections rejects invalid multi-choice id from selector handler', async () => {
+  const rootDir = await tempDir();
+  await assert.rejects(
+    resolveGuidedInitSelections({
+      registry,
+      rootDir,
+      configFile: 'ailib.config.json',
+      bare: true,
+      workspacePatterns: [],
+      defaults: {
+        language: 'typescript',
+        modules: [],
+        targets: ['cursor'],
+        skills: []
+      },
+      promptIO: {
+        interactive: true,
+        ask: async () => '',
+        write: () => {},
+        selectMany: async ({ title }) => {
+          if (title === 'Targets') return ['cursor'];
+          if (title === 'Modules (typescript)') return ['not-a-module'];
+          return [];
+        },
+        selectOne: async () => 'typescript',
+        confirm: async () => true
+      }
+    }),
+    /Invalid selection 'not-a-module' for Modules \(typescript\)/
+  );
+});

--- a/src/cli/init-guided.ts
+++ b/src/cli/init-guided.ts
@@ -18,6 +18,15 @@ type GroupedChoice = {
 type PromptSession = {
   write: (line: string) => void;
   ask: (question: string) => Promise<string>;
+  selectOne?: (args: { title: string; choices: Choice[]; defaultId?: string }) => Promise<string>;
+  selectMany?: (args: {
+    title: string;
+    groups: GroupedChoice[];
+    defaultIds: string[];
+    allowEmpty: boolean;
+    emptyLabel: string;
+  }) => Promise<string[]>;
+  confirm?: (args: { question: string; defaultValue: boolean }) => Promise<boolean>;
   close?: () => void;
 };
 
@@ -25,6 +34,15 @@ export type InitPromptIO = {
   interactive?: boolean;
   ask?: (question: string) => Promise<string>;
   write?: (line: string) => void;
+  selectOne?: (args: { title: string; choices: Choice[]; defaultId?: string }) => Promise<string>;
+  selectMany?: (args: {
+    title: string;
+    groups: GroupedChoice[];
+    defaultIds: string[];
+    allowEmpty: boolean;
+    emptyLabel: string;
+  }) => Promise<string[]>;
+  confirm?: (args: { question: string; defaultValue: boolean }) => Promise<boolean>;
   close?: () => void;
 };
 
@@ -258,6 +276,9 @@ function createPromptSession(promptIO?: InitPromptIO): PromptSession | null {
   return {
     write,
     ask: promptIO.ask,
+    selectOne: promptIO.selectOne,
+    selectMany: promptIO.selectMany,
+    confirm: promptIO.confirm,
     close: promptIO.close
   };
 }
@@ -277,6 +298,17 @@ async function promptSingleChoice({
     throw new Error(`No available choices for ${title}`);
   }
   const fallback = defaultId && choices.some((choice) => choice.id === defaultId) ? defaultId : choices[0].id;
+  if (session.selectOne) {
+    const selectedId = await session.selectOne({
+      title,
+      choices,
+      defaultId: fallback
+    });
+    if (!choices.some((choice) => choice.id === selectedId)) {
+      throw new Error(`Invalid selection '${selectedId}' for ${title}`);
+    }
+    return selectedId;
+  }
   const indexMap = renderChoices([{ heading: title, choices }], session);
   let selectedId = fallback;
   for (;;) {
@@ -311,6 +343,24 @@ async function promptMultiChoice({
   const availableChoices = groups.flatMap((group) => group.choices);
   const availableSet = new Set(availableChoices.map((choice) => choice.id));
   const defaults = uniqueList(defaultIds.filter((id) => availableSet.has(id)));
+  if (session.selectMany) {
+    const selectedIds = await session.selectMany({
+      title,
+      groups,
+      defaultIds: defaults,
+      allowEmpty,
+      emptyLabel
+    });
+    const deduped = uniqueList(selectedIds);
+    const invalid = deduped.find((id) => !availableSet.has(id));
+    if (invalid) {
+      throw new Error(`Invalid selection '${invalid}' for ${title}`);
+    }
+    if (!allowEmpty && !deduped.length) {
+      throw new Error(`At least one selection is required for ${title}`);
+    }
+    return deduped;
+  }
   const indexMap = renderChoices(groups.length ? groups : [{ heading: title, choices: [] }], session);
   if (!indexMap.length) {
     session.write(`${title}: no compatible options.\n`);
@@ -380,6 +430,9 @@ async function promptYesNo({
   defaultValue: boolean;
   session: PromptSession;
 }) {
+  if (session.confirm) {
+    return await session.confirm({ question, defaultValue });
+  }
   let selected = defaultValue;
   for (;;) {
     const answer = (await session.ask(question)).trim().toLowerCase();

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { emitKeypressEvents } from 'node:readline';
 import { createInterface } from 'node:readline/promises';
 import { ensure } from './assertions.ts';
 import { detectProjectRoot, findNearestMonorepoRoot } from './context-resolution.ts';
@@ -154,17 +155,220 @@ export async function initCommand({
   process.stdout.write('ailib initialized\n');
 }
 
+/* c8 ignore start - interactive TTY keyboard handling is not deterministic in unit tests */
 function createDefaultPromptIO(): InitPromptIO {
   const rl = createInterface({
     input: process.stdin,
     output: process.stdout
   });
+  const input = process.stdin as NodeJS.ReadStream;
+  const output = process.stdout as NodeJS.WriteStream;
+  const clearRenderedLines = (lineCount: number) => {
+    if (lineCount <= 0) return;
+    output.write(`\x1b[${String(lineCount)}A`);
+    output.write('\x1b[0J');
+  };
+  const readKeypress = () =>
+    new Promise<{ name?: string; ctrl?: boolean }>((resolve) => {
+      const onKeypress = (_chunk: string, key: { name?: string; ctrl?: boolean } = {}) => {
+        input.off('keypress', onKeypress);
+        resolve(key);
+      };
+      input.on('keypress', onKeypress);
+    });
+  const withRawInput = async <T>(fn: () => Promise<T>) => {
+    const supportsRaw = Boolean(input.isTTY && typeof input.setRawMode === 'function');
+    const previousRaw = (input as NodeJS.ReadStream & { isRaw?: boolean }).isRaw === true;
+    emitKeypressEvents(input);
+    if (supportsRaw) input.setRawMode(true);
+    input.resume();
+    try {
+      return await fn();
+    } finally {
+      if (supportsRaw) input.setRawMode(previousRaw);
+    }
+  };
+  const runInteractiveSelect = async ({
+    title,
+    groups,
+    selectedIds,
+    single,
+    allowEmpty
+  }: {
+    title: string;
+    groups: Array<{ heading: string; choices: Array<{ id: string; label: string; description?: string }> }>;
+    selectedIds: string[];
+    single: boolean;
+    allowEmpty: boolean;
+  }) => {
+    const choices = groups.flatMap((group) => group.choices);
+    if (!choices.length) {
+      output.write(`${title}: no compatible options.\n`);
+      return [];
+    }
+
+    const selected = new Set(single ? [selectedIds[0] || choices[0].id] : selectedIds.filter(Boolean));
+    let cursor = Math.max(
+      0,
+      choices.findIndex((choice) => selected.has(choice.id))
+    );
+    let warning = '';
+    let renderedLines = 0;
+
+    const render = () => {
+      clearRenderedLines(renderedLines);
+      const lines = [
+        '',
+        title,
+        single
+          ? 'Use up/down arrows to move, space to select, enter to confirm.'
+          : 'Use up/down arrows to move, space to toggle, enter to confirm.'
+      ];
+      if (warning) lines.push(warning);
+
+      let index = 0;
+      for (const group of groups) {
+        lines.push('');
+        lines.push(group.heading);
+        if (!group.choices.length) {
+          lines.push('  (none)');
+          continue;
+        }
+        for (const choice of group.choices) {
+          const cursorMark = index === cursor ? '>' : ' ';
+          const selectedMark = single
+            ? selected.has(choice.id)
+              ? '(*)'
+              : '( )'
+            : selected.has(choice.id)
+              ? '[x]'
+              : '[ ]';
+          const description = choice.description ? ` - ${choice.description}` : '';
+          lines.push(` ${cursorMark} ${selectedMark} ${choice.label}${description}`);
+          index += 1;
+        }
+      }
+      output.write(`${lines.join('\n')}\n`);
+      renderedLines = lines.length;
+    };
+
+    await withRawInput(async () => {
+      render();
+      for (;;) {
+        const key = await readKeypress();
+        if (key.ctrl && key.name === 'c') {
+          throw new Error('Guided init cancelled by user');
+        }
+        if (key.name === 'up') {
+          cursor = (cursor - 1 + choices.length) % choices.length;
+          warning = '';
+          render();
+          continue;
+        }
+        if (key.name === 'down') {
+          cursor = (cursor + 1) % choices.length;
+          warning = '';
+          render();
+          continue;
+        }
+        if (key.name === 'space') {
+          const current = choices[cursor];
+          if (single) {
+            selected.clear();
+            selected.add(current.id);
+            warning = '';
+          } else if (selected.has(current.id)) {
+            if (!allowEmpty && selected.size === 1) {
+              warning = 'At least one selection is required.';
+            } else {
+              selected.delete(current.id);
+              warning = '';
+            }
+          } else {
+            selected.add(current.id);
+            warning = '';
+          }
+          render();
+          continue;
+        }
+        if (key.name === 'return' || key.name === 'enter') {
+          if (!allowEmpty && selected.size === 0) {
+            warning = 'At least one selection is required.';
+            render();
+            continue;
+          }
+          break;
+        }
+      }
+    });
+
+    clearRenderedLines(renderedLines);
+    const ordered = choices.map((choice) => choice.id).filter((id) => selected.has(id));
+    if (single) {
+      const selectedLabel = choices.find((choice) => choice.id === ordered[0])?.label || ordered[0];
+      output.write(`${title}: ${selectedLabel}\n`);
+    } else {
+      const selectedLabels = choices
+        .filter((choice) => selected.has(choice.id))
+        .map((choice) => choice.label)
+        .join(', ');
+      output.write(`${title}: ${selectedLabels || 'none'}\n`);
+    }
+    return ordered;
+  };
+
+  type SelectOneArgs = Parameters<NonNullable<InitPromptIO['selectOne']>>[0];
+  type SelectManyArgs = Parameters<NonNullable<InitPromptIO['selectMany']>>[0];
+  type ConfirmArgs = Parameters<NonNullable<InitPromptIO['confirm']>>[0];
+
+  const selectOne = async (args: SelectOneArgs) => {
+    const selected = await runInteractiveSelect({
+      title: args.title,
+      groups: [{ heading: args.title, choices: args.choices }],
+      selectedIds: [args.defaultId || args.choices[0]?.id || ''],
+      single: true,
+      allowEmpty: false
+    });
+    return selected[0];
+  };
+  const selectMany = async (args: SelectManyArgs) => {
+    return await runInteractiveSelect({
+      title: args.title,
+      groups: args.groups,
+      selectedIds: args.defaultIds,
+      single: false,
+      allowEmpty: args.allowEmpty
+    });
+  };
+  const confirm = async ({ question, defaultValue }: ConfirmArgs) => {
+    const normalizedQuestion = question.replace(/\s*\[[^\]]+\]:?\s*$/u, '').trim() || 'Confirm';
+    const selected = await runInteractiveSelect({
+      title: normalizedQuestion,
+      groups: [
+        {
+          heading: normalizedQuestion,
+          choices: [
+            { id: 'yes', label: 'Yes' },
+            { id: 'no', label: 'No' }
+          ]
+        }
+      ],
+      selectedIds: [defaultValue ? 'yes' : 'no'],
+      single: true,
+      allowEmpty: false
+    });
+    return selected[0] === 'yes';
+  };
   return {
     ask: rl.question.bind(rl),
     write: process.stdout.write.bind(process.stdout),
+    selectOne,
+    selectMany,
+    confirm,
     close: rl.close.bind(rl)
   };
 }
+/* c8 ignore stop */
 
 export async function upsertWorkspaceLanguageOverrides({
   rootDir,


### PR DESCRIPTION
## Summary
- add keyboard-driven onboarding selectors for `ailib init` with up/down navigation, space toggle/select, enter confirm, and Ctrl+C cancel
- wire selector hooks through guided init so interactive TTYs use picker UX while existing prompt fallback remains available
- add guided-init tests that validate selector hook execution and invalid selector return handling

## Test plan
- [x] Run `bun test src/cli/init-guided.test.ts src/cli/init.test.ts test/cli.test.ts`
- [x] Run `bun run check`
- [x] Run `bun run coverage:check`

Refs #360

Made with [Cursor](https://cursor.com)