### PR TITLE
fix: stop duplicate top-level skill outputs

### DIFF
--- a/src/cli/workspace-assets.test.ts
+++ b/src/cli/workspace-assets.test.ts
@@ -178,13 +178,10 @@ test('ensureWorkspaceAssets copies and prunes skill assets', async () => {
   });
 
   assert.equal(
-    await fs.readFile(path.join(workspaceDir, '.ailib/skills/task-driven-gh-flow.md'), 'utf8'),
-    'skill-flow'
-  );
-  assert.equal(
     await fs.readFile(path.join(workspaceDir, '.ailib/skills/cursor/task-driven-gh-flow.md'), 'utf8'),
     'skill-flow'
   );
+  await assert.rejects(fs.readFile(path.join(workspaceDir, '.ailib/skills/task-driven-gh-flow.md'), 'utf8'));
   await assert.rejects(fs.readFile(path.join(workspaceDir, '.ailib/skills/legacy-skill.md'), 'utf8'));
   assert.equal(await fs.readFile(path.join(workspaceDir, '.ailib/skills/custom.md'), 'utf8'), 'custom-skill');
 });
@@ -204,7 +201,7 @@ test('ensureWorkspaceAssets copies built-in skill assets from package sources', 
   });
 
   assert.equal(
-    await fs.readFile(path.join(workspaceDir, '.ailib/skills/architecture-decision-flow.md'), 'utf8'),
+    await fs.readFile(path.join(workspaceDir, '.ailib/skills/cursor/architecture-decision-flow.md'), 'utf8'),
     'architecture-flow'
   );
 });
@@ -232,7 +229,7 @@ test('ensureWorkspaceAssets prefers local custom skill over package source', asy
   });
 
   assert.equal(
-    await fs.readFile(path.join(workspaceDir, '.ailib/skills/task-driven-gh-flow.md'), 'utf8'),
+    await fs.readFile(path.join(workspaceDir, '.ailib/skills/cursor/task-driven-gh-flow.md'), 'utf8'),
     'workspace-local-skill'
   );
 });
@@ -251,7 +248,6 @@ test('ensureWorkspaceAssets renders target-specific skill format variants', asyn
     registry
   });
 
-  const legacy = await fs.readFile(path.join(workspaceDir, '.ailib/skills/target-format-skill.md'), 'utf8');
   const cursorRendered = await fs.readFile(
     path.join(workspaceDir, '.ailib/skills/cursor/target-format-skill.md'),
     'utf8'
@@ -261,12 +257,12 @@ test('ensureWorkspaceAssets renders target-specific skill format variants', asyn
     'utf8'
   );
 
-  assert.match(legacy, /## Purpose/);
   assert.match(cursorRendered, /## When to Use/);
   assert.match(cursorRendered, /## Instructions/);
   assert.match(cursorRendered, /Detailed instructions for the agent\./);
   assert.match(claudeRendered, /## Purpose/);
   assert.doesNotMatch(claudeRendered, /## When to Use/);
+  await assert.rejects(fs.readFile(path.join(workspaceDir, '.ailib/skills/target-format-skill.md'), 'utf8'));
 });
 
 test('ensureWorkspaceAssets removes stale target skill directory when target is deselected', async () => {
@@ -341,8 +337,35 @@ test('ensureWorkspaceAssets prefers root local custom skill over package source'
   });
 
   assert.equal(
-    await fs.readFile(path.join(workspaceDir, '.ailib/skills/task-driven-gh-flow.md'), 'utf8'),
+    await fs.readFile(path.join(workspaceDir, '.ailib/skills/cursor/task-driven-gh-flow.md'), 'utf8'),
     'root-local-skill'
+  );
+});
+
+test('ensureWorkspaceAssets prunes selected legacy top-level skill files from previous versions', async () => {
+  const rootDir = await tempDir();
+  const workspaceDir = path.join(rootDir, 'apps/api');
+  const packageRoot = path.join(rootDir, 'pkg');
+  await seedPackage(packageRoot);
+  await fs.mkdir(path.join(workspaceDir, '.ailib/skills'), { recursive: true });
+  await fs.writeFile(path.join(workspaceDir, '.ailib/skills/task-driven-gh-flow.md'), 'legacy-copy', 'utf8');
+
+  await ensureWorkspaceAssets({
+    workspaceDir,
+    packageRoot,
+    state: state([], ['task-driven-gh-flow'], ['cursor', 'claude-code']),
+    rootDir,
+    registry
+  });
+
+  await assert.rejects(fs.readFile(path.join(workspaceDir, '.ailib/skills/task-driven-gh-flow.md'), 'utf8'));
+  assert.equal(
+    await fs.readFile(path.join(workspaceDir, '.ailib/skills/cursor/task-driven-gh-flow.md'), 'utf8'),
+    'skill-flow'
+  );
+  assert.equal(
+    await fs.readFile(path.join(workspaceDir, '.ailib/skills/claude-code/task-driven-gh-flow.md'), 'utf8'),
+    'skill-flow'
   );
 });
 

--- a/src/cli/workspace-assets.ts
+++ b/src/cli/workspace-assets.ts
@@ -94,7 +94,6 @@ export async function ensureWorkspaceAssets({
       rootDir,
       outRoot
     });
-    await writeFileFromContent(path.join(outRoot, 'skills', `${skillId}.md`), source);
     for (const targetId of selectedTargetIds) {
       const targetDef = registry.targets[targetId];
       const targetFormat = resolveTargetSkillFormat({ targetId, targetDef });
@@ -108,7 +107,9 @@ export async function ensureWorkspaceAssets({
     for (const entry of await fs.readdir(skillDir)) {
       if (!entry.endsWith('.md')) continue;
       const id = entry.replace(/\.md$/u, '');
-      if (!localSkillSet.has(id) && registrySkills[id]) await rmIfExists(path.join(skillDir, entry));
+      // Top-level .ailib/skills/*.md files are legacy and should be removed.
+      // Current model keeps only target-scoped skill files in .ailib/skills/<target>/<skill>.md.
+      if (localSkillSet.has(id) || registrySkills[id]) await rmIfExists(path.join(skillDir, entry));
     }
   }
   for (const targetId of Object.keys(registry.targets || {})) {


### PR DESCRIPTION
## Summary
- Stop generating top-level `.ailib/skills/*.md` files during workspace asset updates
- Keep target-specific skill files (`.ailib/skills/<target>/<skill>.md`) as the only generated output model
- Add regression tests to verify duplicate top-level skill files are pruned and target-scoped outputs remain intact

## Test plan
- [x] Run `bun test src/cli/workspace-assets.test.ts`
- [x] Run `bun run check`
- [x] Run `bun run coverage:build`

Refs #370

Made with [Cursor](https://cursor.com)