### PR TITLE
feat: improve init onboarding UX flow

### DIFF
--- a/docs/cli-usage-guide.md
+++ b/docs/cli-usage-guide.md
@@ -38,10 +38,29 @@ ailib init
 
 The guided flow asks for:
 
+- optional preset selection from `.ailib/init-presets.json` (when presets exist)
 - targets (multi-select)
 - default language
 - modules (multi-select)
 - skills grouped by `skill_type` (multi-select)
+- optional workspace language overrides (monorepo)
+
+Interactive picker UX includes:
+
+- arrow-key navigation
+- space to toggle/select
+- inline filter by typing (Backspace edits, Esc clears)
+- `Ctrl+A` to select all and `Ctrl+U` to clear (multi-select prompts)
+- `?` to toggle shortcut help
+
+Before apply, onboarding shows a summary plus a dry-run preview of files that will be created or updated.  
+No files are written until you explicitly confirm with `y` or `n` at the final apply prompt.
+
+After confirming apply, onboarding can optionally save the chosen setup as a named preset in:
+
+```text
+.ailib/init-presets.json
+```
 
 To preselect skills directly in non-interactive mode, use `--skills`:
 

--- a/src/cli/init-guided.test.ts
+++ b/src/cli/init-guided.test.ts
@@ -91,7 +91,8 @@ test('resolveGuidedInitSelections retries invalid input and auto-adds required s
     '3', // release-readiness (auto-add architecture dependency)
     'maybe', // invalid yes/no answer
     'y', // confirm workspace overrides
-    '1' // services/ml language = python
+    '1', // services/ml language = python
+    'y' // apply summary
   ];
   const writes: string[] = [];
   const result = await resolveGuidedInitSelections({
@@ -184,7 +185,8 @@ test('resolveGuidedInitSelections supports id tokens and retries invalid multi-s
     'invalid-language', // invalid single choice token
     'typescript', // id token (non-numeric) for language
     'eslint', // id token for modules
-    'none' // explicit empty skills
+    'none', // explicit empty skills
+    'y' // apply summary
   ];
   const writes: string[] = [];
   const result = await resolveGuidedInitSelections({
@@ -222,6 +224,13 @@ test('resolveGuidedInitSelections handles empty module and skill groups graceful
       go: { modules: {} }
     }
   };
+  const answers = [
+    '', // targets defaults
+    '', // language default
+    '', // modules default
+    '', // skills default
+    'y' // apply summary
+  ];
   const writes: string[] = [];
   const result = await resolveGuidedInitSelections({
     registry: goOnlyRegistry,
@@ -237,7 +246,7 @@ test('resolveGuidedInitSelections handles empty module and skill groups graceful
     },
     promptIO: {
       interactive: true,
-      ask: async () => '',
+      ask: async () => answers.shift() || '',
       write: (line: string) => writes.push(line)
     }
   });
@@ -274,7 +283,8 @@ test('resolveGuidedInitSelections evaluates module compatibility filters', async
     'cursor', // target
     'typescript', // language
     'eslint', // module
-    'none' // skills
+    'none', // skills
+    'y' // apply summary
   ];
 
   const result = await resolveGuidedInitSelections({
@@ -306,7 +316,8 @@ test('resolveGuidedInitSelections accepts comma-only input for optional multi-se
     '1', // target
     '2', // typescript
     ',', // modules (allowEmpty=true, empty token set)
-    '' // skills defaults
+    '', // skills defaults
+    'y' // apply summary
   ];
   const result = await resolveGuidedInitSelections({
     registry,
@@ -340,7 +351,8 @@ test('resolveGuidedInitSelections traverses double-star patterns and ignores mis
     '2', // typescript
     '', // modules
     '', // skills
-    'n' // skip workspace language override configuration
+    'n', // skip workspace language override configuration
+    'y' // apply summary
   ];
   const result = await resolveGuidedInitSelections({
     registry,
@@ -411,7 +423,8 @@ test('resolveGuidedInitSelections supports default writer when prompt write is o
     '', // targets defaults
     '', // language default
     '', // modules default
-    '' // skills default
+    '', // skills default
+    'y' // apply summary
   ];
   const result = await resolveGuidedInitSelections({
     registry,
@@ -433,6 +446,134 @@ test('resolveGuidedInitSelections supports default writer when prompt write is o
 
   assert.deepEqual(result.modules, ['eslint']);
   assert.deepEqual(result.targets, ['cursor']);
+});
+
+test('resolveGuidedInitSelections can load defaults from saved preset', async () => {
+  const rootDir = await tempDir();
+  await fs.mkdir(path.join(rootDir, '.ailib'), { recursive: true });
+  await fs.writeFile(
+    path.join(rootDir, '.ailib', 'init-presets.json'),
+    `${JSON.stringify(
+      {
+        version: 1,
+        presets: {
+          'python-default': {
+            language: 'python',
+            modules: ['ruff'],
+            targets: ['claude-code'],
+            skills: [],
+            workspaceLanguageOverrides: {}
+          }
+        }
+      },
+      null,
+      2
+    )}\n`,
+    'utf8'
+  );
+  const answers = [
+    'y', // load preset
+    '1', // choose python-default
+    '', // targets (preset default)
+    '', // language (preset default)
+    '', // modules (preset default)
+    '', // skills (preset default)
+    'y' // apply summary
+  ];
+  const result = await resolveGuidedInitSelections({
+    registry,
+    rootDir,
+    configFile: 'ailib.config.json',
+    bare: true,
+    workspacePatterns: [],
+    defaults: {
+      language: 'typescript',
+      modules: ['eslint'],
+      targets: ['cursor'],
+      skills: ['architecture-decision-flow']
+    },
+    promptIO: {
+      interactive: true,
+      ask: async () => answers.shift() || '',
+      write: () => {}
+    }
+  });
+
+  assert.equal(result.language, 'python');
+  assert.deepEqual(result.targets, ['claude-code']);
+  assert.deepEqual(result.modules, ['ruff']);
+});
+
+test('resolveGuidedInitSelections can save selected preset after apply', async () => {
+  const rootDir = await tempDir();
+  const answers = [
+    '2', // target = cursor
+    '2', // language = typescript
+    '1', // module = biome
+    'none', // skills
+    'y', // apply summary
+    'y', // save preset
+    'team-default' // preset name
+  ];
+  await resolveGuidedInitSelections({
+    registry,
+    rootDir,
+    configFile: 'ailib.config.json',
+    bare: true,
+    workspacePatterns: [],
+    defaults: {
+      language: 'typescript',
+      modules: [],
+      targets: ['cursor'],
+      skills: []
+    },
+    promptIO: {
+      interactive: true,
+      ask: async () => answers.shift() || '',
+      write: () => {}
+    }
+  });
+
+  const raw = await fs.readFile(path.join(rootDir, '.ailib', 'init-presets.json'), 'utf8');
+  const parsed = JSON.parse(raw) as {
+    presets?: Record<string, { language: string; modules: string[]; targets: string[] }>;
+  };
+  assert.equal(parsed.presets?.['team-default']?.language, 'typescript');
+  assert.deepEqual(parsed.presets?.['team-default']?.modules, ['biome']);
+  assert.deepEqual(parsed.presets?.['team-default']?.targets, ['cursor']);
+});
+
+test('resolveGuidedInitSelections requires explicit yes or no for final apply in text mode', async () => {
+  const rootDir = await tempDir();
+  const answers = [
+    '', // targets defaults
+    '', // language default
+    '', // modules default
+    '', // skills default
+    '', // invalid for explicit final apply
+    'y' // apply summary
+  ];
+  const writes: string[] = [];
+  await resolveGuidedInitSelections({
+    registry,
+    rootDir,
+    configFile: 'ailib.config.json',
+    bare: true,
+    workspacePatterns: [],
+    defaults: {
+      language: 'typescript',
+      modules: ['eslint'],
+      targets: ['cursor'],
+      skills: []
+    },
+    promptIO: {
+      interactive: true,
+      ask: async () => answers.shift() || '',
+      write: (line: string) => writes.push(line)
+    }
+  });
+
+  assert.match(writes.join(''), /Please answer yes or no\./);
 });
 
 test('resolveGuidedInitSelections restarts onboarding when user rejects summary', async () => {
@@ -473,6 +614,7 @@ test('resolveGuidedInitSelections restarts onboarding when user rejects summary'
   assert.deepEqual(result.targets, ['cursor']);
   assert.equal(result.language, 'python');
   assert.match(writes.join(''), /Review your onboarding selections/);
+  assert.match(writes.join(''), /No files will be created or updated until you confirm apply\./);
   assert.match(writes.join(''), /Restarting guided onboarding/);
 });
 
@@ -540,9 +682,9 @@ test('resolveGuidedInitSelections uses custom selector handlers when provided', 
         if (title === 'Default language') return 'typescript';
         throw new Error(`Unexpected single select: ${title}`);
       },
-      confirm: async ({ question, defaultValue }) => {
-        calls.push(`confirm:${question}:${String(defaultValue)}`);
-        return true;
+      confirm: async ({ question, defaultValue, requireExplicit }) => {
+        calls.push(`confirm:${question}:${String(defaultValue)}:${String(requireExplicit)}`);
+        return question.startsWith('Apply this setup?');
       }
     }
   });
@@ -555,6 +697,7 @@ test('resolveGuidedInitSelections uses custom selector handlers when provided', 
   assert.ok(calls.includes('multi:Targets'));
   assert.ok(calls.includes('multi:Modules (typescript)'));
   assert.ok(calls.includes('multi:Skills'));
+  assert.ok(calls.some((entry) => entry.startsWith('confirm:Apply this setup? [y/n]: :false:true')));
 });
 
 test('resolveGuidedInitSelections rejects invalid single-choice id from selector handler', async () => {
@@ -578,7 +721,7 @@ test('resolveGuidedInitSelections rejects invalid single-choice id from selector
         write: () => {},
         selectMany: async ({ title }) => (title === 'Targets' ? ['cursor'] : []),
         selectOne: async () => 'not-a-language',
-        confirm: async () => true
+        confirm: async ({ question }) => question.startsWith('Apply this setup?')
       }
     }),
     /Invalid selection 'not-a-language' for Default language/
@@ -610,7 +753,7 @@ test('resolveGuidedInitSelections rejects invalid multi-choice id from selector 
           return [];
         },
         selectOne: async () => 'typescript',
-        confirm: async () => true
+        confirm: async ({ question }) => question.startsWith('Apply this setup?')
       }
     }),
     /Invalid selection 'not-a-module' for Modules \(typescript\)/

--- a/src/cli/init-guided.ts
+++ b/src/cli/init-guided.ts
@@ -26,7 +26,7 @@ type PromptSession = {
     allowEmpty: boolean;
     emptyLabel: string;
   }) => Promise<string[]>;
-  confirm?: (args: { question: string; defaultValue: boolean }) => Promise<boolean>;
+  confirm?: (args: { question: string; defaultValue: boolean; requireExplicit?: boolean }) => Promise<boolean>;
   close?: () => void;
 };
 
@@ -42,7 +42,7 @@ export type InitPromptIO = {
     allowEmpty: boolean;
     emptyLabel: string;
   }) => Promise<string[]>;
-  confirm?: (args: { question: string; defaultValue: boolean }) => Promise<boolean>;
+  confirm?: (args: { question: string; defaultValue: boolean; requireExplicit?: boolean }) => Promise<boolean>;
   close?: () => void;
 };
 
@@ -52,6 +52,11 @@ export type GuidedInitSelections = {
   targets: string[];
   skills: string[];
   workspaceLanguageOverrides: Record<string, string>;
+};
+
+type InitPresetStore = {
+  version: 1;
+  presets: Record<string, GuidedInitSelections>;
 };
 
 export async function resolveGuidedInitSelections({
@@ -87,11 +92,56 @@ export async function resolveGuidedInitSelections({
     };
   }
 
+  const presetsPath = path.join(rootDir, '.ailib', 'init-presets.json');
+  const presetStore = await readPresetStore(presetsPath);
+  const availableLanguageChoices = Object.entries(registry.languages)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([id]) => ({ id, label: id }));
+  const hasPresets = Object.keys(presetStore.presets).length > 0;
+  let selectedDefaults: GuidedInitSelections = {
+    language: defaults.language,
+    modules: defaults.modules,
+    targets: defaults.targets,
+    skills: defaults.skills,
+    workspaceLanguageOverrides: {}
+  };
+
   try {
     session.write('\nWelcome to ailib init onboarding\n');
-    session.write('This setup wizard helps you pick language, modules, targets, and skills.\n');
-    session.write('Use numbers or IDs. Press Enter to accept defaults.\n');
-    session.write('For multi-select prompts, use comma-separated values.\n');
+    session.write('This guided setup helps you choose targets, language, modules, and skills.\n');
+    session.write('You can restart before applying, and nothing is written until apply is confirmed.\n');
+    session.write('Use numbers or IDs in text mode. For multi-select prompts, use comma-separated values.\n');
+
+    if (hasPresets) {
+      session.write('\nStep 0/6: Presets (optional)\n');
+      const usePreset = await promptYesNo({
+        question: 'Load a saved preset first? [y/N]: ',
+        defaultValue: false,
+        session
+      });
+      if (usePreset) {
+        const presetChoices = Object.keys(presetStore.presets)
+          .sort((left, right) => left.localeCompare(right))
+          .map((name) => ({ id: name, label: name }));
+        const presetName = await promptSingleChoice({
+          title: 'Saved presets',
+          choices: presetChoices,
+          defaultId: presetChoices[0]?.id,
+          session
+        });
+        const preset = presetStore.presets[presetName];
+        if (preset) {
+          selectedDefaults = {
+            language: preset.language,
+            modules: preset.modules,
+            targets: preset.targets,
+            skills: preset.skills,
+            workspaceLanguageOverrides: preset.workspaceLanguageOverrides
+          };
+          session.write(`Loaded preset '${presetName}'.\n`);
+        }
+      }
+    }
 
     for (;;) {
       session.write('\nStep 1/5: Choose targets\n');
@@ -109,7 +159,7 @@ export async function resolveGuidedInitSelections({
               }))
           }
         ],
-        defaultIds: defaults.targets,
+        defaultIds: selectedDefaults.targets,
         allowEmpty: false,
         emptyLabel: 'none',
         session
@@ -118,10 +168,8 @@ export async function resolveGuidedInitSelections({
       session.write('\nStep 2/5: Choose default language\n');
       const language = await promptSingleChoice({
         title: 'Default language',
-        choices: Object.entries(registry.languages)
-          .sort(([a], [b]) => a.localeCompare(b))
-          .map(([id]) => ({ id, label: id })),
-        defaultId: defaults.language,
+        choices: availableLanguageChoices,
+        defaultId: selectedDefaults.language,
         session
       });
 
@@ -140,7 +188,7 @@ export async function resolveGuidedInitSelections({
               }))
           }
         ],
-        defaultIds: defaults.modules,
+        defaultIds: selectedDefaults.modules,
         allowEmpty: true,
         emptyLabel: 'none',
         session
@@ -157,7 +205,7 @@ export async function resolveGuidedInitSelections({
       const skills = await promptMultiChoice({
         title: 'Skills',
         groups: groupedSkillChoices,
-        defaultIds: defaults.skills.filter((id) => compatibleSkills.some((skill) => skill.id === id)),
+        defaultIds: selectedDefaults.skills.filter((id) => compatibleSkills.some((skill) => skill.id === id)),
         allowEmpty: true,
         emptyLabel: 'none',
         session
@@ -173,9 +221,12 @@ export async function resolveGuidedInitSelections({
         session.write('\nStep 5/5: Workspace language overrides (optional)\n');
         const candidates = await discoverWorkspaceCandidates(rootDir, workspacePatterns);
         if (candidates.length) {
+          const hasPresetWorkspaceOverrides = Object.keys(selectedDefaults.workspaceLanguageOverrides).length > 0;
           const configureOverrides = await promptYesNo({
-            question: 'Configure workspace-specific language overrides? [y/N]: ',
-            defaultValue: false,
+            question: hasPresetWorkspaceOverrides
+              ? 'Configure workspace-specific language overrides? [Y/n]: '
+              : 'Configure workspace-specific language overrides? [y/N]: ',
+            defaultValue: hasPresetWorkspaceOverrides,
             session
           });
           if (configureOverrides) {
@@ -184,9 +235,8 @@ export async function resolveGuidedInitSelections({
               configFile,
               candidates,
               defaultLanguage: language,
-              languageChoices: Object.entries(registry.languages)
-                .sort(([a], [b]) => a.localeCompare(b))
-                .map(([id]) => ({ id, label: id })),
+              languageChoices: availableLanguageChoices,
+              initialOverrides: selectedDefaults.workspaceLanguageOverrides,
               session
             });
           }
@@ -203,13 +253,42 @@ export async function resolveGuidedInitSelections({
         workspaceLanguageOverrides,
         session
       });
+      renderPlannedFileChangesPreview({
+        configFile,
+        registry,
+        targets,
+        workspaceLanguageOverrides,
+        session
+      });
+      session.write('No files will be created or updated until you confirm apply.\n');
 
       const confirmSelection = await promptYesNo({
-        question: 'Apply this setup? [Y/n]: ',
-        defaultValue: true,
+        question: 'Apply this setup? [y/n]: ',
+        defaultValue: false,
+        requireExplicit: true,
         session
       });
       if (confirmSelection) {
+        const savePreset = await promptYesNo({
+          question: 'Save these selections as a preset for future init runs? [y/N]: ',
+          defaultValue: false,
+          session
+        });
+        if (savePreset) {
+          const presetName = await promptPresetName({
+            session,
+            existingPresetNames: Object.keys(presetStore.presets)
+          });
+          presetStore.presets[presetName] = {
+            language,
+            modules,
+            targets,
+            skills: expandedSkills,
+            workspaceLanguageOverrides
+          };
+          await writePresetStore(presetsPath, presetStore);
+          session.write(`Saved preset '${presetName}' to .ailib/init-presets.json.\n`);
+        }
         session.write('\n');
         return {
           language,
@@ -262,6 +341,38 @@ function renderOnboardingSummary({
     summaryLines.push('  - none');
   }
   session.write(`${summaryLines.join('\n')}\n`);
+}
+
+function renderPlannedFileChangesPreview({
+  configFile,
+  registry,
+  targets,
+  workspaceLanguageOverrides,
+  session
+}: {
+  configFile: string;
+  registry: Registry;
+  targets: string[];
+  workspaceLanguageOverrides: Record<string, string>;
+  session: PromptSession;
+}) {
+  const previewPaths = new Set<string>([configFile, '.ailib/**']);
+  for (const targetId of targets) {
+    const target = registry.targets[targetId];
+    if (!target) continue;
+    previewPaths.add(target.output);
+    if (target.root_output) {
+      previewPaths.add(target.root_output);
+    }
+  }
+  for (const workspace of Object.keys(workspaceLanguageOverrides)) {
+    previewPaths.add(toPosix(path.join(workspace, configFile)));
+  }
+  const previewLines = ['\nPlanned file changes after apply:'];
+  for (const previewPath of [...previewPaths].sort((left, right) => left.localeCompare(right))) {
+    previewLines.push(`  - ${previewPath}`);
+  }
+  session.write(`${previewLines.join('\n')}\n`);
 }
 
 function createPromptSession(promptIO?: InitPromptIO): PromptSession | null {
@@ -424,19 +535,27 @@ async function promptMultiChoice({
 async function promptYesNo({
   question,
   defaultValue,
+  requireExplicit,
   session
 }: {
   question: string;
   defaultValue: boolean;
+  requireExplicit?: boolean;
   session: PromptSession;
 }) {
   if (session.confirm) {
-    return await session.confirm({ question, defaultValue });
+    return await session.confirm({ question, defaultValue, requireExplicit });
   }
   let selected = defaultValue;
   for (;;) {
     const answer = (await session.ask(question)).trim().toLowerCase();
-    if (!answer) break;
+    if (!answer) {
+      if (requireExplicit) {
+        session.write('Please answer yes or no.\n');
+        continue;
+      }
+      break;
+    }
     if (['y', 'yes'].includes(answer)) {
       selected = true;
       break;
@@ -456,6 +575,7 @@ async function promptWorkspaceLanguageOverrides({
   candidates,
   defaultLanguage,
   languageChoices,
+  initialOverrides,
   session
 }: {
   rootDir: string;
@@ -463,6 +583,7 @@ async function promptWorkspaceLanguageOverrides({
   candidates: string[];
   defaultLanguage: string;
   languageChoices: Choice[];
+  initialOverrides: Record<string, string>;
   session: PromptSession;
 }) {
   const overrides: Record<string, string> = {};
@@ -476,7 +597,7 @@ async function promptWorkspaceLanguageOverrides({
     const selectedLanguage = await promptSingleChoice({
       title: `Language for workspace ${rel}`,
       choices: languageChoices,
-      defaultId: defaultLanguage,
+      defaultId: initialOverrides[rel] || defaultLanguage,
       session
     });
     if (selectedLanguage !== defaultLanguage) {
@@ -484,6 +605,98 @@ async function promptWorkspaceLanguageOverrides({
     }
   }
   return overrides;
+}
+
+async function promptPresetName({
+  session,
+  existingPresetNames
+}: {
+  session: PromptSession;
+  existingPresetNames: string[];
+}) {
+  const existing = new Set(existingPresetNames);
+  for (;;) {
+    const answer = (await session.ask('Preset name (letters, numbers, "-", "_" or "."): ')).trim();
+    if (!answer) {
+      session.write('Preset name cannot be empty.\n');
+      continue;
+    }
+    if (!/^[a-z0-9][a-z0-9._-]*$/iu.test(answer)) {
+      session.write('Invalid preset name. Use letters, numbers, "-", "_" or ".".\n');
+      continue;
+    }
+    if (!existing.has(answer)) {
+      return answer;
+    }
+    const overwrite = await promptYesNo({
+      question: `Preset '${answer}' exists. Overwrite it? [y/N]: `,
+      defaultValue: false,
+      session
+    });
+    if (overwrite) {
+      return answer;
+    }
+  }
+}
+
+async function readPresetStore(presetsPath: string): Promise<InitPresetStore> {
+  if (!(await exists(presetsPath))) {
+    return { version: 1, presets: {} };
+  }
+  let loaded: unknown = null;
+  try {
+    loaded = await readJsonSafe(presetsPath);
+  } catch {
+    return { version: 1, presets: {} };
+  }
+  const store = loaded as Partial<InitPresetStore>;
+  const rawPresets = store?.presets;
+  if (!rawPresets || typeof rawPresets !== 'object') {
+    return { version: 1, presets: {} };
+  }
+  const presets: Record<string, GuidedInitSelections> = {};
+  for (const [name, value] of Object.entries(rawPresets)) {
+    if (!value || typeof value !== 'object') continue;
+    const preset = value as Partial<GuidedInitSelections>;
+    if (
+      typeof preset.language !== 'string' ||
+      !Array.isArray(preset.modules) ||
+      !Array.isArray(preset.targets) ||
+      !Array.isArray(preset.skills)
+    ) {
+      continue;
+    }
+    const rawWorkspaceOverrides = preset.workspaceLanguageOverrides;
+    const workspaceLanguageOverrides: Record<string, string> = {};
+    if (rawWorkspaceOverrides && typeof rawWorkspaceOverrides === 'object') {
+      for (const [workspace, language] of Object.entries(rawWorkspaceOverrides)) {
+        if (typeof language === 'string' && typeof workspace === 'string') {
+          workspaceLanguageOverrides[workspace] = language;
+        }
+      }
+    }
+    presets[name] = {
+      language: preset.language,
+      modules: uniqueList(preset.modules.filter((entry): entry is string => typeof entry === 'string')),
+      targets: uniqueList(preset.targets.filter((entry): entry is string => typeof entry === 'string')),
+      skills: uniqueList(preset.skills.filter((entry): entry is string => typeof entry === 'string')),
+      workspaceLanguageOverrides
+    };
+  }
+  return {
+    version: 1,
+    presets
+  };
+}
+
+async function writePresetStore(presetsPath: string, store: InitPresetStore) {
+  await fs.mkdir(path.dirname(presetsPath), { recursive: true });
+  await fs.writeFile(presetsPath, `${JSON.stringify(store, null, 2)}\n`, 'utf8');
+}
+
+async function readJsonSafe(filePath: string) {
+  const raw = await fs.readFile(filePath, 'utf8');
+  return JSON.parse(raw) as unknown;
 }
 
 function resolveChoiceToken(token: string, indexMap: Array<{ id: string }>) {

--- a/src/cli/init.test.ts
+++ b/src/cli/init.test.ts
@@ -11,6 +11,15 @@ async function tempDir() {
   return fs.mkdtemp(path.join(os.tmpdir(), 'ailib-init-'));
 }
 
+async function fileExists(filePath: string) {
+  try {
+    await fs.stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 const registry: Registry = {
   version: 'test-registry',
   slots: ['linter'],
@@ -122,7 +131,8 @@ test('initCommand guided flow selects targets language modules and skills', asyn
       '1,2', // targets
       '2', // default language = typescript
       '1', // modules (eslint)
-      '2,1' // skills (release-readiness + task-driven-gh-flow)
+      '2,1', // skills (release-readiness + task-driven-gh-flow)
+      'y' // apply summary
     ])
   });
 
@@ -156,7 +166,8 @@ test('initCommand guided flow writes monorepo language override configs', async 
       '', // skills -> none
       'y', // configure workspace overrides
       '', // apps/web -> keep default typescript
-      '1' // services/ml -> python
+      '1', // services/ml -> python
+      'y' // apply summary
     ])
   });
 
@@ -203,4 +214,65 @@ test('upsertWorkspaceLanguageOverrides updates existing workspace config', async
   ) as WorkspaceConfig;
   assert.equal(updated.language, 'python');
   assert.deepEqual(updated.modules, ['ruff']);
+});
+
+test('initCommand waits for onboarding apply confirmation before writing files', async () => {
+  const rootDir = await tempDir();
+  await fs.writeFile(path.join(rootDir, 'package.json'), '{"name":"root"}\n', 'utf8');
+  const packageRoot = path.join(rootDir, 'pkg');
+  await fs.mkdir(packageRoot, { recursive: true });
+  await fs.writeFile(path.join(packageRoot, 'registry.json'), `${JSON.stringify(registry)}\n`, 'utf8');
+
+  let applyCalled = false;
+  let resolveConfirmReached: (() => void) | undefined;
+  const confirmReached = new Promise<void>((resolve) => {
+    resolveConfirmReached = resolve;
+  });
+  let releaseApplyConfirm: (() => void) | undefined;
+  const applyConfirmGate = new Promise<void>((resolve) => {
+    releaseApplyConfirm = resolve;
+  });
+
+  const runPromise = initCommand({
+    cwd: rootDir,
+    packageRoot,
+    flags: { _: [], bare: true } as CliFlags,
+    configFile: 'ailib.config.json',
+    canonicalSlot: (_registry, slot) => slot || null,
+    applyWorkspaceUpdate: async () => {
+      applyCalled = true;
+    },
+    promptIO: {
+      interactive: true,
+      ask: async () => '',
+      write: () => {},
+      selectMany: async ({ title }) => {
+        if (title === 'Targets') return ['cursor'];
+        if (title === 'Modules (typescript)') return ['eslint'];
+        if (title === 'Skills') return [];
+        return [];
+      },
+      selectOne: async ({ title }) => {
+        if (title === 'Default language') return 'typescript';
+        throw new Error(`Unexpected single select: ${title}`);
+      },
+      confirm: async ({ question }) => {
+        if (question.startsWith('Apply this setup?')) {
+          resolveConfirmReached?.();
+          await applyConfirmGate;
+          return true;
+        }
+        return false;
+      }
+    }
+  });
+
+  await confirmReached;
+  assert.equal(await fileExists(path.join(rootDir, 'ailib.config.json')), false);
+  assert.equal(applyCalled, false);
+
+  releaseApplyConfirm?.();
+  await runPromise;
+  assert.equal(await fileExists(path.join(rootDir, 'ailib.config.json')), true);
+  assert.equal(applyCalled, true);
 });

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -169,10 +169,13 @@ function createDefaultPromptIO(): InitPromptIO {
     output.write('\x1b[0J');
   };
   const readKeypress = () =>
-    new Promise<{ name?: string; ctrl?: boolean }>((resolve) => {
-      const onKeypress = (_chunk: string, key: { name?: string; ctrl?: boolean } = {}) => {
+    new Promise<{ name?: string; ctrl?: boolean; sequence?: string; chunk?: string }>((resolve) => {
+      const onKeypress = (chunk: string, key: { name?: string; ctrl?: boolean; sequence?: string } = {}) => {
         input.off('keypress', onKeypress);
-        resolve(key);
+        resolve({
+          ...key,
+          chunk
+        });
       };
       input.on('keypress', onKeypress);
     });
@@ -193,41 +196,96 @@ function createDefaultPromptIO(): InitPromptIO {
     groups,
     selectedIds,
     single,
-    allowEmpty
+    allowEmpty,
+    requireExplicitSingleSelection = false
   }: {
     title: string;
     groups: Array<{ heading: string; choices: Array<{ id: string; label: string; description?: string }> }>;
     selectedIds: string[];
     single: boolean;
     allowEmpty: boolean;
+    requireExplicitSingleSelection?: boolean;
   }) => {
-    const choices = groups.flatMap((group) => group.choices);
-    if (!choices.length) {
+    const allChoices = groups.flatMap((group) => group.choices);
+    if (!allChoices.length) {
       output.write(`${title}: no compatible options.\n`);
       return [];
     }
 
-    const selected = new Set(single ? [selectedIds[0] || choices[0].id] : selectedIds.filter(Boolean));
+    const selected = new Set(
+      single
+        ? selectedIds[0]
+          ? [selectedIds[0]]
+          : requireExplicitSingleSelection
+            ? []
+            : [allChoices[0].id]
+        : selectedIds.filter(Boolean)
+    );
+    let filterQuery = '';
+    let showHelp = true;
     let cursor = Math.max(
       0,
-      choices.findIndex((choice) => selected.has(choice.id))
+      allChoices.findIndex((choice) => selected.has(choice.id))
     );
+    if (cursor < 0) cursor = 0;
     let warning = '';
     let renderedLines = 0;
+    const isPrintable = (chunk: string | undefined) => Boolean(chunk && /^[\x20-\x7E]$/u.test(chunk));
+    const visibleGroups = () => {
+      const query = filterQuery.trim().toLowerCase();
+      const out: typeof groups = [];
+      for (const group of groups) {
+        const choices = group.choices.filter((choice) => {
+          if (!query) return true;
+          const searchText = `${choice.id} ${choice.label} ${choice.description || ''}`.toLowerCase();
+          return searchText.includes(query);
+        });
+        if (choices.length) {
+          out.push({
+            heading: group.heading,
+            choices
+          });
+        }
+      }
+      return out;
+    };
+    const visibleChoices = () => visibleGroups().flatMap((group) => group.choices);
+    const normalizeCursor = () => {
+      const visible = visibleChoices();
+      if (!visible.length) {
+        cursor = 0;
+        return visible;
+      }
+      if (cursor >= visible.length) {
+        cursor = visible.length - 1;
+      }
+      return visible;
+    };
 
     const render = () => {
       clearRenderedLines(renderedLines);
-      const lines = [
-        '',
-        title,
-        single
-          ? 'Use up/down arrows to move, space to select, enter to confirm.'
-          : 'Use up/down arrows to move, space to toggle, enter to confirm.'
-      ];
-      if (warning) lines.push(warning);
+      const groupsToRender = visibleGroups();
+      const choicesToRender = normalizeCursor();
+      const lines = ['', title, 'Use up/down to move and Enter to confirm.'];
+      if (showHelp) {
+        lines.push(
+          single
+            ? 'Space: select option, ?: hide help'
+            : 'Space: toggle option, Ctrl+A: select all, Ctrl+U: clear all, ?: hide help'
+        );
+        lines.push('Type to filter, Backspace to edit, Esc to clear filter.');
+      } else {
+        lines.push('Press ? to show keyboard help.');
+      }
+      lines.push(`Filter: ${filterQuery || '(none)'}`);
+      if (!single) {
+        lines.push(`Selected: ${String(selected.size)}`);
+      }
+      if (warning) lines.push(`Warning: ${warning}`);
+      if (!choicesToRender.length) lines.push('No matching options.');
 
       let index = 0;
-      for (const group of groups) {
+      for (const group of groupsToRender) {
         lines.push('');
         lines.push(group.heading);
         if (!group.choices.length) {
@@ -256,22 +314,72 @@ function createDefaultPromptIO(): InitPromptIO {
       render();
       for (;;) {
         const key = await readKeypress();
+        const choices = normalizeCursor();
         if (key.ctrl && key.name === 'c') {
           throw new Error('Guided init cancelled by user');
         }
-        if (key.name === 'up') {
-          cursor = (cursor - 1 + choices.length) % choices.length;
+        if (key.chunk === '?') {
+          showHelp = !showHelp;
           warning = '';
           render();
+          continue;
+        }
+        if (!single && key.ctrl && key.name === 'a') {
+          for (const choice of choices) {
+            selected.add(choice.id);
+          }
+          warning = '';
+          render();
+          continue;
+        }
+        if (!single && key.ctrl && key.name === 'u') {
+          if (!allowEmpty && selected.size > 0) {
+            warning = 'At least one selection is required.';
+          } else {
+            selected.clear();
+            warning = '';
+          }
+          render();
+          continue;
+        }
+        if (key.name === 'backspace') {
+          if (filterQuery.length) {
+            filterQuery = filterQuery.slice(0, -1);
+            warning = '';
+            render();
+          }
+          continue;
+        }
+        if (key.name === 'escape') {
+          if (filterQuery.length) {
+            filterQuery = '';
+            warning = '';
+            render();
+          }
+          continue;
+        }
+        if (key.name === 'up') {
+          if (choices.length) {
+            cursor = (cursor - 1 + choices.length) % choices.length;
+            warning = '';
+            render();
+          }
           continue;
         }
         if (key.name === 'down') {
-          cursor = (cursor + 1) % choices.length;
-          warning = '';
-          render();
+          if (choices.length) {
+            cursor = (cursor + 1) % choices.length;
+            warning = '';
+            render();
+          }
           continue;
         }
         if (key.name === 'space') {
+          if (!choices.length) {
+            warning = 'No matching options for current filter.';
+            render();
+            continue;
+          }
           const current = choices[cursor];
           if (single) {
             selected.clear();
@@ -292,6 +400,12 @@ function createDefaultPromptIO(): InitPromptIO {
           continue;
         }
         if (key.name === 'return' || key.name === 'enter') {
+          if (single && selected.size === 0 && requireExplicitSingleSelection) {
+            const current = choices[cursor];
+            if (current) {
+              selected.add(current.id);
+            }
+          }
           if (!allowEmpty && selected.size === 0) {
             warning = 'At least one selection is required.';
             render();
@@ -299,16 +413,22 @@ function createDefaultPromptIO(): InitPromptIO {
           }
           break;
         }
+        if (isPrintable(key.chunk)) {
+          filterQuery += key.chunk || '';
+          warning = '';
+          render();
+          continue;
+        }
       }
     });
 
     clearRenderedLines(renderedLines);
-    const ordered = choices.map((choice) => choice.id).filter((id) => selected.has(id));
+    const ordered = allChoices.map((choice) => choice.id).filter((id) => selected.has(id));
     if (single) {
-      const selectedLabel = choices.find((choice) => choice.id === ordered[0])?.label || ordered[0];
+      const selectedLabel = allChoices.find((choice) => choice.id === ordered[0])?.label || ordered[0];
       output.write(`${title}: ${selectedLabel}\n`);
     } else {
-      const selectedLabels = choices
+      const selectedLabels = allChoices
         .filter((choice) => selected.has(choice.id))
         .map((choice) => choice.label)
         .join(', ');
@@ -340,7 +460,7 @@ function createDefaultPromptIO(): InitPromptIO {
       allowEmpty: args.allowEmpty
     });
   };
-  const confirm = async ({ question, defaultValue }: ConfirmArgs) => {
+  const confirm = async ({ question, defaultValue, requireExplicit = false }: ConfirmArgs) => {
     const normalizedQuestion = question.replace(/\s*\[[^\]]+\]:?\s*$/u, '').trim() || 'Confirm';
     const selected = await runInteractiveSelect({
       title: normalizedQuestion,
@@ -353,9 +473,10 @@ function createDefaultPromptIO(): InitPromptIO {
           ]
         }
       ],
-      selectedIds: [defaultValue ? 'yes' : 'no'],
+      selectedIds: requireExplicit ? [] : [defaultValue ? 'yes' : 'no'],
       single: true,
-      allowEmpty: false
+      allowEmpty: false,
+      requireExplicitSingleSelection: requireExplicit
     });
     return selected[0] === 'yes';
   };


### PR DESCRIPTION
## Summary
- Add optional preset load/save support in `ailib init` using `.ailib/init-presets.json`
- Improve guided onboarding UX with planned file-change preview, explicit apply confirmation, and clearer copy
- Enhance keyboard picker interactions with filter, select all/clear shortcuts, and toggleable help
- Extend unit/integration coverage and update `docs/cli-usage-guide.md` for the new onboarding behavior

## Test plan
- [x] Run `bun test src/cli/init-guided.test.ts src/cli/init.test.ts --timeout 5000`
- [x] Run `bun run check`

Refs #362

Made with [Cursor](https://cursor.com)